### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/team-gpt/prompt-area/security/code-scanning/8](https://github.com/team-gpt/prompt-area/security/code-scanning/8)

In general, the fix is to add an explicit `permissions:` block that grants the minimal required privileges for this workflow. Since all jobs simply check out code and run pnpm-based commands, they only need read access to repository contents; no job needs to write to the repo, issues, or pull requests.

The best minimal fix without changing existing functionality is to add a single top-level `permissions:` block (applies to all jobs) right after the `on:` section. Set `contents: read`, which is sufficient for `actions/checkout@v4` to work and does not grant any write permissions. There is no need to add per-job `permissions` blocks, and no other keys (like `pull-requests`) are required based on the current steps.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `concurrency:` block (lines 9–11). No imports, methods, or other code changes are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
