### PR TITLE
Update domain from vercel.app to prompt-area.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A production-grade contentEditable rich text input distributed as a [shadcn regi
 ## Install
 
 ```bash
-npx shadcn@latest add https://prompt-area.vercel.app/r/prompt-area.json
+npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 ```
 
 > **Note:** Add the required CSS classes to your `globals.css` after `@layer base`:

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1262,7 +1262,7 @@ export default function Home() {
           component.
         </p>
         <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
-          npx shadcn@latest add https://prompt-area.vercel.app/r/prompt-area.json
+          npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
         </div>
       </div>
 
@@ -1398,7 +1398,7 @@ export default function Home() {
             chat input experience. Independently installable.
           </p>
           <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
-            npx shadcn@latest add https://prompt-area.vercel.app/r/action-bar.json
+            npx shadcn@latest add https://prompt-area.com/r/action-bar.json
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Update all references to the prompt-area service domain from the Vercel deployment URL to the custom domain.

## Changes
- Updated installation command in `app/page.tsx` (2 occurrences):
  - Prompt Area component installation URL
  - Action Bar component installation URL
- Updated installation command in `README.md`

All references changed from `https://prompt-area.vercel.app/r/` to `https://prompt-area.com/r/`

## Details
This change reflects the migration from the temporary Vercel deployment domain to the permanent custom domain for the prompt-area registry. Users following the installation instructions will now use the correct, production domain.

https://claude.ai/code/session_01E2bkJXjGCMyAZ49BG9wQUD