### PR TITLE
Add registry build integration tests

### DIFF
--- a/__tests__/registry.test.ts
+++ b/__tests__/registry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { execSync } from "child_process"
+import { existsSync, readFileSync, mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+
+describe("registry installability", () => {
+  let registryJsonPath: string
+
+  beforeAll(() => {
+    // Build the registry
+    execSync("pnpm registry:build", { cwd: process.cwd(), stdio: "pipe" })
+    registryJsonPath = path.resolve("public/r/prompt-area.json")
+  })
+
+  it("builds a valid registry JSON file", () => {
+    expect(existsSync(registryJsonPath)).toBe(true)
+    const json = JSON.parse(readFileSync(registryJsonPath, "utf-8"))
+    expect(json.name).toBe("prompt-area")
+    expect(json.type).toBe("registry:component")
+    expect(json.files).toHaveLength(1)
+    expect(json.files[0].content).toContain("PromptArea")
+  })
+
+  it("registry JSON contains valid component source", () => {
+    const json = JSON.parse(readFileSync(registryJsonPath, "utf-8"))
+    const source = json.files[0].content
+
+    // Has proper exports
+    expect(source).toContain("export { PromptArea }")
+    // Has forwardRef
+    expect(source).toContain("React.forwardRef")
+    // Has displayName
+    expect(source).toContain('PromptArea.displayName = "PromptArea"')
+    // Uses cn utility
+    expect(source).toContain('import { cn } from "@/lib/utils"')
+  })
+
+  it("registry JSON conforms to shadcn schema", () => {
+    const json = JSON.parse(readFileSync(registryJsonPath, "utf-8"))
+    expect(json.$schema).toBe(
+      "https://ui.shadcn.com/schema/registry-item.json"
+    )
+    expect(json).toHaveProperty("name")
+    expect(json).toHaveProperty("type")
+    expect(json).toHaveProperty("files")
+    expect(json.files[0]).toHaveProperty("path")
+    expect(json.files[0]).toHaveProperty("content")
+    expect(json.files[0]).toHaveProperty("type")
+  })
+})


### PR DESCRIPTION
Verifies that `shadcn build` produces valid registry JSON with correct schema, component source, exports, and structure.

https://claude.ai/code/session_01LDXdxt3BkKxDtoFZSbVFw2