### PR TITLE
Add CompactPromptArea component - pill-shaped prompt that expands on focus

### DIFF
--- a/app/examples/compact-prompt-area.tsx
+++ b/app/examples/compact-prompt-area.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import { Mic } from 'lucide-react'
+import { CompactPromptArea } from '@/registry/new-york/blocks/compact-prompt-area/compact-prompt-area'
+import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
+import type {
+  Segment,
+  TriggerConfig,
+  PromptAreaHandle,
+} from '@/registry/new-york/blocks/prompt-area/types'
+
+const USERS = [
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'strategist', label: 'Strategist', description: 'Campaign planning' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
+]
+
+const COMMANDS = [
+  { value: 'deep-research', label: 'deep-research', description: 'Research a topic in depth' },
+  { value: 'summarize', label: 'summarize', description: 'Summarize the conversation' },
+]
+
+const TRIGGERS: TriggerConfig[] = [
+  {
+    char: '@',
+    position: 'any',
+    mode: 'dropdown',
+    chipClassName: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+    onSearch: (q) => USERS.filter((u) => u.label.toLowerCase().includes(q.toLowerCase())),
+  },
+  {
+    char: '/',
+    position: 'start',
+    mode: 'dropdown',
+    chipStyle: 'inline',
+    chipClassName: 'text-violet-700 dark:text-violet-400',
+    onSearch: (q) => COMMANDS.filter((c) => c.label.toLowerCase().includes(q.toLowerCase())),
+  },
+]
+
+const MIC_BUTTON_CLASS =
+  'flex items-center justify-center rounded-full size-8 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors'
+
+export function CompactPromptAreaExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [submitted, setSubmitted] = useState('')
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const handleSubmit = useCallback((segs: Segment[]) => {
+    const text = segmentsToPlainText(segs)
+    if (!text.trim()) return
+    setSubmitted(text)
+    promptRef.current?.clear()
+    setSegments([])
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-2">
+      <CompactPromptArea
+        ref={promptRef}
+        value={segments}
+        onChange={setSegments}
+        triggers={TRIGGERS}
+        placeholder="Ask anything..."
+        onSubmit={handleSubmit}
+        onPlusClick={() => alert('Plus clicked')}
+        beforeSubmitSlot={
+          <button type="button" className={MIC_BUTTON_CLASS} aria-label="Voice input">
+            <Mic className="size-4" />
+          </button>
+        }
+      />
+      {submitted && (
+        <div className="bg-muted/50 rounded-lg border p-3">
+          <div className="text-muted-foreground mb-1 text-xs font-medium">Submitted:</div>
+          <div className="text-sm">{submitted}</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const compactPromptAreaCode = `import { useCallback, useRef, useState } from 'react'
+import { Mic } from 'lucide-react'
+import { CompactPromptArea } from '@/registry/new-york/blocks/compact-prompt-area/compact-prompt-area'
+import type { Segment, TriggerConfig, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
+
+const triggers: TriggerConfig[] = [
+  { char: '@', position: 'any', mode: 'dropdown', onSearch: (q) => USERS.filter(...) },
+  { char: '/', position: 'start', mode: 'dropdown', chipStyle: 'inline', onSearch: (q) => COMMANDS.filter(...) },
+]
+
+function CompactPromptAreaExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const handleSubmit = useCallback((segs: Segment[]) => {
+    promptRef.current?.clear()
+    setSegments([])
+  }, [])
+
+  return (
+    <CompactPromptArea
+      ref={promptRef}
+      value={segments}
+      onChange={setSegments}
+      triggers={triggers}
+      placeholder="Ask anything..."
+      onSubmit={handleSubmit}
+      onPlusClick={() => console.log('Plus clicked')}
+      beforeSubmitSlot={
+        <button aria-label="Voice input">
+          <Mic className="size-4" />
+        </button>
+      }
+    />
+  )
+}`

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -19,3 +19,4 @@ export {
   StatusBarBothExample,
   statusBarBothCode,
 } from './status-bar'
+export { CompactPromptAreaExample, compactPromptAreaCode } from './compact-prompt-area'

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -35,6 +35,8 @@ import {
   statusBarBelowCode,
   StatusBarBothExample,
   statusBarBothCode,
+  CompactPromptAreaExample,
+  compactPromptAreaCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
 import { DemoSection } from './sections/demo-section'
@@ -274,8 +276,8 @@ export default function HomeContent() {
           </SectionHeading>
           <p className="text-muted-foreground">
             A horizontal bar with left and right slots for displaying contextual information. Sits
-            above or below the PromptArea to show things like branch name, model selector, or project
-            context. Independently installable.
+            above or below the PromptArea to show things like branch name, model selector, or
+            project context. Independently installable.
           </p>
           <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
             npx shadcn@latest add https://prompt-area.com/r/status-bar.json
@@ -309,6 +311,34 @@ export default function HomeContent() {
           </p>
           <ExampleShowcase code={statusBarBothCode}>
             <StatusBarBothExample />
+          </ExampleShowcase>
+        </div>
+      </div>
+
+      {/* Compact Prompt Area */}
+      <div className="flex flex-col gap-6">
+        <div id="compact-prompt-area" className="flex scroll-mt-16 flex-col gap-3">
+          <SectionHeading id="compact-prompt-area" as="h2">
+            Compact Prompt Area
+          </SectionHeading>
+          <p className="text-muted-foreground">
+            A pill-shaped prompt input that expands downward on focus. Circular plus and submit
+            buttons with a customizable slot for extras like a microphone. Independently
+            installable.
+          </p>
+          <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
+            npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json
+          </div>
+        </div>
+
+        <div id="compact-prompt-area-demo" className="flex scroll-mt-16 flex-col gap-2">
+          <SectionHeading id="compact-prompt-area-demo">Demo</SectionHeading>
+          <p className="text-muted-foreground text-xs">
+            Compact single-row input with circular plus and submit buttons. Expands downward on
+            focus with a microphone slot before the submit button.
+          </p>
+          <ExampleShowcase code={compactPromptAreaCode}>
+            <CompactPromptAreaExample />
           </ExampleShowcase>
         </div>
       </div>

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -53,6 +53,11 @@ const NAV_ITEMS: NavItem[] = [
     ],
   },
   {
+    id: 'compact-prompt-area',
+    label: 'Compact Prompt Area',
+    children: [{ id: 'compact-prompt-area-demo', label: 'Demo' }],
+  },
+  {
     id: 'dark-theme',
     label: 'Dark Theme',
     children: [{ id: 'dark-theme-preview', label: 'Preview' }],

--- a/registry.json
+++ b/registry.json
@@ -77,6 +77,23 @@
           "type": "registry:component"
         }
       ]
+    },
+    {
+      "name": "compact-prompt-area",
+      "type": "registry:component",
+      "title": "Compact Prompt Area",
+      "description": "A compact pill-shaped prompt input that expands downward on focus. Wraps PromptArea with circular plus and submit buttons and a customizable slot.",
+      "registryDependencies": ["prompt-area"],
+      "files": [
+        {
+          "path": "registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "registry/new-york/blocks/compact-prompt-area/types.ts",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { Plus, ArrowUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { BLUR_DELAY_MS } from '@/registry/new-york/blocks/prompt-area/use-prompt-area-events'
+import type { PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
+import type { CompactPromptAreaProps } from './types'
+
+/**
+ * CompactPromptArea – A pill-shaped prompt input that sits on a single row
+ * and expands downward on focus.
+ *
+ * - Left: circular plus button
+ * - Middle: PromptArea text input (expands down when focused)
+ * - Right: optional slot + circular submit button
+ *
+ * Reuses PromptArea internally with autoGrow enabled.
+ *
+ * @example
+ * ```tsx
+ * <CompactPromptArea
+ *   value={segments}
+ *   onChange={setSegments}
+ *   placeholder="Ask anything..."
+ *   onSubmit={handleSubmit}
+ *   onPlusClick={() => setMenuOpen(true)}
+ *   beforeSubmitSlot={<button aria-label="Voice"><Mic className="size-4" /></button>}
+ * />
+ * ```
+ */
+export function CompactPromptArea({
+  value,
+  onChange,
+  triggers,
+  placeholder,
+  disabled = false,
+  markdown,
+  onSubmit,
+  onEscape,
+  onChipClick,
+  onChipAdd,
+  onChipDelete,
+  onPaste,
+  images,
+  onImagePaste,
+  onImageRemove,
+  files,
+  onFileRemove,
+  plusButtonIcon,
+  onPlusClick,
+  submitButtonIcon,
+  beforeSubmitSlot,
+  maxHeight = 320,
+  className,
+  'aria-label': ariaLabel,
+  'data-test-id': dataTestId,
+  ref,
+}: CompactPromptAreaProps & { ref?: React.Ref<PromptAreaHandle> }) {
+  const promptRef = useRef<PromptAreaHandle>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isFocused, setIsFocused] = useState(false)
+
+  useImperativeHandle(ref, () => promptRef.current!, [])
+
+  const isEmpty =
+    value.length === 0 || (value.length === 1 && value[0].type === 'text' && value[0].text === '')
+
+  const isExpanded = isFocused || !isEmpty
+
+  const handleContainerFocus = useCallback(() => {
+    setIsFocused(true)
+  }, [])
+
+  const handleContainerBlur = useCallback(() => {
+    setTimeout(() => {
+      if (!containerRef.current?.contains(document.activeElement)) {
+        setIsFocused(false)
+      }
+    }, BLUR_DELAY_MS)
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    onSubmit?.(value)
+  }, [onSubmit, value])
+
+  return (
+    <div
+      ref={containerRef}
+      onFocus={handleContainerFocus}
+      onBlur={handleContainerBlur}
+      aria-label={ariaLabel}
+      data-test-id={dataTestId}
+      className={cn(
+        'compact-prompt-area',
+        'bg-background border transition-all duration-200 ease-out',
+        isExpanded ? 'rounded-2xl' : 'rounded-full',
+        className,
+      )}>
+      <div className={cn('flex', isExpanded ? 'flex-col' : 'items-center')}>
+        {/* Prompt area region */}
+        <div
+          className={cn('min-w-0 flex-1', isExpanded ? 'px-4 pt-3 pb-1' : 'overflow-hidden px-1')}
+          onClick={() => promptRef.current?.focus()}>
+          <PromptArea
+            ref={promptRef}
+            value={value}
+            onChange={onChange}
+            triggers={triggers}
+            placeholder={placeholder}
+            disabled={disabled}
+            markdown={markdown}
+            onSubmit={handleSubmit}
+            onEscape={onEscape}
+            onChipClick={onChipClick}
+            onChipAdd={onChipAdd}
+            onChipDelete={onChipDelete}
+            onPaste={onPaste}
+            images={images}
+            onImagePaste={onImagePaste}
+            onImageRemove={onImageRemove}
+            files={files}
+            onFileRemove={onFileRemove}
+            autoGrow
+            minHeight={isExpanded ? 48 : 24}
+            maxHeight={maxHeight}
+          />
+        </div>
+
+        {/* Button bar */}
+        <div
+          className={cn(
+            'flex shrink-0 items-center justify-between',
+            isExpanded ? 'px-2 pt-1 pb-2' : 'gap-1 pr-1',
+          )}>
+          {/* Plus button – circular */}
+          <button
+            type="button"
+            onClick={onPlusClick}
+            disabled={disabled}
+            className={cn(
+              'flex shrink-0 items-center justify-center rounded-full transition-colors',
+              'bg-muted text-muted-foreground size-8',
+              'hover:bg-accent hover:text-foreground',
+              'disabled:pointer-events-none disabled:opacity-50',
+            )}
+            aria-label="Add attachment">
+            {plusButtonIcon ?? <Plus className="size-4" />}
+          </button>
+
+          {/* Right side: slot + submit */}
+          <div className="flex items-center gap-1">
+            {beforeSubmitSlot}
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={disabled || isEmpty}
+              className={cn(
+                'flex shrink-0 items-center justify-center rounded-full transition-colors',
+                'bg-primary text-primary-foreground size-8',
+                'hover:bg-primary/90',
+                'disabled:pointer-events-none disabled:opacity-50',
+              )}
+              aria-label="Send message">
+              {submitButtonIcon ?? <ArrowUp className="size-4" />}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -106,8 +106,8 @@ export function CompactPromptArea({
             onClick={onPlusClick}
             disabled={disabled}
             className={cn(
-              'ml-2 flex shrink-0 items-center justify-center rounded-full transition-colors',
-              'bg-muted text-muted-foreground size-8',
+              'ml-1.5 flex shrink-0 items-center justify-center rounded-xl transition-colors',
+              'bg-muted text-muted-foreground size-9',
               'hover:bg-accent hover:text-foreground',
               'disabled:pointer-events-none disabled:opacity-50',
             )}
@@ -158,8 +158,8 @@ export function CompactPromptArea({
               onClick={onPlusClick}
               disabled={disabled}
               className={cn(
-                'flex shrink-0 items-center justify-center rounded-full transition-colors',
-                'bg-muted text-muted-foreground size-8',
+                'flex shrink-0 items-center justify-center rounded-xl transition-colors',
+                'bg-muted text-muted-foreground size-9',
                 'hover:bg-accent hover:text-foreground',
                 'disabled:pointer-events-none disabled:opacity-50',
               )}
@@ -169,15 +169,15 @@ export function CompactPromptArea({
           )}
 
           {/* Right side: slot + submit */}
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1.5">
             {beforeSubmitSlot}
             <button
               type="button"
               onClick={handleSubmit}
               disabled={disabled || isEmpty}
               className={cn(
-                'flex shrink-0 items-center justify-center rounded-full transition-colors',
-                'bg-primary text-primary-foreground size-8',
+                'flex shrink-0 items-center justify-center rounded-xl transition-colors',
+                'bg-primary text-primary-foreground size-9',
                 'hover:bg-primary/90',
                 'disabled:pointer-events-none disabled:opacity-50',
               )}

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { useCallback, useImperativeHandle, useRef, useState } from 'react'
 import { Plus, ArrowUp } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { BLUR_DELAY_MS } from '@/registry/new-york/blocks/prompt-area/use-prompt-area-events'
 import type { PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 import type { CompactPromptAreaProps } from './types'
 
@@ -59,60 +60,26 @@ export function CompactPromptArea({
 }: CompactPromptAreaProps & { ref?: React.Ref<PromptAreaHandle> }) {
   const promptRef = useRef<PromptAreaHandle>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const promptWrapperRef = useRef<HTMLDivElement>(null)
-  const [isOverflowing, setIsOverflowing] = useState(false)
-  const isOverflowingRef = useRef(false)
+  const [isFocused, setIsFocused] = useState(false)
 
   useImperativeHandle(ref, () => promptRef.current!, [])
 
   const isEmpty =
     value.length === 0 || (value.length === 1 && value[0].type === 'text' && value[0].text === '')
 
-  const hasAttachments = (images && images.length > 0) || (files && files.length > 0)
-  const isExpanded = isOverflowing || hasAttachments
+  const isExpanded = isFocused || !isEmpty
 
-  // Detect multiline content with hysteresis to prevent flickering.
-  // We measure scrollHeight on a hidden clone so layout shifts from
-  // expanding/collapsing don't feed back into the measurement.
-  useEffect(() => {
-    const wrapper = promptWrapperRef.current
-    if (!wrapper) return
-    const EXPAND_THRESHOLD = 32
-    const COLLAPSE_THRESHOLD = 28
+  const handleContainerFocus = useCallback(() => {
+    setIsFocused(true)
+  }, [])
 
-    const check = () => {
-      const editor = wrapper.querySelector('[contenteditable]') as HTMLElement | null
-      if (!editor) return
-
-      // Measure in a detached clone to avoid layout feedback loops
-      const clone = editor.cloneNode(true) as HTMLElement
-      clone.style.cssText = `
-        position:fixed;left:-9999px;top:0;
-        width:${editor.offsetWidth}px;
-        height:auto;min-height:0;max-height:none;
-        visibility:hidden;pointer-events:none;
-        white-space:pre-wrap;word-break:break-word;
-        font:${getComputedStyle(editor).font};
-        padding:${getComputedStyle(editor).padding};
-      `
-      document.body.appendChild(clone)
-      const contentHeight = clone.scrollHeight
-      document.body.removeChild(clone)
-
-      const current = isOverflowingRef.current
-      const next = current ? contentHeight > COLLAPSE_THRESHOLD : contentHeight > EXPAND_THRESHOLD
-
-      if (next !== current) {
-        isOverflowingRef.current = next
-        setIsOverflowing(next)
+  const handleContainerBlur = useCallback(() => {
+    setTimeout(() => {
+      if (!containerRef.current?.contains(document.activeElement)) {
+        setIsFocused(false)
       }
-    }
-
-    const observer = new ResizeObserver(check)
-    observer.observe(wrapper)
-    check()
-    return () => observer.disconnect()
-  }, [value])
+    }, BLUR_DELAY_MS)
+  }, [])
 
   const handleSubmit = useCallback(() => {
     onSubmit?.(value)
@@ -121,6 +88,8 @@ export function CompactPromptArea({
   return (
     <div
       ref={containerRef}
+      onFocus={handleContainerFocus}
+      onBlur={handleContainerBlur}
       aria-label={ariaLabel}
       data-test-id={dataTestId}
       className={cn(
@@ -149,8 +118,7 @@ export function CompactPromptArea({
 
         {/* Prompt area region */}
         <div
-          ref={promptWrapperRef}
-          className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'px-3')}
+          className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'overflow-hidden px-3')}
           onClick={() => promptRef.current?.focus()}>
           <PromptArea
             ref={promptRef}
@@ -172,7 +140,7 @@ export function CompactPromptArea({
             files={files}
             onFileRemove={onFileRemove}
             autoGrow
-            minHeight={24}
+            minHeight={isExpanded ? 48 : 24}
             maxHeight={maxHeight}
           />
         </div>

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -99,6 +99,23 @@ export function CompactPromptArea({
         className,
       )}>
       <div className={cn('flex', isExpanded ? 'flex-col' : 'items-center')}>
+        {/* Plus button – left side in collapsed mode */}
+        {!isExpanded && (
+          <button
+            type="button"
+            onClick={onPlusClick}
+            disabled={disabled}
+            className={cn(
+              'ml-2 flex shrink-0 items-center justify-center rounded-full transition-colors',
+              'bg-muted text-muted-foreground size-8',
+              'hover:bg-accent hover:text-foreground',
+              'disabled:pointer-events-none disabled:opacity-50',
+            )}
+            aria-label="Add attachment">
+            {plusButtonIcon ?? <Plus className="size-4" />}
+          </button>
+        )}
+
         {/* Prompt area region */}
         <div
           className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'overflow-hidden px-3')}
@@ -131,23 +148,25 @@ export function CompactPromptArea({
         {/* Button bar */}
         <div
           className={cn(
-            'flex shrink-0 items-center justify-between',
-            isExpanded ? 'px-3 pt-1 pb-3' : 'gap-1.5 pr-2',
+            'flex shrink-0 items-center',
+            isExpanded ? 'justify-between px-3 pt-1 pb-3' : 'gap-1.5 pr-2',
           )}>
-          {/* Plus button – circular */}
-          <button
-            type="button"
-            onClick={onPlusClick}
-            disabled={disabled}
-            className={cn(
-              'flex shrink-0 items-center justify-center rounded-full transition-colors',
-              'bg-muted text-muted-foreground size-8',
-              'hover:bg-accent hover:text-foreground',
-              'disabled:pointer-events-none disabled:opacity-50',
-            )}
-            aria-label="Add attachment">
-            {plusButtonIcon ?? <Plus className="size-4" />}
-          </button>
+          {/* Plus button – bottom-left in expanded mode */}
+          {isExpanded && (
+            <button
+              type="button"
+              onClick={onPlusClick}
+              disabled={disabled}
+              className={cn(
+                'flex shrink-0 items-center justify-center rounded-full transition-colors',
+                'bg-muted text-muted-foreground size-8',
+                'hover:bg-accent hover:text-foreground',
+                'disabled:pointer-events-none disabled:opacity-50',
+              )}
+              aria-label="Add attachment">
+              {plusButtonIcon ?? <Plus className="size-4" />}
+            </button>
+          )}
 
           {/* Right side: slot + submit */}
           <div className="flex items-center gap-1">

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -98,7 +98,7 @@ export function CompactPromptArea({
         isExpanded ? 'rounded-2xl' : 'rounded-full',
         className,
       )}>
-      <div className={cn('flex', isExpanded ? 'flex-col' : 'items-center')}>
+      <div className={cn('flex', isExpanded ? 'flex-col' : 'items-center p-1.5')}>
         {/* Plus button – left side in collapsed mode */}
         {!isExpanded && (
           <button
@@ -106,7 +106,7 @@ export function CompactPromptArea({
             onClick={onPlusClick}
             disabled={disabled}
             className={cn(
-              'ml-1.5 flex shrink-0 items-center justify-center rounded-xl transition-colors',
+              'flex shrink-0 items-center justify-center rounded-xl transition-colors',
               'bg-muted text-muted-foreground size-9',
               'hover:bg-accent hover:text-foreground',
               'disabled:pointer-events-none disabled:opacity-50',
@@ -149,7 +149,7 @@ export function CompactPromptArea({
         <div
           className={cn(
             'flex shrink-0 items-center',
-            isExpanded ? 'justify-between px-3 pt-1 pb-3' : 'gap-1.5 pr-2',
+            isExpanded ? 'justify-between px-3 pt-1 pb-3' : 'gap-1.5',
           )}>
           {/* Plus button – bottom-left in expanded mode */}
           {isExpanded && (

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useCallback, useImperativeHandle, useRef, useState } from 'react'
+import { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { Plus, ArrowUp } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
-import { BLUR_DELAY_MS } from '@/registry/new-york/blocks/prompt-area/use-prompt-area-events'
 import type { PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 import type { CompactPromptAreaProps } from './types'
 
@@ -60,26 +59,35 @@ export function CompactPromptArea({
 }: CompactPromptAreaProps & { ref?: React.Ref<PromptAreaHandle> }) {
   const promptRef = useRef<PromptAreaHandle>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const [isFocused, setIsFocused] = useState(false)
+  const promptWrapperRef = useRef<HTMLDivElement>(null)
+  const [isOverflowing, setIsOverflowing] = useState(false)
 
   useImperativeHandle(ref, () => promptRef.current!, [])
 
   const isEmpty =
     value.length === 0 || (value.length === 1 && value[0].type === 'text' && value[0].text === '')
 
-  const isExpanded = isFocused || !isEmpty
+  const hasAttachments = (images && images.length > 0) || (files && files.length > 0)
+  const isExpanded = isOverflowing || hasAttachments
 
-  const handleContainerFocus = useCallback(() => {
-    setIsFocused(true)
-  }, [])
+  // Observe the contenteditable height to detect multiline content
+  useEffect(() => {
+    const wrapper = promptWrapperRef.current
+    if (!wrapper) return
+    const SINGLE_LINE_THRESHOLD = 32
 
-  const handleContainerBlur = useCallback(() => {
-    setTimeout(() => {
-      if (!containerRef.current?.contains(document.activeElement)) {
-        setIsFocused(false)
-      }
-    }, BLUR_DELAY_MS)
-  }, [])
+    const check = () => {
+      const editor = wrapper.querySelector('[contenteditable]') as HTMLElement | null
+      if (!editor) return
+      setIsOverflowing(editor.scrollHeight > SINGLE_LINE_THRESHOLD)
+    }
+
+    const observer = new ResizeObserver(check)
+    observer.observe(wrapper)
+    // Also check immediately in case content already overflows
+    check()
+    return () => observer.disconnect()
+  }, [value])
 
   const handleSubmit = useCallback(() => {
     onSubmit?.(value)
@@ -88,8 +96,6 @@ export function CompactPromptArea({
   return (
     <div
       ref={containerRef}
-      onFocus={handleContainerFocus}
-      onBlur={handleContainerBlur}
       aria-label={ariaLabel}
       data-test-id={dataTestId}
       className={cn(
@@ -118,7 +124,8 @@ export function CompactPromptArea({
 
         {/* Prompt area region */}
         <div
-          className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'overflow-hidden px-3')}
+          ref={promptWrapperRef}
+          className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'px-3')}
           onClick={() => promptRef.current?.focus()}>
           <PromptArea
             ref={promptRef}
@@ -140,7 +147,7 @@ export function CompactPromptArea({
             files={files}
             onFileRemove={onFileRemove}
             autoGrow
-            minHeight={isExpanded ? 48 : 24}
+            minHeight={24}
             maxHeight={maxHeight}
           />
         </div>

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -101,7 +101,7 @@ export function CompactPromptArea({
       <div className={cn('flex', isExpanded ? 'flex-col' : 'items-center')}>
         {/* Prompt area region */}
         <div
-          className={cn('min-w-0 flex-1', isExpanded ? 'px-4 pt-3 pb-1' : 'overflow-hidden px-1')}
+          className={cn('min-w-0 flex-1', isExpanded ? 'px-5 pt-4 pb-2' : 'overflow-hidden px-3')}
           onClick={() => promptRef.current?.focus()}>
           <PromptArea
             ref={promptRef}
@@ -132,7 +132,7 @@ export function CompactPromptArea({
         <div
           className={cn(
             'flex shrink-0 items-center justify-between',
-            isExpanded ? 'px-2 pt-1 pb-2' : 'gap-1 pr-1',
+            isExpanded ? 'px-3 pt-1 pb-3' : 'gap-1.5 pr-2',
           )}>
           {/* Plus button – circular */}
           <button

--- a/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
+++ b/registry/new-york/blocks/compact-prompt-area/compact-prompt-area.tsx
@@ -61,6 +61,7 @@ export function CompactPromptArea({
   const containerRef = useRef<HTMLDivElement>(null)
   const promptWrapperRef = useRef<HTMLDivElement>(null)
   const [isOverflowing, setIsOverflowing] = useState(false)
+  const isOverflowingRef = useRef(false)
 
   useImperativeHandle(ref, () => promptRef.current!, [])
 
@@ -70,21 +71,45 @@ export function CompactPromptArea({
   const hasAttachments = (images && images.length > 0) || (files && files.length > 0)
   const isExpanded = isOverflowing || hasAttachments
 
-  // Observe the contenteditable height to detect multiline content
+  // Detect multiline content with hysteresis to prevent flickering.
+  // We measure scrollHeight on a hidden clone so layout shifts from
+  // expanding/collapsing don't feed back into the measurement.
   useEffect(() => {
     const wrapper = promptWrapperRef.current
     if (!wrapper) return
-    const SINGLE_LINE_THRESHOLD = 32
+    const EXPAND_THRESHOLD = 32
+    const COLLAPSE_THRESHOLD = 28
 
     const check = () => {
       const editor = wrapper.querySelector('[contenteditable]') as HTMLElement | null
       if (!editor) return
-      setIsOverflowing(editor.scrollHeight > SINGLE_LINE_THRESHOLD)
+
+      // Measure in a detached clone to avoid layout feedback loops
+      const clone = editor.cloneNode(true) as HTMLElement
+      clone.style.cssText = `
+        position:fixed;left:-9999px;top:0;
+        width:${editor.offsetWidth}px;
+        height:auto;min-height:0;max-height:none;
+        visibility:hidden;pointer-events:none;
+        white-space:pre-wrap;word-break:break-word;
+        font:${getComputedStyle(editor).font};
+        padding:${getComputedStyle(editor).padding};
+      `
+      document.body.appendChild(clone)
+      const contentHeight = clone.scrollHeight
+      document.body.removeChild(clone)
+
+      const current = isOverflowingRef.current
+      const next = current ? contentHeight > COLLAPSE_THRESHOLD : contentHeight > EXPAND_THRESHOLD
+
+      if (next !== current) {
+        isOverflowingRef.current = next
+        setIsOverflowing(next)
+      }
     }
 
     const observer = new ResizeObserver(check)
     observer.observe(wrapper)
-    // Also check immediately in case content already overflows
     check()
     return () => observer.disconnect()
   }, [value])

--- a/registry/new-york/blocks/compact-prompt-area/types.ts
+++ b/registry/new-york/blocks/compact-prompt-area/types.ts
@@ -1,0 +1,63 @@
+import type {
+  Segment,
+  TriggerConfig,
+  ChipSegment,
+  PromptAreaImage,
+  PromptAreaFile,
+} from '../prompt-area/types'
+
+export type CompactPromptAreaProps = {
+  /** The document segments (controlled) */
+  value: Segment[]
+  /** Called when the content changes */
+  onChange: (segments: Segment[]) => void
+  /** Trigger configurations */
+  triggers?: TriggerConfig[]
+  /** Placeholder text when empty. Pass an array to animate between them. */
+  placeholder?: string | string[]
+  /** Whether the input is disabled */
+  disabled?: boolean
+  /** Whether to render simple inline markdown */
+  markdown?: boolean
+  /** Called when Enter is pressed (without Shift) */
+  onSubmit?: (segments: Segment[]) => void
+  /** Called when Escape is pressed */
+  onEscape?: () => void
+  /** Called when a chip element is clicked */
+  onChipClick?: (chip: ChipSegment) => void
+  /** Called when a new chip is added */
+  onChipAdd?: (chip: ChipSegment) => void
+  /** Called when a chip is deleted */
+  onChipDelete?: (chip: ChipSegment) => void
+  /** Called after content is pasted */
+  onPaste?: (data: { segments: Segment[]; source: 'internal' | 'external' }) => void
+  /** Array of image attachments */
+  images?: PromptAreaImage[]
+  /** Called when the user pastes an image */
+  onImagePaste?: (file: File) => void
+  /** Called when the user removes an image */
+  onImageRemove?: (image: PromptAreaImage) => void
+  /** Array of file attachments */
+  files?: PromptAreaFile[]
+  /** Called when the user removes a file */
+  onFileRemove?: (file: PromptAreaFile) => void
+
+  // ---- Compact-specific props ----
+
+  /** Icon for the circular plus button on the left. Defaults to Plus icon. */
+  plusButtonIcon?: React.ReactNode
+  /** Click handler for the plus button */
+  onPlusClick?: () => void
+  /** Icon for the circular submit button on the right. Defaults to ArrowUp icon. */
+  submitButtonIcon?: React.ReactNode
+  /** Slot rendered immediately before the submit button (e.g., mic button) */
+  beforeSubmitSlot?: React.ReactNode
+  /** Maximum height the expanded area can reach in pixels. Defaults to 320. */
+  maxHeight?: number
+  /** Additional CSS class for the outer container */
+  className?: string
+  /** Accessible label */
+  'aria-label'?: string
+  /** data-test-id for e2e testing */
+  'data-test-id'?: string
+}


### PR DESCRIPTION
New component that wraps PromptArea in a compact single-row layout with
circular plus (left) and submit (right) buttons, a customizable slot
before submit, and smooth expansion from pill to rounded-2xl on focus.

https://claude.ai/code/session_018c6rGbiHo42z5PLmFQJaNq