### PR TITLE
Add DX helpers: usePromptAreaState, trigger presets, and segment helpers

### DIFF
--- a/app/examples/dx-helpers.tsx
+++ b/app/examples/dx-helpers.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { usePromptAreaState } from '@/registry/new-york/blocks/prompt-area/use-prompt-area-state'
+import {
+  mentionTrigger,
+  commandTrigger,
+  hashtagTrigger,
+} from '@/registry/new-york/blocks/prompt-area/trigger-presets'
+import { getChipsByTrigger } from '@/registry/new-york/blocks/prompt-area/segment-helpers'
+
+const AGENTS = [
+  { value: 'copywriter', label: 'Copywriter', description: 'Ad copy & content' },
+  { value: 'analyst', label: 'Analyst', description: 'Performance insights' },
+  { value: 'designer', label: 'Designer', description: 'Visual & brand assets' },
+]
+
+const COMMANDS = [
+  { value: 'summarize', label: 'summarize', description: 'Summarize the conversation' },
+  { value: 'deep-research', label: 'deep-research', description: 'Research a topic in depth' },
+]
+
+const TAGS = [
+  { value: 'campaign', label: 'campaign' },
+  { value: 'branding', label: 'branding' },
+]
+
+const search =
+  <T extends { label: string }>(items: T[]) =>
+  (q: string) =>
+    items.filter((i) => i.label.toLowerCase().includes(q.toLowerCase()))
+
+export function DxHelpersExample() {
+  const { bind, isEmpty, chips, plainText, clear } = usePromptAreaState()
+
+  const mentions = getChipsByTrigger(bind.value, '@')
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-lg border p-4">
+        <PromptArea
+          {...bind}
+          triggers={[
+            mentionTrigger({
+              chipClassName: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+              onSearch: search(AGENTS),
+            }),
+            commandTrigger({
+              chipClassName: 'text-violet-700 dark:text-violet-400',
+              onSearch: search(COMMANDS),
+            }),
+            hashtagTrigger({
+              chipClassName: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+              onSearch: search(TAGS),
+            }),
+          ]}
+          placeholder="Try @mention, /command, and #tags..."
+          onSubmit={() => clear()}
+          minHeight={48}
+        />
+      </div>
+      <div className="text-muted-foreground flex gap-4 text-xs">
+        <span>empty: {String(isEmpty)}</span>
+        <span>chips: {chips.length}</span>
+        <span>mentions: {mentions.length}</span>
+        {plainText && <span className="max-w-48 truncate">text: {plainText}</span>}
+      </div>
+    </div>
+  )
+}
+
+export const dxHelpersCode = `import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { usePromptAreaState } from '@/registry/new-york/blocks/prompt-area/use-prompt-area-state'
+import { mentionTrigger, commandTrigger, hashtagTrigger } from '@/registry/new-york/blocks/prompt-area/trigger-presets'
+import { getChipsByTrigger } from '@/registry/new-york/blocks/prompt-area/segment-helpers'
+
+function ChatInput() {
+  const { bind, plainText, isEmpty, chips, clear, focus } = usePromptAreaState()
+  const mentions = getChipsByTrigger(bind.value, '@')
+
+  return (
+    <>
+      <PromptArea
+        {...bind}
+        triggers={[
+          mentionTrigger({ onSearch: searchAgents }),
+          commandTrigger({ onSearch: searchCommands }),
+          hashtagTrigger({ onSearch: searchTags }),
+        ]}
+        placeholder="Try @mention, /command, and #tags..."
+        onSubmit={() => {
+          sendMessage(plainText, mentions)
+          clear()
+        }}
+      />
+      <button disabled={isEmpty} onClick={() => focus()}>
+        Send
+      </button>
+    </>
+  )
+}`

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -21,3 +21,4 @@ export {
 } from './status-bar'
 export { CompactPromptAreaExample, compactPromptAreaCode } from './compact-prompt-area'
 export { ChatPromptLayoutExample, chatPromptLayoutCode } from './chat-prompt-layout'
+export { DxHelpersExample, dxHelpersCode } from './dx-helpers'

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -39,6 +39,8 @@ import {
   compactPromptAreaCode,
   ChatPromptLayoutExample,
   chatPromptLayoutCode,
+  DxHelpersExample,
+  dxHelpersCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
 import { DemoSection } from './sections/demo-section'
@@ -113,6 +115,19 @@ export default function HomeContent() {
         <SectionHeading id="examples" as="h2">
           Examples
         </SectionHeading>
+
+        <div id="example-dx-helpers" className="flex scroll-mt-16 flex-col gap-2">
+          <SectionHeading id="example-dx-helpers">DX Helpers</SectionHeading>
+          <p className="text-muted-foreground text-xs">
+            Use <code>usePromptAreaState()</code> for zero-boilerplate state,{' '}
+            <code>mentionTrigger()</code> / <code>commandTrigger()</code> /{' '}
+            <code>hashtagTrigger()</code> for one-liner trigger setup, and{' '}
+            <code>getChipsByTrigger()</code> to inspect segments.
+          </p>
+          <ExampleShowcase code={dxHelpersCode}>
+            <DxHelpersExample />
+          </ExampleShowcase>
+        </div>
 
         <div id="example-basic" className="flex scroll-mt-16 flex-col gap-2">
           <SectionHeading id="example-basic">Basic (no triggers)</SectionHeading>

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -25,6 +25,7 @@ const NAV_ITEMS: NavItem[] = [
     id: 'examples',
     label: 'Examples',
     children: [
+      { id: 'example-dx-helpers', label: 'DX Helpers' },
       { id: 'example-basic', label: 'Basic' },
       { id: 'example-mentions', label: '@Mentions' },
       { id: 'example-commands', label: '/Commands' },

--- a/registry/new-york/blocks/prompt-area/__tests__/segment-helpers.test.ts
+++ b/registry/new-york/blocks/prompt-area/__tests__/segment-helpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import {
+  text,
+  chip,
+  isSegmentsEmpty,
+  hasChips,
+  getChips,
+  getChipsByTrigger,
+  segmentsToPlainText,
+  plainTextToSegments,
+} from '../segment-helpers'
+import type { Segment } from '../types'
+
+describe('segment-helpers', () => {
+  // -----------------------------------------------------------------------
+  // Factories
+  // -----------------------------------------------------------------------
+
+  describe('text()', () => {
+    it('creates a TextSegment', () => {
+      expect(text('hello')).toEqual({ type: 'text', text: 'hello' })
+    })
+
+    it('handles empty string', () => {
+      expect(text('')).toEqual({ type: 'text', text: '' })
+    })
+  })
+
+  describe('chip()', () => {
+    it('creates a ChipSegment', () => {
+      const result = chip({ trigger: '@', value: 'u1', displayText: 'Alice' })
+      expect(result).toEqual({
+        type: 'chip',
+        trigger: '@',
+        value: 'u1',
+        displayText: 'Alice',
+      })
+    })
+
+    it('passes through optional fields', () => {
+      const result = chip({
+        trigger: '#',
+        value: 'tag1',
+        displayText: 'react',
+        data: { color: 'blue' },
+        autoResolved: true,
+      })
+      expect(result.data).toEqual({ color: 'blue' })
+      expect(result.autoResolved).toBe(true)
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Predicates
+  // -----------------------------------------------------------------------
+
+  describe('isSegmentsEmpty()', () => {
+    it('returns true for empty array', () => {
+      expect(isSegmentsEmpty([])).toBe(true)
+    })
+
+    it('returns true for whitespace-only text', () => {
+      expect(isSegmentsEmpty([text(''), text('  '), text('\n')])).toBe(true)
+    })
+
+    it('returns false when there is real text', () => {
+      expect(isSegmentsEmpty([text('hello')])).toBe(false)
+    })
+
+    it('returns false when there is a chip', () => {
+      expect(
+        isSegmentsEmpty([text(''), chip({ trigger: '@', value: 'u1', displayText: 'Alice' })]),
+      ).toBe(false)
+    })
+  })
+
+  describe('hasChips()', () => {
+    it('returns false for text-only segments', () => {
+      expect(hasChips([text('hello')])).toBe(false)
+    })
+
+    it('returns true when a chip is present', () => {
+      expect(
+        hasChips([text('hi '), chip({ trigger: '@', value: 'u1', displayText: 'Alice' })]),
+      ).toBe(true)
+    })
+  })
+
+  describe('getChips()', () => {
+    it('extracts only chip segments', () => {
+      const segments: Segment[] = [
+        text('hi '),
+        chip({ trigger: '@', value: 'u1', displayText: 'Alice' }),
+        text(' and '),
+        chip({ trigger: '@', value: 'u2', displayText: 'Bob' }),
+      ]
+      const chips = getChips(segments)
+      expect(chips).toHaveLength(2)
+      expect(chips[0].displayText).toBe('Alice')
+      expect(chips[1].displayText).toBe('Bob')
+    })
+
+    it('returns empty array for text-only', () => {
+      expect(getChips([text('hello')])).toEqual([])
+    })
+  })
+
+  describe('getChipsByTrigger()', () => {
+    it('filters chips by trigger character', () => {
+      const segments: Segment[] = [
+        chip({ trigger: '@', value: 'u1', displayText: 'Alice' }),
+        chip({ trigger: '#', value: 't1', displayText: 'react' }),
+        chip({ trigger: '@', value: 'u2', displayText: 'Bob' }),
+      ]
+      const mentions = getChipsByTrigger(segments, '@')
+      expect(mentions).toHaveLength(2)
+      expect(mentions[0].displayText).toBe('Alice')
+
+      const tags = getChipsByTrigger(segments, '#')
+      expect(tags).toHaveLength(1)
+      expect(tags[0].displayText).toBe('react')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Re-exports
+  // -----------------------------------------------------------------------
+
+  describe('re-exported utilities', () => {
+    it('segmentsToPlainText works', () => {
+      const segments: Segment[] = [
+        text('Hello '),
+        chip({ trigger: '@', value: 'u1', displayText: 'Alice' }),
+      ]
+      expect(segmentsToPlainText(segments)).toBe('Hello @Alice')
+    })
+
+    it('plainTextToSegments works', () => {
+      expect(plainTextToSegments('hello')).toEqual([{ type: 'text', text: 'hello' }])
+      expect(plainTextToSegments('')).toEqual([])
+    })
+  })
+})

--- a/registry/new-york/blocks/prompt-area/__tests__/trigger-presets.test.ts
+++ b/registry/new-york/blocks/prompt-area/__tests__/trigger-presets.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { mentionTrigger, commandTrigger, hashtagTrigger, callbackTrigger } from '../trigger-presets'
+
+describe('trigger-presets', () => {
+  describe('mentionTrigger()', () => {
+    it('returns sensible defaults', () => {
+      const config = mentionTrigger()
+      expect(config.char).toBe('@')
+      expect(config.position).toBe('any')
+      expect(config.mode).toBe('dropdown')
+      expect(config.chipStyle).toBe('pill')
+      expect(config.accessibilityLabel).toBe('mention')
+    })
+
+    it('allows overriding onSearch', () => {
+      const onSearch = () => []
+      const config = mentionTrigger({ onSearch })
+      expect(config.onSearch).toBe(onSearch)
+    })
+
+    it('allows overriding the trigger character', () => {
+      const config = mentionTrigger({ char: '+' })
+      expect(config.char).toBe('+')
+    })
+
+    it('allows overriding chipClassName', () => {
+      const config = mentionTrigger({ chipClassName: 'bg-blue-100' })
+      expect(config.chipClassName).toBe('bg-blue-100')
+    })
+  })
+
+  describe('commandTrigger()', () => {
+    it('returns sensible defaults', () => {
+      const config = commandTrigger()
+      expect(config.char).toBe('/')
+      expect(config.position).toBe('start')
+      expect(config.mode).toBe('dropdown')
+      expect(config.chipStyle).toBe('inline')
+      expect(config.accessibilityLabel).toBe('command')
+    })
+
+    it('allows overriding emptyMessage', () => {
+      const config = commandTrigger({ emptyMessage: 'No commands found' })
+      expect(config.emptyMessage).toBe('No commands found')
+    })
+  })
+
+  describe('hashtagTrigger()', () => {
+    it('returns sensible defaults with resolveOnSpace', () => {
+      const config = hashtagTrigger()
+      expect(config.char).toBe('#')
+      expect(config.position).toBe('any')
+      expect(config.mode).toBe('dropdown')
+      expect(config.chipStyle).toBe('pill')
+      expect(config.resolveOnSpace).toBe(true)
+      expect(config.accessibilityLabel).toBe('tag')
+    })
+
+    it('allows disabling resolveOnSpace', () => {
+      const config = hashtagTrigger({ resolveOnSpace: false })
+      expect(config.resolveOnSpace).toBe(false)
+    })
+  })
+
+  describe('callbackTrigger()', () => {
+    it('creates a callback-mode trigger', () => {
+      const onActivate = () => {}
+      const config = callbackTrigger({ char: '!', onActivate })
+      expect(config.char).toBe('!')
+      expect(config.mode).toBe('callback')
+      expect(config.position).toBe('start')
+      expect(config.onActivate).toBe(onActivate)
+    })
+
+    it('allows overriding position', () => {
+      const config = callbackTrigger({ char: '!', position: 'any' })
+      expect(config.position).toBe('any')
+    })
+  })
+})

--- a/registry/new-york/blocks/prompt-area/__tests__/use-prompt-area-state.test.ts
+++ b/registry/new-york/blocks/prompt-area/__tests__/use-prompt-area-state.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePromptAreaState } from '../use-prompt-area-state'
+import type { Segment } from '../types'
+
+describe('usePromptAreaState', () => {
+  it('starts with empty value by default', () => {
+    const { result } = renderHook(() => usePromptAreaState())
+    expect(result.current.bind.value).toEqual([])
+    expect(result.current.isEmpty).toBe(true)
+    expect(result.current.hasChips).toBe(false)
+    expect(result.current.plainText).toBe('')
+    expect(result.current.chips).toEqual([])
+  })
+
+  it('accepts an initial value', () => {
+    const initial: Segment[] = [{ type: 'text', text: 'hello' }]
+    const { result } = renderHook(() => usePromptAreaState({ initialValue: initial }))
+    expect(result.current.bind.value).toEqual(initial)
+    expect(result.current.isEmpty).toBe(false)
+    expect(result.current.plainText).toBe('hello')
+  })
+
+  it('updates value via bind.onChange', () => {
+    const { result } = renderHook(() => usePromptAreaState())
+    act(() => {
+      result.current.bind.onChange([{ type: 'text', text: 'world' }])
+    })
+    expect(result.current.bind.value).toEqual([{ type: 'text', text: 'world' }])
+    expect(result.current.plainText).toBe('world')
+    expect(result.current.isEmpty).toBe(false)
+  })
+
+  it('derives hasChips and chips correctly', () => {
+    const { result } = renderHook(() => usePromptAreaState())
+    act(() => {
+      result.current.bind.onChange([
+        { type: 'text', text: 'hi ' },
+        { type: 'chip', trigger: '@', value: 'u1', displayText: 'Alice' },
+        { type: 'text', text: ' and ' },
+        { type: 'chip', trigger: '#', value: 't1', displayText: 'react' },
+      ])
+    })
+    expect(result.current.hasChips).toBe(true)
+    expect(result.current.chips).toHaveLength(2)
+    expect(result.current.chips[0].displayText).toBe('Alice')
+    expect(result.current.chips[1].displayText).toBe('react')
+    expect(result.current.plainText).toBe('hi @Alice and #react')
+  })
+
+  it('clear() resets value when no ref is attached', () => {
+    const { result } = renderHook(() => usePromptAreaState())
+    act(() => {
+      result.current.bind.onChange([{ type: 'text', text: 'data' }])
+    })
+    expect(result.current.isEmpty).toBe(false)
+
+    act(() => {
+      result.current.clear()
+    })
+    expect(result.current.bind.value).toEqual([])
+    expect(result.current.isEmpty).toBe(true)
+  })
+
+  it('provides a stable bind.ref object', () => {
+    const { result, rerender } = renderHook(() => usePromptAreaState())
+    const ref1 = result.current.bind.ref
+    rerender()
+    expect(result.current.bind.ref).toBe(ref1)
+  })
+})

--- a/registry/new-york/blocks/prompt-area/segment-helpers.ts
+++ b/registry/new-york/blocks/prompt-area/segment-helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Convenience helpers for creating and inspecting Segments.
+ *
+ * These reduce boilerplate when building AI chat UIs that work with the
+ * PromptArea document model.
+ *
+ * @example
+ * ```ts
+ * import { text, chip, isSegmentsEmpty, segmentsToPlainText } from './segment-helpers'
+ *
+ * const greeting = [text('Hello '), chip({ trigger: '@', value: 'u1', displayText: 'Alice' })]
+ * isSegmentsEmpty(greeting) // false
+ * segmentsToPlainText(greeting) // "Hello @Alice"
+ * ```
+ */
+
+import type { Segment, TextSegment, ChipSegment } from './types'
+import { segmentsToPlainText, plainTextToSegments } from './prompt-area-engine'
+
+// Re-export serialization utilities so consumers have a single import.
+export { segmentsToPlainText, plainTextToSegments }
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/** Create a text segment. */
+export function text(value: string): TextSegment {
+  return { type: 'text', text: value }
+}
+
+/** Create a chip segment. */
+export function chip(opts: Omit<ChipSegment, 'type'>): ChipSegment {
+  return { type: 'chip', ...opts }
+}
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+/** Returns `true` when the segment array is empty or contains only whitespace text. */
+export function isSegmentsEmpty(segments: Segment[]): boolean {
+  if (segments.length === 0) return true
+  return segments.every((seg) => seg.type === 'text' && seg.text.trim() === '')
+}
+
+/** Returns `true` when the segment array contains at least one chip. */
+export function hasChips(segments: Segment[]): boolean {
+  return segments.some((seg) => seg.type === 'chip')
+}
+
+/** Extracts all chip segments from a segment array. */
+export function getChips(segments: Segment[]): ChipSegment[] {
+  return segments.filter((seg): seg is ChipSegment => seg.type === 'chip')
+}
+
+/** Extracts chips matching a specific trigger character. */
+export function getChipsByTrigger(segments: Segment[], trigger: string): ChipSegment[] {
+  return segments.filter(
+    (seg): seg is ChipSegment => seg.type === 'chip' && seg.trigger === trigger,
+  )
+}

--- a/registry/new-york/blocks/prompt-area/trigger-presets.ts
+++ b/registry/new-york/blocks/prompt-area/trigger-presets.ts
@@ -1,0 +1,133 @@
+/**
+ * Pre-built trigger configuration factories for common AI chat patterns.
+ *
+ * Each factory returns a full `TriggerConfig` with sensible defaults.
+ * Pass only what you need to override.
+ *
+ * @example
+ * ```tsx
+ * <PromptArea
+ *   triggers={[
+ *     mentionTrigger({ onSearch: searchUsers }),
+ *     commandTrigger({ onSearch: searchCommands }),
+ *     hashtagTrigger(),
+ *   ]}
+ * />
+ * ```
+ */
+
+import type { TriggerConfig } from './types'
+
+// ---------------------------------------------------------------------------
+// Shared option type — everything in TriggerConfig except the keys each
+// factory sets by default.
+// ---------------------------------------------------------------------------
+
+type TriggerPresetOptions = Omit<Partial<TriggerConfig>, 'char' | 'position' | 'mode'>
+
+// ---------------------------------------------------------------------------
+// @mention — dropdown at any position
+// ---------------------------------------------------------------------------
+
+export type MentionTriggerOptions = TriggerPresetOptions & {
+  /** Override the trigger character. Defaults to `'@'`. */
+  char?: string
+}
+
+/**
+ * Creates a **mention** trigger (`@`).
+ *
+ * Defaults: `position: 'any'`, `mode: 'dropdown'`, `chipStyle: 'pill'`,
+ * accessible label `"mention"`.
+ */
+export function mentionTrigger(opts: MentionTriggerOptions = {}): TriggerConfig {
+  const { char = '@', ...rest } = opts
+  return {
+    char,
+    position: 'any',
+    mode: 'dropdown',
+    chipStyle: 'pill',
+    accessibilityLabel: 'mention',
+    ...rest,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// /command — dropdown only at line start
+// ---------------------------------------------------------------------------
+
+export type CommandTriggerOptions = TriggerPresetOptions & {
+  /** Override the trigger character. Defaults to `'/'`. */
+  char?: string
+}
+
+/**
+ * Creates a **command** trigger (`/`).
+ *
+ * Defaults: `position: 'start'`, `mode: 'dropdown'`, `chipStyle: 'inline'`,
+ * accessible label `"command"`.
+ */
+export function commandTrigger(opts: CommandTriggerOptions = {}): TriggerConfig {
+  const { char = '/', ...rest } = opts
+  return {
+    char,
+    position: 'start',
+    mode: 'dropdown',
+    chipStyle: 'inline',
+    accessibilityLabel: 'command',
+    ...rest,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// #hashtag — dropdown at any position, auto-resolve on space
+// ---------------------------------------------------------------------------
+
+export type HashtagTriggerOptions = TriggerPresetOptions & {
+  /** Override the trigger character. Defaults to `'#'`. */
+  char?: string
+}
+
+/**
+ * Creates a **hashtag / tag** trigger (`#`).
+ *
+ * Defaults: `position: 'any'`, `mode: 'dropdown'`, `chipStyle: 'pill'`,
+ * `resolveOnSpace: true`, accessible label `"tag"`.
+ */
+export function hashtagTrigger(opts: HashtagTriggerOptions = {}): TriggerConfig {
+  const { char = '#', ...rest } = opts
+  return {
+    char,
+    position: 'any',
+    mode: 'dropdown',
+    chipStyle: 'pill',
+    resolveOnSpace: true,
+    accessibilityLabel: 'tag',
+    ...rest,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic callback trigger (e.g., for file pickers, model selectors)
+// ---------------------------------------------------------------------------
+
+export type CallbackTriggerOptions = Omit<Partial<TriggerConfig>, 'mode'> & {
+  /** The trigger character. Required. */
+  char: string
+}
+
+/**
+ * Creates a **callback** trigger that fires `onActivate` instead of showing
+ * a dropdown. Useful for opening file pickers, model selectors, etc.
+ *
+ * Defaults: `position: 'start'`, `mode: 'callback'`.
+ */
+export function callbackTrigger(opts: CallbackTriggerOptions): TriggerConfig {
+  const { char, ...rest } = opts
+  return {
+    char,
+    position: 'start',
+    mode: 'callback',
+    ...rest,
+  }
+}

--- a/registry/new-york/blocks/prompt-area/use-prompt-area-state.ts
+++ b/registry/new-york/blocks/prompt-area/use-prompt-area-state.ts
@@ -1,0 +1,131 @@
+/**
+ * Convenience hook that wires up all the boilerplate state for a PromptArea.
+ *
+ * Instead of manually managing `useState<Segment[]>`, `useRef<PromptAreaHandle>`,
+ * and computing derived values, call `usePromptAreaState()` once and spread
+ * `bind` into your `<PromptArea>`.
+ *
+ * @example
+ * ```tsx
+ * function ChatInput() {
+ *   const { bind, plainText, isEmpty, chips, clear, focus } = usePromptAreaState()
+ *
+ *   return (
+ *     <PromptArea
+ *       {...bind}
+ *       onSubmit={() => {
+ *         sendMessage(plainText)
+ *         clear()
+ *       }}
+ *     />
+ *   )
+ * }
+ * ```
+ */
+
+'use client'
+
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { Segment, ChipSegment, PromptAreaHandle } from './types'
+import { segmentsToPlainText } from './prompt-area-engine'
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export type UsePromptAreaStateOptions = {
+  /** Initial segment value. Defaults to `[]`. */
+  initialValue?: Segment[]
+}
+
+// ---------------------------------------------------------------------------
+// Return type
+// ---------------------------------------------------------------------------
+
+export type PromptAreaBind = {
+  /** Ref to attach to PromptArea — gives access to imperative methods. */
+  ref: React.RefObject<PromptAreaHandle | null>
+  /** Current segment array — pass as `value` prop. */
+  value: Segment[]
+  /** Setter — pass as `onChange` prop. */
+  onChange: (segments: Segment[]) => void
+}
+
+export type PromptAreaState = {
+  /** Props to spread directly onto `<PromptArea {...bind} />`. Contains ref, value, and onChange. */
+  bind: PromptAreaBind
+  /** Derived plain text representation of the current value. */
+  plainText: string
+  /** `true` when the value is empty or whitespace-only. */
+  isEmpty: boolean
+  /** `true` when the value contains at least one chip. */
+  hasChips: boolean
+  /** All chip segments in the current value. */
+  chips: ChipSegment[]
+  /** Clear all content (both state and the editor DOM). */
+  clear: () => void
+  /** Focus the editor. */
+  focus: () => void
+  /** Blur the editor. */
+  blur: () => void
+  /** Insert a chip at the current cursor position. */
+  insertChip: (chip: Omit<ChipSegment, 'type'>) => void
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePromptAreaState(options: UsePromptAreaStateOptions = {}): PromptAreaState {
+  const { initialValue = [] } = options
+
+  const [value, setValue] = useState<Segment[]>(initialValue)
+  const ref = useRef<PromptAreaHandle>(null)
+
+  // Derived
+  const plainText = useMemo(() => segmentsToPlainText(value), [value])
+
+  const isEmpty = useMemo(() => {
+    if (value.length === 0) return true
+    return value.every((seg) => seg.type === 'text' && seg.text.trim() === '')
+  }, [value])
+
+  const hasChips = useMemo(() => value.some((seg) => seg.type === 'chip'), [value])
+
+  const chips = useMemo(
+    () => value.filter((seg): seg is ChipSegment => seg.type === 'chip'),
+    [value],
+  )
+
+  // Bind object — safe to spread onto <PromptArea>
+  const bind = useMemo<PromptAreaBind>(() => ({ ref, value, onChange: setValue }), [value])
+
+  // Actions that proxy to the imperative handle
+  const clear = useCallback(() => {
+    if (ref.current) {
+      ref.current.clear()
+    } else {
+      setValue([])
+    }
+  }, [])
+
+  const focus = useCallback(() => ref.current?.focus(), [])
+  const blur = useCallback(() => ref.current?.blur(), [])
+
+  const insertChip = useCallback(
+    (chip: Omit<ChipSegment, 'type'>) => ref.current?.insertChip(chip),
+    [],
+  )
+
+  return {
+    bind,
+    plainText,
+    isEmpty,
+    hasChips,
+    chips,
+    clear,
+    focus,
+    blur,
+    insertChip,
+  }
+}


### PR DESCRIPTION
Improve developer experience for AI projects consuming PromptArea:

- usePromptAreaState(): Zero-boilerplate hook with { bind, plainText,
  isEmpty, hasChips, chips, clear, focus, blur, insertChip }. Spread
  `bind` directly onto <PromptArea {...bind} />.
- Trigger presets: mentionTrigger(), commandTrigger(), hashtagTrigger(),
  callbackTrigger() — one-liner trigger configs with sensible defaults
- Segment helpers: text(), chip(), isSegmentsEmpty(), hasChips(), getChips(),
  getChipsByTrigger() + re-exports of segmentsToPlainText/plainTextToSegments
- 31 new tests covering all helpers
- DX Helpers showcase example on the demo page

https://claude.ai/code/session_017MGMRN1noFXKiroE8TDnmU