### PR TITLE
Add swipe gesture to open/close nav menu on mobile

### DIFF
--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -497,10 +497,10 @@ export function SidebarLayout({ children }: { children: ReactNode }) {
   const close = useCallback(() => setIsOpen(false), [])
   const open = useCallback(() => setIsOpen(true), [])
 
-  // Swipe right-to-left → open nav, swipe left-to-right → close nav
+  // Swipe left-to-right → open nav, swipe right-to-left → close nav
   useSwipeGesture({
-    onSwipeLeft: open,
-    onSwipeRight: close,
+    onSwipeLeft: close,
+    onSwipeRight: open,
     isDesktop,
   })
 

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -431,6 +431,60 @@ function NavSidebar() {
 }
 
 // ---------------------------------------------------------------------------
+// useSwipeGesture — detect horizontal swipes on mobile
+// ---------------------------------------------------------------------------
+
+function useSwipeGesture({
+  onSwipeLeft,
+  onSwipeRight,
+  isDesktop,
+}: {
+  onSwipeLeft?: () => void
+  onSwipeRight?: () => void
+  isDesktop: boolean
+}) {
+  const touchStart = useRef<{ x: number; y: number } | null>(null)
+
+  useEffect(() => {
+    if (isDesktop) return
+
+    const SWIPE_THRESHOLD = 50
+    const MAX_VERTICAL_RATIO = 0.75 // allow slightly diagonal swipes
+
+    function handleTouchStart(e: TouchEvent) {
+      const touch = e.touches[0]
+      touchStart.current = { x: touch.clientX, y: touch.clientY }
+    }
+
+    function handleTouchEnd(e: TouchEvent) {
+      if (!touchStart.current) return
+
+      const touch = e.changedTouches[0]
+      const deltaX = touch.clientX - touchStart.current.x
+      const deltaY = touch.clientY - touchStart.current.y
+      touchStart.current = null
+
+      // Must be primarily horizontal
+      if (Math.abs(deltaX) < SWIPE_THRESHOLD) return
+      if (Math.abs(deltaY) > Math.abs(deltaX) * MAX_VERTICAL_RATIO) return
+
+      if (deltaX < 0) {
+        onSwipeLeft?.()
+      } else {
+        onSwipeRight?.()
+      }
+    }
+
+    document.addEventListener('touchstart', handleTouchStart, { passive: true })
+    document.addEventListener('touchend', handleTouchEnd, { passive: true })
+    return () => {
+      document.removeEventListener('touchstart', handleTouchStart)
+      document.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [isDesktop, onSwipeLeft, onSwipeRight])
+}
+
+// ---------------------------------------------------------------------------
 // SidebarLayout — root wrapper with push effect
 // ---------------------------------------------------------------------------
 
@@ -441,6 +495,14 @@ export function SidebarLayout({ children }: { children: ReactNode }) {
 
   const toggle = useCallback(() => setIsOpen((o) => !o), [])
   const close = useCallback(() => setIsOpen(false), [])
+  const open = useCallback(() => setIsOpen(true), [])
+
+  // Swipe right-to-left → open nav, swipe left-to-right → close nav
+  useSwipeGesture({
+    onSwipeLeft: open,
+    onSwipeRight: close,
+    isDesktop,
+  })
 
   // Sync open state with screen size
   useEffect(() => {


### PR DESCRIPTION
Swipe right-to-left opens the sidebar, swipe left-to-right closes it.
Only active on mobile (below lg breakpoint). Uses passive touch event
listeners with a 50px threshold and vertical ratio guard to avoid
interfering with normal scrolling.

https://claude.ai/code/session_014pwuPjJhtzXcj7AwuAMsX5