### PR TITLE
Add comparison table link and improve product references

### DIFF
--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -92,7 +92,10 @@ export default function HomeContent() {
           Features
         </SectionHeading>
         <p className="text-muted-foreground text-sm">
-          Everything you need for a production-ready rich text input.
+          Everything you need for a production-ready rich text input. See how we stack up against alternatives in the{' '}
+          <a href="#comparison" className="text-foreground underline underline-offset-2 hover:decoration-foreground/50">
+            comparison table
+          </a>.
         </p>
         <FeaturesGrid />
       </div>

--- a/app/sections/comparison-section.tsx
+++ b/app/sections/comparison-section.tsx
@@ -263,7 +263,7 @@ export function ComparisonSection() {
                 'min-w-[120px] border-r px-4 py-3 text-center',
                 'bg-primary/5 border-primary/20',
               )}>
-              <div className="text-xs font-semibold">Prompt Area</div>
+              <a href="https://github.com/team-gpt/prompt-area" target="_blank" rel="noopener noreferrer" className="text-xs font-semibold underline decoration-muted-foreground/30 underline-offset-2 hover:decoration-foreground/50">Prompt Area</a>
             </th>
             {COMPETITORS.map((c) => (
               <th


### PR DESCRIPTION
## Summary
Enhanced the Features section with a link to the comparison table and made the "Prompt Area" competitor name a clickable link to their GitHub repository.

## Key Changes
- Added an inline link in the Features section description that directs users to the comparison table below
- Converted "Prompt Area" in the comparison table header from plain text to a hyperlink pointing to their GitHub repository (https://github.com/team-gpt/prompt-area)
- Applied consistent styling to both links with underlines and hover effects matching the design system

## Implementation Details
- The Features section link uses an anchor reference (`#comparison`) for smooth navigation within the page
- The Prompt Area link opens in a new tab with `target="_blank"` and includes security attributes (`rel="noopener noreferrer"`)
- Both links use the existing design tokens (`text-foreground`, `text-muted-foreground`, `underline-offset-2`) for visual consistency

https://claude.ai/code/session_01QQ66fAFeHNn6eGUoH9TTkj