### PR TITLE
Add LLM documentation links and footer section

### DIFF
--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -92,10 +92,14 @@ export default function HomeContent() {
           Features
         </SectionHeading>
         <p className="text-muted-foreground text-sm">
-          Everything you need for a production-ready rich text input. See how we stack up against alternatives in the{' '}
-          <a href="#comparison" className="text-foreground underline underline-offset-2 hover:decoration-foreground/50">
+          Everything you need for a production-ready rich text input. See how we stack up against
+          alternatives in the{' '}
+          <a
+            href="#comparison"
+            className="text-foreground hover:decoration-foreground/50 underline underline-offset-2">
             comparison table
-          </a>.
+          </a>
+          .
         </p>
         <FeaturesGrid />
       </div>
@@ -424,6 +428,23 @@ export default function HomeContent() {
         </p>
         <ComparisonSection />
       </div>
+
+      {/* Footer */}
+      <footer className="border-border text-muted-foreground border-t pt-6 text-center text-xs">
+        <div className="flex items-center justify-center gap-3">
+          <a
+            href="/llms.txt"
+            className="hover:text-foreground underline underline-offset-4 transition-colors">
+            llms.txt
+          </a>
+          <span aria-hidden="true">&middot;</span>
+          <a
+            href="/llms-full.txt"
+            className="hover:text-foreground underline underline-offset-4 transition-colors">
+            llms-full.txt
+          </a>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,6 +90,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <link rel="help" type="text/plain" href="/llms.txt" title="LLM Documentation" />
+        <link
+          rel="alternate"
+          type="text/plain"
+          href="/llms-full.txt"
+          title="LLM Documentation (Full)"
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=localStorage.getItem('theme');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')}catch(e){}})()`,


### PR DESCRIPTION
## Summary
This PR adds LLM documentation support to the website by introducing footer links and HTML head metadata for LLM-related documentation files.

## Key Changes
- **Added footer section** to `home-content.tsx` with links to `/llms.txt` and `/llms-full.txt` documentation files
  - Footer includes styled links with hover effects and a visual separator
  - Positioned at the bottom of the main content area
- **Added HTML head links** in `layout.tsx` to reference LLM documentation
  - `rel="help"` link pointing to `/llms.txt`
  - `rel="alternate"` link pointing to `/llms-full.txt` for full documentation
- **Minor formatting improvements** to the Features section description in `home-content.tsx` for better code readability

## Implementation Details
- Footer uses semantic HTML with proper accessibility attributes (`aria-hidden` for decorative separator)
- Links include consistent styling with underline effects and smooth color transitions
- Documentation links are discoverable both in the page footer and through HTML head metadata, supporting LLM crawlers and documentation tools

https://claude.ai/code/session_01HvHqjwXpifHwfHFjYrD2ZM