### PR TITLE
Collapse CSS setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Most rich text editors are full document editors shoehorned into chat inputs. Pr
 npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 ```
 
-Add the required CSS classes to your `globals.css` after `@layer base`:
+<details>
+<summary>Add the required CSS classes to your <code>globals.css</code> after <code>@layer base</code></summary>
 
 ```css
 @layer components {
@@ -48,6 +49,8 @@ Add the required CSS classes to your `globals.css` after `@layer base`:
   }
 }
 ```
+
+</details>
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
Wrapped the CSS setup instructions in a collapsible details section to improve README readability and reduce visual clutter.

## Changes
- Converted the "Add the required CSS classes to your `globals.css`" section into a collapsible `<details>` element
- The CSS code block and all related setup instructions are now hidden by default behind a `<summary>` tag
- Users can expand the section when needed for installation/setup purposes

## Details
This change improves the README's initial presentation by hiding verbose CSS configuration details that are only needed during setup. The Quick Start section and other content now appear higher on the page, making the documentation more scannable while keeping all necessary information accessible.

https://claude.ai/code/session_01R1bFG3H4ruyDZ6txoBqP9W