### PR TITLE
Update mock data for marketing/sales workflow

### DIFF
--- a/app/examples/action-bar-full.tsx
+++ b/app/examples/action-bar-full.tsx
@@ -23,21 +23,21 @@ import type {
 } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
 ]
 
 const COMMANDS = [
+  { value: 'deep-research', label: 'deep-research', description: 'Research a topic in depth' },
   { value: 'summarize', label: 'summarize', description: 'Summarize the conversation' },
-  { value: 'translate', label: 'translate', description: 'Translate to another language' },
-  { value: 'improve', label: 'improve', description: 'Improve writing quality' },
+  { value: 'create-slides', label: 'create-slides', description: 'Generate a slide deck' },
 ]
 
 const TAGS = [
-  { value: 'bug', label: 'bug' },
-  { value: 'feature', label: 'feature' },
-  { value: 'docs', label: 'docs' },
+  { value: 'campaign', label: 'campaign' },
+  { value: 'lead-gen', label: 'lead-gen' },
+  { value: 'conversion', label: 'conversion' },
 ]
 
 function isSegmentsEmpty(segments: Segment[]): boolean {

--- a/app/examples/async-search.tsx
+++ b/app/examples/async-search.tsx
@@ -5,11 +5,11 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
-  { value: 'diana', label: 'Diana', description: 'Marketing' },
-  { value: 'eve', label: 'Eve', description: 'Sales' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
+  { value: 'outreach', label: 'Outreach', description: 'Sales prospecting' },
+  { value: 'designer', label: 'Designer', description: 'Visual & brand assets' },
 ]
 
 export function AsyncSearchExample() {
@@ -26,7 +26,7 @@ export function AsyncSearchExample() {
               position: 'any',
               mode: 'dropdown',
               searchDebounceMs: 300,
-              emptyMessage: 'No users found',
+              emptyMessage: 'No agents found',
               accessibilityLabel: 'mention',
               onSearch: async (query, { signal }) => {
                 await new Promise<void>((resolve, reject) => {
@@ -47,7 +47,7 @@ export function AsyncSearchExample() {
               },
             },
           ]}
-          placeholder="Type @ to search users (async, 300ms debounce)..."
+          placeholder="Type @ to search agents (async, 300ms debounce)..."
           minHeight={48}
         />
       </div>
@@ -60,9 +60,9 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
 ]
 
 function AsyncSearchExample() {
@@ -77,7 +77,7 @@ function AsyncSearchExample() {
           position: 'any',
           mode: 'dropdown',
           searchDebounceMs: 300,
-          emptyMessage: 'No users found',
+          emptyMessage: 'No agents found',
           accessibilityLabel: 'mention',
           onSearch: async (query, { signal }) => {
             // Simulate a 500ms API call
@@ -95,7 +95,7 @@ function AsyncSearchExample() {
           onSearchError: (err) => console.error('Search failed:', err),
         },
       ]}
-      placeholder="Type @ to search users (async, 300ms debounce)..."
+      placeholder="Type @ to search agents (async, 300ms debounce)..."
       minHeight={48}
     />
   )

--- a/app/examples/commands.tsx
+++ b/app/examples/commands.tsx
@@ -5,11 +5,11 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const COMMANDS = [
+  { value: 'deep-research', label: 'deep-research', description: 'Research a topic in depth' },
   { value: 'summarize', label: 'summarize', description: 'Summarize the conversation' },
-  { value: 'translate', label: 'translate', description: 'Translate to another language' },
-  { value: 'improve', label: 'improve', description: 'Improve writing quality' },
-  { value: 'explain', label: 'explain', description: 'Explain a concept' },
-  { value: 'code', label: 'code', description: 'Generate code snippet' },
+  { value: 'create-slides', label: 'create-slides', description: 'Generate a slide deck' },
+  { value: 'draft-email', label: 'draft-email', description: 'Compose a sales email' },
+  { value: 'analyze', label: 'analyze', description: 'Break down key metrics' },
 ]
 
 export function CommandsExample() {
@@ -42,9 +42,9 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const COMMANDS = [
+  { value: 'deep-research', label: 'deep-research', description: 'Research a topic in depth' },
   { value: 'summarize', label: 'summarize', description: 'Summarize the conversation' },
-  { value: 'translate', label: 'translate', description: 'Translate to another language' },
-  { value: 'improve', label: 'improve', description: 'Improve writing quality' },
+  { value: 'create-slides', label: 'create-slides', description: 'Generate a slide deck' },
 ]
 
 function CommandsExample() {

--- a/app/examples/copy-paste.tsx
+++ b/app/examples/copy-paste.tsx
@@ -5,15 +5,15 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment, TriggerConfig } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
 ]
 
 const TAGS = [
-  { value: 'bug', label: 'bug' },
-  { value: 'feature', label: 'feature' },
-  { value: 'docs', label: 'docs' },
+  { value: 'campaign', label: 'campaign' },
+  { value: 'lead-gen', label: 'lead-gen' },
+  { value: 'conversion', label: 'conversion' },
 ]
 
 const COPY_PASTE_TRIGGERS: TriggerConfig[] = [
@@ -35,11 +35,11 @@ const COPY_PASTE_TRIGGERS: TriggerConfig[] = [
 ]
 
 const INITIAL_SEGMENTS: Segment[] = [
-  { type: 'text', text: 'Hello ' },
-  { type: 'chip', trigger: '@', value: 'alice', displayText: 'Alice' },
-  { type: 'text', text: ' please review ' },
-  { type: 'chip', trigger: '#', value: 'feature', displayText: 'feature' },
-  { type: 'text', text: ' when you can' },
+  { type: 'text', text: 'Hey ' },
+  { type: 'chip', trigger: '@', value: 'copywriter', displayText: 'Copywriter' },
+  { type: 'text', text: ' please review the ' },
+  { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+  { type: 'text', text: ' draft when you can' },
 ]
 
 export function CopyPasteExample() {
@@ -100,10 +100,10 @@ const TRIGGERS: TriggerConfig[] = [
 function CopyPasteExample() {
   const [sourceSegments, setSourceSegments] = useState<Segment[]>([
     { type: 'text', text: 'Hello ' },
-    { type: 'chip', trigger: '@', value: 'alice', displayText: 'Alice' },
-    { type: 'text', text: ' please review ' },
-    { type: 'chip', trigger: '#', value: 'feature', displayText: 'feature' },
-    { type: 'text', text: ' when you can' },
+    { type: 'chip', trigger: '@', value: 'copywriter', displayText: 'Copywriter' },
+    { type: 'text', text: ' please review the ' },
+    { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+    { type: 'text', text: ' draft when you can' },
   ])
   const [targetSegments, setTargetSegments] = useState<Segment[]>([])
   return (

--- a/app/examples/mentions.tsx
+++ b/app/examples/mentions.tsx
@@ -5,11 +5,11 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
-  { value: 'diana', label: 'Diana', description: 'Marketing' },
-  { value: 'eve', label: 'Eve', description: 'Sales' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
+  { value: 'outreach', label: 'Outreach', description: 'Sales prospecting' },
+  { value: 'designer', label: 'Designer', description: 'Visual & brand assets' },
 ]
 
 export function MentionsExample() {
@@ -28,7 +28,7 @@ export function MentionsExample() {
             onSearch: (q) => USERS.filter((u) => u.label.toLowerCase().includes(q.toLowerCase())),
           },
         ]}
-        placeholder="Type @ to mention someone..."
+        placeholder="Type @ to mention an agent..."
         minHeight={48}
       />
     </div>
@@ -40,9 +40,9 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
 ]
 
 function MentionsExample() {
@@ -61,7 +61,7 @@ function MentionsExample() {
             USERS.filter((u) => u.label.toLowerCase().includes(q.toLowerCase())),
         },
       ]}
-      placeholder="Type @ to mention someone..."
+      placeholder="Type @ to mention an agent..."
       minHeight={48}
     />
   )

--- a/app/examples/tags.tsx
+++ b/app/examples/tags.tsx
@@ -5,11 +5,11 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const TAGS = [
-  { value: 'bug', label: 'bug' },
-  { value: 'feature', label: 'feature' },
-  { value: 'docs', label: 'docs' },
-  { value: 'urgent', label: 'urgent' },
-  { value: 'question', label: 'question' },
+  { value: 'campaign', label: 'campaign' },
+  { value: 'lead-gen', label: 'lead-gen' },
+  { value: 'conversion', label: 'conversion' },
+  { value: 'branding', label: 'branding' },
+  { value: 'outbound', label: 'outbound' },
 ]
 
 export function TagsExample() {
@@ -41,10 +41,10 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
 
 const TAGS = [
-  { value: 'bug', label: 'bug' },
-  { value: 'feature', label: 'feature' },
-  { value: 'docs', label: 'docs' },
-  { value: 'urgent', label: 'urgent' },
+  { value: 'campaign', label: 'campaign' },
+  { value: 'lead-gen', label: 'lead-gen' },
+  { value: 'conversion', label: 'conversion' },
+  { value: 'branding', label: 'branding' },
 ]
 
 function TagsExample() {

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -180,7 +180,7 @@ export default function HomeContent() {
           <p className="text-muted-foreground text-xs">
             Select content with chips in the source editor and <strong>Cmd+C</strong> to copy, then{' '}
             <strong>Cmd+V</strong> in the target to paste — chips are preserved. Pasting plain text
-            like <code>@alice #bug</code> from outside auto-resolves matching triggers.
+            like <code>@Copywriter #campaign</code> from outside auto-resolves matching triggers.
           </p>
           <ExampleShowcase code={copyPasteCode}>
             <CopyPasteExample />

--- a/app/sections/demo-section.tsx
+++ b/app/sections/demo-section.tsx
@@ -24,15 +24,15 @@ import { USERS, COMMANDS, TAGS } from './mock-data'
 
 const DEMO_INITIAL_SEGMENTS: Segment[] = [
   { type: 'chip', trigger: '/', value: 'summarize', displayText: 'summarize' },
-  { type: 'text', text: ' the meeting notes from ' },
-  { type: 'chip', trigger: '@', value: 'alice', displayText: 'Alice' },
+  { type: 'text', text: ' the campaign brief from ' },
+  { type: 'chip', trigger: '@', value: 'strategist', displayText: 'Strategist' },
   { type: 'text', text: ' and ' },
-  { type: 'chip', trigger: '@', value: 'bob', displayText: 'Bob' },
+  { type: 'chip', trigger: '@', value: 'copywriter', displayText: 'Copywriter' },
   { type: 'text', text: '. Tag anything marked ' },
-  { type: 'chip', trigger: '#', value: 'urgent', displayText: 'urgent' },
+  { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
   {
     type: 'text',
-    text: ' and format the output as:\n- **Key decisions** made during the meeting\n- *Action items* assigned to each team member\n- Open questions for follow-up',
+    text: ' and format the output as:\n- **Key messages** for the target audience\n- *Action items* assigned to each agent\n- Open questions for follow-up',
   },
 ]
 

--- a/app/sections/inspector-section.tsx
+++ b/app/sections/inspector-section.tsx
@@ -12,7 +12,7 @@ import { USERS, COMMANDS, TAGS } from './mock-data'
 export function InspectorSection() {
   const [segments, setSegments] = useState<Segment[]>([
     { type: 'text', text: 'Hello ' },
-    { type: 'chip', trigger: '@', value: 'alice', displayText: 'Alice' },
+    { type: 'chip', trigger: '@', value: 'strategist', displayText: 'Strategist' },
     {
       type: 'text',
       text: ' — click a chip, paste text, or try every feature!',

--- a/app/sections/mock-data.ts
+++ b/app/sections/mock-data.ts
@@ -1,35 +1,39 @@
 export const USERS = [
-  { value: 'alice', label: 'Alice', description: 'Engineering' },
-  { value: 'bob', label: 'Bob', description: 'Design' },
-  { value: 'charlie', label: 'Charlie', description: 'Product' },
-  { value: 'diana', label: 'Diana', description: 'Marketing' },
-  { value: 'eve', label: 'Eve', description: 'Sales' },
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
+  { value: 'outreach', label: 'Outreach', description: 'Sales prospecting' },
+  { value: 'designer', label: 'Designer', description: 'Visual & brand assets' },
 ]
 
 export const COMMANDS = [
+  {
+    value: 'deep-research',
+    label: 'deep-research',
+    description: 'Research a topic in depth',
+  },
   {
     value: 'summarize',
     label: 'summarize',
     description: 'Summarize the conversation',
   },
   {
-    value: 'translate',
-    label: 'translate',
-    description: 'Translate to another language',
+    value: 'create-slides',
+    label: 'create-slides',
+    description: 'Generate a slide deck',
   },
   {
-    value: 'improve',
-    label: 'improve',
-    description: 'Improve writing quality',
+    value: 'draft-email',
+    label: 'draft-email',
+    description: 'Compose a sales email',
   },
-  { value: 'explain', label: 'explain', description: 'Explain a concept' },
-  { value: 'code', label: 'code', description: 'Generate code snippet' },
+  { value: 'analyze', label: 'analyze', description: 'Break down key metrics' },
 ]
 
 export const TAGS = [
-  { value: 'bug', label: 'bug' },
-  { value: 'feature', label: 'feature' },
-  { value: 'docs', label: 'docs' },
-  { value: 'urgent', label: 'urgent' },
-  { value: 'question', label: 'question' },
+  { value: 'campaign', label: 'campaign' },
+  { value: 'lead-gen', label: 'lead-gen' },
+  { value: 'conversion', label: 'conversion' },
+  { value: 'branding', label: 'branding' },
+  { value: 'outbound', label: 'outbound' },
 ]


### PR DESCRIPTION
## Summary
Updated mock data to reflect a marketing and sales-focused workflow instead of the previous generic engineering/product setup.

## Key Changes
- **Users**: Replaced generic team members (Alice, Bob, Charlie, etc.) with marketing/sales roles:
  - Copywriter, Strategist, Analyst, Outreach, Designer
  
- **Commands**: Replaced general-purpose commands with marketing-specific actions:
  - Added `deep-research` for topic research
  - Replaced `translate` with `create-slides` for presentation generation
  - Replaced `improve` with `draft-email` for sales email composition
  - Replaced `explain` and `code` with `analyze` for metrics breakdown
  - Kept `summarize` as it remains relevant

- **Tags**: Replaced development/issue tracking tags with marketing campaign tags:
  - campaign, lead-gen, conversion, branding, outbound

## Notes
These changes align the mock data with a marketing operations or sales enablement use case, enabling testing and demonstration of the application in that domain.

https://claude.ai/code/session_011mw5W36sCn5oLa71rnrsqU