### PR TITLE
Fix markdown bullet dashes not converting to bullets on initial render

### DIFF
--- a/registry/new-york/blocks/prompt-area/__tests__/prompt-area-engine.test.ts
+++ b/registry/new-york/blocks/prompt-area/__tests__/prompt-area-engine.test.ts
@@ -19,6 +19,7 @@ import {
   parseInlineMarkdown,
   toggleMarkdownWrap,
   segmentsEqual,
+  normalizeListPrefixes,
 } from '../prompt-area-engine'
 
 // ---------------------------------------------------------------------------
@@ -1384,5 +1385,58 @@ describe('resolveChip cursor offset', () => {
 
     // "hey " (4) + "@Bob" (4) + " ping " (6) + "@Carol" (6) + " " (1) = 21
     expect(result.cursorOffset).toBe(21)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizeListPrefixes
+// ---------------------------------------------------------------------------
+
+describe('normalizeListPrefixes', () => {
+  it('converts dashes to bullets when markdown is enabled', () => {
+    const segments: Segment[] = [{ type: 'text', text: '- item one\n- item two' }]
+    const result = normalizeListPrefixes(segments, true)
+    expect(result).not.toBe(segments)
+    expect(result[0]).toEqual({ type: 'text', text: '\u2022 item one\n\u2022 item two' })
+  })
+
+  it('converts bullets to dashes when markdown is disabled', () => {
+    const segments: Segment[] = [{ type: 'text', text: '\u2022 item one\n\u2022 item two' }]
+    const result = normalizeListPrefixes(segments, false)
+    expect(result).not.toBe(segments)
+    expect(result[0]).toEqual({ type: 'text', text: '- item one\n- item two' })
+  })
+
+  it('preserves indentation during conversion', () => {
+    const segments: Segment[] = [{ type: 'text', text: '- root\n  - nested' }]
+    const result = normalizeListPrefixes(segments, true)
+    expect(result[0]).toEqual({ type: 'text', text: '\u2022 root\n  \u2022 nested' })
+  })
+
+  it('returns same array if no changes needed', () => {
+    const segments: Segment[] = [{ type: 'text', text: '\u2022 already bullets' }]
+    const result = normalizeListPrefixes(segments, true)
+    expect(result).toBe(segments)
+  })
+
+  it('skips chip segments', () => {
+    const segments: Segment[] = [
+      { type: 'text', text: '- item' },
+      { type: 'chip', trigger: '@', value: 'user', displayText: 'User' },
+    ]
+    const result = normalizeListPrefixes(segments, true)
+    expect(result[0]).toEqual({ type: 'text', text: '\u2022 item' })
+    expect(result[1]).toBe(segments[1])
+  })
+
+  it('handles text with mixed content and list lines', () => {
+    const segments: Segment[] = [
+      { type: 'text', text: 'format as:\n- **Key messages**\n- *Action items*' },
+    ]
+    const result = normalizeListPrefixes(segments, true)
+    expect(result[0]).toEqual({
+      type: 'text',
+      text: 'format as:\n\u2022 **Key messages**\n\u2022 *Action items*',
+    })
   })
 })

--- a/registry/new-york/blocks/prompt-area/prompt-area-engine.ts
+++ b/registry/new-york/blocks/prompt-area/prompt-area-engine.ts
@@ -827,6 +827,31 @@ export function parseInlineMarkdown(text: string): MarkdownToken[] {
 }
 
 // ---------------------------------------------------------------------------
+// List prefix normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes markdown list prefixes in segments:
+ * - When markdown is enabled, converts "- " at line starts to "• "
+ * - When markdown is disabled, converts "• " at line starts to "- "
+ *
+ * Returns the original array unchanged if no conversions were needed.
+ */
+export function normalizeListPrefixes(segments: Segment[], markdownEnabled: boolean): Segment[] {
+  let changed = false
+  const result = segments.map((seg) => {
+    if (seg.type !== 'text') return seg
+    const newText = markdownEnabled
+      ? seg.text.replace(/(^|\n)(\s*)- /g, '$1$2\u2022 ')
+      : seg.text.replace(/(^|\n)(\s*)\u2022 /g, '$1$2- ')
+    if (newText === seg.text) return seg
+    changed = true
+    return { ...seg, text: newText }
+  })
+  return changed ? result : segments
+}
+
+// ---------------------------------------------------------------------------
 // Segment comparison
 // ---------------------------------------------------------------------------
 

--- a/registry/new-york/blocks/prompt-area/use-prompt-area.ts
+++ b/registry/new-york/blocks/prompt-area/use-prompt-area.ts
@@ -25,6 +25,7 @@ import {
   removeListPrefix,
   replaceTextRange,
   toggleMarkdownWrap,
+  normalizeListPrefixes,
 } from './prompt-area-engine'
 import {
   isHTMLElement,
@@ -387,8 +388,19 @@ export function usePromptArea({
   useEffect(() => {
     if (isSyncing.current) return
     if (segmentsEqual(value, lastRenderedValue.current)) return
+
+    // Normalize list prefixes (e.g., "- " → "• " when markdown is on)
+    // so externally-provided segments render bullet characters correctly.
+    if (markdownEnabled) {
+      const normalized = normalizeListPrefixes(value, true)
+      if (normalized !== value) {
+        onChange(normalized)
+        return // onChange will trigger a re-render with the normalized value
+      }
+    }
+
     renderSegmentsToDOM(value)
-  }, [value, renderSegmentsToDOM])
+  }, [value, renderSegmentsToDOM, markdownEnabled, onChange])
 
   // Re-render when markdown mode changes to apply/strip decorations
   // Also convert bullet characters: • ↔ - in text segments
@@ -397,17 +409,8 @@ export function usePromptArea({
     if (prevMarkdown.current === markdownEnabled) return
     prevMarkdown.current = markdownEnabled
 
-    const converted = value.map((seg) => {
-      if (seg.type !== 'text') return seg
-      // markdown OFF: replace "• " with "- " | markdown ON: replace "- " with "• "
-      const newText = markdownEnabled
-        ? seg.text.replace(/(^|\n)(\s*)- /g, '$1$2\u2022 ')
-        : seg.text.replace(/(^|\n)(\s*)\u2022 /g, '$1$2- ')
-      return newText === seg.text ? seg : { ...seg, text: newText }
-    })
-
-    const changed = converted.some((seg, i) => seg !== value[i])
-    if (changed) {
+    const converted = normalizeListPrefixes(value, markdownEnabled)
+    if (converted !== value) {
       onChange(converted)
     } else {
       renderSegmentsToDOM(value)


### PR DESCRIPTION
When segments are provided externally (e.g., initial value prop), lines
starting with "- " were not being converted to "• " because
autoFormatListPrefix only runs on user input events. Added
normalizeListPrefixes() to the engine and call it in the value sync
effect so dash-prefixed lines are normalized on mount and external
updates.

https://claude.ai/code/session_01DGcpGRJShfKH67B91cXddR