### PR TITLE
Add comprehensive "All Options" example for PromptArea component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -397,6 +397,245 @@ function CopyPasteExample() {
 }
 
 // ---------------------------------------------------------------------------
+// All Options – a single example exercising every prop / option
+// ---------------------------------------------------------------------------
+
+function AllOptionsExample() {
+  const [segments, setSegments] = useState<Segment[]>([
+    { type: 'text', text: 'Hello ' },
+    { type: 'chip', trigger: '@', value: 'alice', displayText: 'Alice' },
+    { type: 'text', text: ' — click a chip, paste text, or try every feature!' },
+  ])
+  const [eventLog, setEventLog] = useState<string[]>([])
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const log = useCallback((msg: string) => {
+    setEventLog((prev) => [`${new Date().toLocaleTimeString()} ${msg}`, ...prev].slice(0, 80))
+  }, [])
+
+  // Every trigger variation in one config ----------------------------------
+
+  const triggers: TriggerConfig[] = [
+    // 1. Dropdown at start-of-line, inline chip style
+    {
+      char: '/',
+      position: 'start',
+      mode: 'dropdown',
+      chipStyle: 'inline',
+      chipClassName: 'text-violet-700 dark:text-violet-400',
+      accessibilityLabel: 'command',
+      onSearch: (query) =>
+        COMMANDS.filter(
+          (c) =>
+            c.label.toLowerCase().includes(query.toLowerCase()) ||
+            c.description.toLowerCase().includes(query.toLowerCase()),
+        ),
+      onSelect: (s) => {
+        log(`/ onSelect → ${s.label}`)
+        return s.label
+      },
+    },
+    // 2. Dropdown anywhere, pill chip style (default), with icons
+    {
+      char: '@',
+      position: 'any',
+      mode: 'dropdown',
+      chipStyle: 'pill',
+      chipClassName: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+      accessibilityLabel: 'mention',
+      onSearch: (query) =>
+        USERS.filter(
+          (u) =>
+            u.label.toLowerCase().includes(query.toLowerCase()) ||
+            u.description.toLowerCase().includes(query.toLowerCase()),
+        ),
+      onSelect: (s) => {
+        log(`@ onSelect → ${s.label}`)
+        return s.label
+      },
+    },
+    // 3. Dropdown anywhere + resolveOnSpace (free-form tags)
+    {
+      char: '#',
+      position: 'any',
+      mode: 'dropdown',
+      resolveOnSpace: true,
+      chipClassName: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+      accessibilityLabel: 'tag',
+      onSearch: (query) =>
+        TAGS.filter((t) => t.label.toLowerCase().includes(query.toLowerCase())),
+      onSelect: (s) => {
+        log(`# onSelect → ${s.label}`)
+        return s.label
+      },
+    },
+    // 4. Callback mode (no dropdown)
+    {
+      char: '!',
+      position: 'any',
+      mode: 'callback',
+      onActivate: (ctx) => {
+        log(`! onActivate → cursor at ${ctx.cursorPosition}`)
+        ctx.insertChip({ trigger: '!', value: 'alert', displayText: 'alert' })
+      },
+    },
+  ]
+
+  // Disabled state toggle ---------------------------------------------------
+
+  const [disabled, setDisabled] = useState(false)
+  const [markdownEnabled, setMarkdownEnabled] = useState(true)
+  const [autoGrow, setAutoGrow] = useState(true)
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Toggle controls */}
+      <div className="flex flex-wrap gap-3 text-sm">
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={disabled}
+            onChange={(e) => setDisabled(e.target.checked)}
+          />
+          disabled
+        </label>
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={markdownEnabled}
+            onChange={(e) => setMarkdownEnabled(e.target.checked)}
+          />
+          markdown
+        </label>
+        <label className="flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={autoGrow}
+            onChange={(e) => setAutoGrow(e.target.checked)}
+          />
+          autoGrow
+        </label>
+      </div>
+
+      {/* The PromptArea with every prop */}
+      <div className="rounded-lg border p-4">
+        <PromptArea
+          ref={promptRef}
+          // ── controlled value ───────────────────────────────────
+          value={segments}
+          onChange={(segs) => {
+            setSegments(segs)
+            log(`onChange → ${segs.length} segment(s)`)
+          }}
+          // ── trigger configs ───────────────────────────────────
+          triggers={triggers}
+          // ── appearance ────────────────────────────────────────
+          placeholder="All options active — try /, @, #, !, **bold**, *italic*, - lists, URLs…"
+          className="my-custom-class"
+          disabled={disabled}
+          markdown={markdownEnabled}
+          // ── dimensions ────────────────────────────────────────
+          minHeight={60}
+          maxHeight={300}
+          autoGrow={autoGrow}
+          autoFocus={false}
+          // ── callbacks ─────────────────────────────────────────
+          onSubmit={(segs) => {
+            const text = segs
+              .map((s) => (s.type === 'text' ? s.text : `${s.trigger}${s.displayText}`))
+              .join('')
+            log(`onSubmit → "${text}"`)
+            promptRef.current?.clear()
+            setSegments([])
+          }}
+          onEscape={() => log('onEscape')}
+          onChipClick={(chip) => log(`onChipClick → ${chip.trigger}${chip.displayText}`)}
+          onChipAdd={(chip) => log(`onChipAdd → ${chip.trigger}${chip.displayText}`)}
+          onChipDelete={(chip) => log(`onChipDelete → ${chip.trigger}${chip.displayText}`)}
+          onLinkClick={(url) => log(`onLinkClick → ${url}`)}
+          onPaste={(data) => log(`onPaste → ${data.source}, ${data.segments.length} segment(s)`)}
+          onUndo={(segs) => log(`onUndo → ${segs.length} segment(s)`)}
+          onRedo={(segs) => log(`onRedo → ${segs.length} segment(s)`)}
+          // ── accessibility / testing ───────────────────────────
+          aria-label="All-options demo input"
+          data-test-id="all-options-prompt"
+        />
+      </div>
+
+      {/* Imperative handle buttons */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          onClick={() => promptRef.current?.focus()}>
+          focus()
+        </button>
+        <button
+          type="button"
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          onClick={() => promptRef.current?.blur()}>
+          blur()
+        </button>
+        <button
+          type="button"
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          onClick={() =>
+            promptRef.current?.insertChip({
+              trigger: '@',
+              value: 'system',
+              displayText: 'System',
+            })
+          }>
+          insertChip()
+        </button>
+        <button
+          type="button"
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          onClick={() => log(`getPlainText() → "${promptRef.current?.getPlainText()}"`)}>
+          getPlainText()
+        </button>
+        <button
+          type="button"
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          onClick={() => {
+            promptRef.current?.clear()
+            setSegments([])
+            log('clear()')
+          }}>
+          clear()
+        </button>
+      </div>
+
+      {/* Live state & event log */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border p-3">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            Segments ({segments.length})
+          </div>
+          <pre className="max-h-[200px] overflow-auto text-xs">
+            {JSON.stringify(segments, null, 2)}
+          </pre>
+        </div>
+        <div className="rounded-lg border p-3">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">Event Log</div>
+          <div className="max-h-[200px] overflow-auto text-xs">
+            {eventLog.length === 0 ? (
+              <span className="text-muted-foreground">Interact to see events…</span>
+            ) : (
+              eventLog.map((entry, i) => (
+                <div key={i} className="border-b border-border/50 py-0.5">
+                  {entry}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -442,6 +681,25 @@ export default function Home() {
           type <code>- </code> to start a list.
         </p>
         <FullDemo />
+      </div>
+
+      {/* All Options */}
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">All Options</h2>
+        <p className="text-sm text-muted-foreground">
+          Every prop and option in a single example. Toggles for{' '}
+          <code>disabled</code>, <code>markdown</code>, and <code>autoGrow</code>. All 4 trigger
+          types (<code>/</code> start-of-line dropdown, <code>@</code> pill dropdown,{' '}
+          <code>#</code> auto-resolve on space, <code>!</code> callback mode). Every callback
+          (<code>onSubmit</code>, <code>onEscape</code>, <code>onChipClick</code>,{' '}
+          <code>onChipAdd</code>, <code>onChipDelete</code>, <code>onLinkClick</code>,{' '}
+          <code>onPaste</code>, <code>onUndo</code>, <code>onRedo</code>) logs to the event panel.
+          Imperative handle methods (<code>focus</code>, <code>blur</code>,{' '}
+          <code>insertChip</code>, <code>getPlainText</code>, <code>clear</code>) are wired to
+          buttons. Also sets <code>minHeight</code>, <code>maxHeight</code>,{' '}
+          <code>className</code>, <code>aria-label</code>, and <code>data-test-id</code>.
+        </p>
+        <AllOptionsExample />
       </div>
 
       {/* Examples */}


### PR DESCRIPTION
Adds a single interactive example that exercises every prop and option:
- All 4 trigger types (/ start-of-line, @ pill dropdown, # resolveOnSpace, ! callback)
- Toggle controls for disabled, markdown, and autoGrow props
- All callbacks logged to an event panel (onSubmit, onEscape, onChipClick, onChipAdd, onChipDelete, onLinkClick, onPaste, onUndo, onRedo)
- Imperative handle buttons (focus, blur, insertChip, getPlainText, clear)
- minHeight, maxHeight, className, aria-label, and data-test-id props

https://claude.ai/code/session_01KoLGgcnGikXrq2CUjXFs4f