### PR TITLE
Add gradient overflow indicator for collapsed auto-grow prompt area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # dependencies
 /node_modules
+package-lock.json
 /.pnp
 .pnp.*
 .yarn/*

--- a/registry/new-york/blocks/prompt-area/__tests__/prompt-area.test.tsx
+++ b/registry/new-york/blocks/prompt-area/__tests__/prompt-area.test.tsx
@@ -280,6 +280,122 @@ describe('PromptArea', () => {
 
       expect(editor.style.height).toBeDefined()
     })
+
+    it('shows overflow gradient when collapsed content overflows', async () => {
+      const { container } = render(
+        <PromptArea
+          {...defaultProps}
+          autoGrow
+          minHeight={80}
+          value={[{ type: 'text', text: 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8' }]}
+        />,
+      )
+      const editor = screen.getByRole('textbox')
+
+      // Simulate content taller than container
+      Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
+
+      // Trigger the rAF-based overflow check
+      await act(async () => {
+        vi.advanceTimersByTime(0)
+        await vi.runAllTimersAsync()
+      })
+
+      const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
+      expect(gradient).toBeInTheDocument()
+    })
+
+    it('does not show overflow gradient when content fits', async () => {
+      const { container } = render(
+        <PromptArea
+          {...defaultProps}
+          autoGrow
+          minHeight={80}
+          value={[{ type: 'text', text: 'Short' }]}
+        />,
+      )
+      const editor = screen.getByRole('textbox')
+
+      // Content fits within the container
+      Object.defineProperty(editor, 'scrollHeight', { value: 40, configurable: true })
+      Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
+
+      await act(async () => {
+        vi.advanceTimersByTime(0)
+        await vi.runAllTimersAsync()
+      })
+
+      const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
+      expect(gradient).not.toBeInTheDocument()
+    })
+
+    it('hides overflow gradient when focused', async () => {
+      const { container } = render(
+        <PromptArea
+          {...defaultProps}
+          autoGrow
+          minHeight={80}
+          value={[{ type: 'text', text: 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8' }]}
+        />,
+      )
+      const editor = screen.getByRole('textbox')
+
+      Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
+
+      // Let overflow check run
+      await act(async () => {
+        vi.advanceTimersByTime(0)
+        await vi.runAllTimersAsync()
+      })
+
+      // Focus the editor – should hide gradient
+      fireEvent.focus(editor)
+
+      const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
+      expect(gradient).not.toBeInTheDocument()
+    })
+
+    it('focuses editor when overflow gradient is clicked', async () => {
+      const { container } = render(
+        <PromptArea
+          {...defaultProps}
+          autoGrow
+          minHeight={80}
+          value={[{ type: 'text', text: 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8' }]}
+        />,
+      )
+      const editor = screen.getByRole('textbox')
+
+      Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
+
+      await act(async () => {
+        vi.advanceTimersByTime(0)
+        await vi.runAllTimersAsync()
+      })
+
+      const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
+      expect(gradient).toBeInTheDocument()
+
+      fireEvent.click(gradient!)
+      expect(document.activeElement).toBe(editor)
+    })
+
+    it('uses overflow-hidden when collapsed, auto when focused', () => {
+      render(<PromptArea {...defaultProps} autoGrow />)
+      const editor = screen.getByRole('textbox')
+
+      // Collapsed: overflow should be hidden
+      expect(editor.style.overflowY).toBe('hidden')
+
+      Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
+      fireEvent.focus(editor)
+
+      // Focused: overflow should be auto
+      expect(editor.style.overflowY).toBe('auto')
+    })
   })
 
   describe('default aria-label', () => {

--- a/registry/new-york/blocks/prompt-area/__tests__/prompt-area.test.tsx
+++ b/registry/new-york/blocks/prompt-area/__tests__/prompt-area.test.tsx
@@ -296,10 +296,9 @@ describe('PromptArea', () => {
       Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
       Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
 
-      // Trigger the rAF-based overflow check
+      // Advance past the 160ms overflow check delay
       await act(async () => {
-        vi.advanceTimersByTime(0)
-        await vi.runAllTimersAsync()
+        vi.advanceTimersByTime(200)
       })
 
       const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
@@ -322,8 +321,7 @@ describe('PromptArea', () => {
       Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
 
       await act(async () => {
-        vi.advanceTimersByTime(0)
-        await vi.runAllTimersAsync()
+        vi.advanceTimersByTime(200)
       })
 
       const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
@@ -346,8 +344,7 @@ describe('PromptArea', () => {
 
       // Let overflow check run
       await act(async () => {
-        vi.advanceTimersByTime(0)
-        await vi.runAllTimersAsync()
+        vi.advanceTimersByTime(200)
       })
 
       // Focus the editor – should hide gradient
@@ -372,8 +369,7 @@ describe('PromptArea', () => {
       Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
 
       await act(async () => {
-        vi.advanceTimersByTime(0)
-        await vi.runAllTimersAsync()
+        vi.advanceTimersByTime(200)
       })
 
       const gradient = container.querySelector('[aria-hidden="true"].pointer-events-auto')
@@ -381,6 +377,50 @@ describe('PromptArea', () => {
 
       fireEvent.click(gradient!)
       expect(document.activeElement).toBe(editor)
+    })
+
+    it('re-shows overflow gradient after focus then blur', async () => {
+      const { container } = render(
+        <PromptArea
+          {...defaultProps}
+          autoGrow
+          minHeight={80}
+          value={[{ type: 'text', text: 'Line1\nLine2\nLine3\nLine4\nLine5\nLine6\nLine7\nLine8' }]}
+        />,
+      )
+      const editor = screen.getByRole('textbox')
+
+      Object.defineProperty(editor, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(editor, 'clientHeight', { value: 80, configurable: true })
+
+      // Initial overflow check
+      await act(async () => {
+        vi.advanceTimersByTime(200)
+      })
+      expect(
+        container.querySelector('[aria-hidden="true"].pointer-events-auto'),
+      ).toBeInTheDocument()
+
+      // Focus – gradient should disappear
+      fireEvent.focus(editor)
+      expect(
+        container.querySelector('[aria-hidden="true"].pointer-events-auto'),
+      ).not.toBeInTheDocument()
+
+      // Blur – after delays, gradient should reappear
+      fireEvent.blur(editor)
+      // First: blur delay (150ms) fires setIsFocused(false)
+      await act(async () => {
+        vi.advanceTimersByTime(200)
+      })
+      // Then: overflow check delay (160ms) fires checkOverflow
+      await act(async () => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(
+        container.querySelector('[aria-hidden="true"].pointer-events-auto'),
+      ).toBeInTheDocument()
     })
 
     it('uses overflow-hidden when collapsed, auto when focused', () => {

--- a/registry/new-york/blocks/prompt-area/prompt-area.tsx
+++ b/registry/new-york/blocks/prompt-area/prompt-area.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react'
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { PromptAreaProps, PromptAreaHandle } from './types'
 import { usePromptArea } from './use-prompt-area'
@@ -163,6 +163,35 @@ export function PromptArea({
   }, [value, autoGrow, isFocused, syncHeight])
 
   // -----------------------------------------------------------------------
+  // Overflow indicator: detect when collapsed content is clipped
+  // -----------------------------------------------------------------------
+
+  const [hasOverflow, setHasOverflow] = useState(false)
+  const overflowCheckRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!autoGrow) return
+
+    const checkOverflow = () => {
+      if (isFocused) {
+        setHasOverflow(false)
+        return
+      }
+      const el = editorRef.current
+      if (!el) return
+      setHasOverflow(el.scrollHeight > el.clientHeight)
+    }
+
+    // Check after render settles
+    overflowCheckRef.current = requestAnimationFrame(checkOverflow)
+    return () => {
+      if (overflowCheckRef.current !== null) {
+        cancelAnimationFrame(overflowCheckRef.current)
+      }
+    }
+  }, [autoGrow, isFocused, value, editorRef])
+
+  // -----------------------------------------------------------------------
   // Compute editor style
   // -----------------------------------------------------------------------
 
@@ -177,7 +206,7 @@ export function PromptArea({
       height: isFocused && editorHeight ? `${editorHeight}px` : `${minHeight}px`,
       minHeight: `${minHeight}px`,
       maxHeight: '70dvh',
-      overflowY: 'auto',
+      overflowY: isFocused ? 'auto' : ('hidden' as const),
       transition: 'height 150ms ease-out',
     }
   }, [autoGrow, minHeight, maxHeight, isFocused, editorHeight])
@@ -241,6 +270,17 @@ export function PromptArea({
           onCompositionEnd={eventHandlers.onCompositionEnd}
           onBlur={autoGrow ? handleBlurWithShrink : eventHandlers.onBlur}
         />
+
+        {/* Overflow gradient indicator – visible when auto-grow is collapsed and content is clipped */}
+        {autoGrow && hasOverflow && !isFocused && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-auto absolute right-0 bottom-0 left-0 cursor-pointer"
+            style={{ height: '32px' }}
+            onClick={() => editorRef.current?.focus()}>
+            <div className="from-background/0 via-background/80 to-background h-full w-full bg-gradient-to-b" />
+          </div>
+        )}
 
         {/* Placeholder overlay */}
         {isEmpty &&

--- a/registry/new-york/blocks/prompt-area/prompt-area.tsx
+++ b/registry/new-york/blocks/prompt-area/prompt-area.tsx
@@ -167,7 +167,7 @@ export function PromptArea({
   // -----------------------------------------------------------------------
 
   const [hasOverflow, setHasOverflow] = useState(false)
-  const overflowCheckRef = useRef<number | null>(null)
+  const overflowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!autoGrow) return
@@ -182,11 +182,13 @@ export function PromptArea({
       setHasOverflow(el.scrollHeight > el.clientHeight)
     }
 
-    // Check after render settles
-    overflowCheckRef.current = requestAnimationFrame(checkOverflow)
+    // Delay the check so the CSS height transition (150ms) finishes first;
+    // on initial mount there is no transition so the check still runs quickly.
+    const delay = isFocused ? 0 : 160
+    overflowTimerRef.current = setTimeout(checkOverflow, delay)
     return () => {
-      if (overflowCheckRef.current !== null) {
-        cancelAnimationFrame(overflowCheckRef.current)
+      if (overflowTimerRef.current !== null) {
+        clearTimeout(overflowTimerRef.current)
       }
     }
   }, [autoGrow, isFocused, value, editorRef])


### PR DESCRIPTION
When autoGrow is enabled and the editor is collapsed (blurred), a
bottom gradient fade now appears if text extends beyond the visible
area. This signals to users that more content exists below the fold.
Clicking the gradient focuses the editor, triggering the auto-expand.

https://claude.ai/code/session_011SE9zXwVStFVS98i6vDJxw