### PR TITLE
Improve OG image formatting with bullet points and better spacing

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -152,7 +152,8 @@ export default async function OGImage() {
             <span style={mentionChip}>@Strategist</span>
             <span>and</span>
             <span style={mentionChip}>@Copywriter</span>
-            <span>. Tag anything marked</span>
+            <span>.</span>
+            <span>Tag anything marked</span>
             <span style={tagChip}>#campaign</span>
             <span>and format the output as:</span>
           </div>
@@ -169,17 +170,20 @@ export default async function OGImage() {
               lineHeight: 1.6,
               marginTop: '4px',
             }}>
-            <div style={{ display: 'flex' }}>
-              <span>-&nbsp;</span>
+            <div style={{ display: 'flex', alignItems: 'baseline' }}>
+              <span style={{ marginRight: '10px' }}>•</span>
               <span style={{ fontWeight: 700 }}>Key messages</span>
               <span>&nbsp;for the target audience</span>
             </div>
-            <div style={{ display: 'flex' }}>
-              <span>-&nbsp;</span>
+            <div style={{ display: 'flex', alignItems: 'baseline' }}>
+              <span style={{ marginRight: '10px' }}>•</span>
               <span style={{ fontStyle: 'italic' }}>Action items</span>
               <span>&nbsp;assigned to each agent</span>
             </div>
-            <div style={{ display: 'flex' }}>- Open questions for follow-up</div>
+            <div style={{ display: 'flex', alignItems: 'baseline' }}>
+              <span style={{ marginRight: '10px' }}>•</span>
+              <span>Open questions for follow-up</span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Updated the OpenGraph image template to improve visual formatting and readability of the instruction list.

## Key Changes
- Replaced dash list markers (`-`) with bullet points (`•`) for better visual consistency
- Added `alignItems: 'baseline'` to flex containers for improved vertical alignment of list items
- Applied consistent `marginRight: '10px'` spacing to all bullet point markers
- Separated "Tag anything marked" text onto its own line for better readability
- Restructured the last list item to use the same flex layout pattern as other items

## Implementation Details
- All three list items now use consistent styling with flexbox and baseline alignment
- Bullet points are now properly spaced from their accompanying text
- The layout changes maintain the existing visual hierarchy while improving clarity

https://claude.ai/code/session_01SSw2CqaC1ZqN6eRBhZoi7E