### PR TITLE
Add registry sync CI job to validate generated output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,22 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+
+  registry-sync:
+    name: Registry Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm registry:build
+      - name: Check registry is up to date
+        run: |
+          if ! git diff --exit-code public/r/; then
+            echo "::error::Registry output is out of sync with sources. Run 'pnpm registry:build' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
This PR adds a new CI workflow job that ensures the registry output files remain in sync with their source files.

## Key Changes
- Added `registry-sync` job to the CI pipeline that:
  - Checks out the code and sets up the Node.js environment (v22) with pnpm
  - Runs `pnpm registry:build` to regenerate registry output
  - Validates that the generated `public/r/` directory matches what's committed in the repository
  - Fails the CI check if the registry output is out of sync, with a helpful error message instructing developers to run the build command and commit the results

## Implementation Details
The job uses `git diff --exit-code` to detect any uncommitted changes in the registry output directory, ensuring that developers keep the generated files up to date with source changes. This prevents stale registry artifacts from being committed to the repository.

https://claude.ai/code/session_016EPDRBeKaxUedEk2Kd9RLh