### PR TITLE
Add GitHub repository link to nav sidebar footer

### DIFF
--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, Github, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/theme-toggle'
 
@@ -393,7 +393,19 @@ function NavSidebar() {
         )}
       </nav>
 
-      <div className="border-sidebar-border border-t px-4 py-3">
+      <div className="border-sidebar-border flex flex-col gap-3 border-t px-4 py-3">
+        <a
+          href="https://github.com/team-gpt/prompt-area"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            'group flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+            'bg-accent/50 text-foreground hover:bg-accent',
+          )}>
+          <Github className="size-4 shrink-0" />
+          <span className="flex-1">GitHub Repo</span>
+          <Star className="size-3.5 text-muted-foreground transition-colors group-hover:text-yellow-500" />
+        </a>
         <ThemeToggle />
       </div>
     </aside>


### PR DESCRIPTION
## Summary
Added a GitHub repository link to the navigation sidebar footer, allowing users to quickly access the project's GitHub repository.

## Changes
- Imported `Github` and `Star` icons from lucide-react
- Added a new GitHub repository link button in the sidebar footer with:
  - Link to `https://github.com/team-gpt/prompt-area`
  - Opens in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
  - Styled with accent background color and hover effects
  - Includes a star icon that changes color on hover (muted-foreground → yellow-500)
- Updated the footer container to use flexbox layout with gap spacing to accommodate the new link alongside the existing ThemeToggle component

## Implementation Details
- The link uses consistent styling with the rest of the navigation UI (rounded corners, padding, transition effects)
- The star icon provides visual feedback on hover, encouraging users to star the repository
- The layout is responsive with proper spacing between the GitHub link and theme toggle

https://claude.ai/code/session_0185beDm37hpmiVx6ebQqBsL