### PR TITLE
Sanitize URLs in editor to prevent XSS attacks (CWE-79)

### DIFF
--- a/registry/new-york/blocks/prompt-area/dom-helpers.ts
+++ b/registry/new-york/blocks/prompt-area/dom-helpers.ts
@@ -277,30 +277,37 @@ export function decorateURLsInEditor(editor: HTMLElement): boolean {
 
     if (matches.length === 0) continue
 
-    decorated = true
     const parent = textNode.parentNode
     if (!parent) continue
 
+    // Validate URLs upfront – only keep those with safe protocols (CWE-79)
+    const safeMatches: Array<{ url: string; href: string; index: number }> = []
+    for (const { url, index } of matches) {
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+          safeMatches.push({ url, href: parsed.href, index })
+        }
+      } catch {
+        // skip malformed URLs
+      }
+    }
+
+    if (safeMatches.length === 0) continue
+
+    decorated = true
     const fragment = document.createDocumentFragment()
     let lastIndex = 0
 
-    for (const { url, index } of matches) {
+    for (const { url, href, index } of safeMatches) {
       // Text before this URL
       if (index > lastIndex) {
         fragment.appendChild(document.createTextNode(text.slice(lastIndex, index)))
       }
 
-      // Create the link element – sanitize the URL to prevent XSS (CWE-79)
+      // Create the link element
       const anchor = document.createElement('a')
-      try {
-        const parsed = new URL(url)
-        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-          continue
-        }
-        anchor.href = parsed.href
-      } catch {
-        continue
-      }
+      anchor.href = href
       anchor.target = '_blank'
       anchor.rel = 'noopener noreferrer'
       anchor.dataset.url = 'true'

--- a/registry/new-york/blocks/prompt-area/dom-helpers.ts
+++ b/registry/new-york/blocks/prompt-area/dom-helpers.ts
@@ -290,9 +290,17 @@ export function decorateURLsInEditor(editor: HTMLElement): boolean {
         fragment.appendChild(document.createTextNode(text.slice(lastIndex, index)))
       }
 
-      // Create the link element
+      // Create the link element – sanitize the URL to prevent XSS (CWE-79)
       const anchor = document.createElement('a')
-      anchor.href = url
+      try {
+        const parsed = new URL(url)
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          continue
+        }
+        anchor.href = parsed.href
+      } catch {
+        continue
+      }
       anchor.target = '_blank'
       anchor.rel = 'noopener noreferrer'
       anchor.dataset.url = 'true'


### PR DESCRIPTION
## Summary
This change adds URL validation and sanitization to the `decorateURLsInEditor` function to prevent Cross-Site Scripting (XSS) vulnerabilities when processing URLs in the editor.

## Key Changes
- Added URL parsing validation using the `URL` constructor to ensure only valid URLs are processed
- Restricted anchor links to only `http:` and `https:` protocols, rejecting potentially dangerous protocols like `javascript:`, `data:`, etc.
- Wrapped URL processing in a try-catch block to gracefully skip malformed URLs instead of creating invalid links
- Updated the anchor's `href` attribute to use the parsed and validated URL

## Implementation Details
- Invalid or malformed URLs now cause the URL decoration to be skipped entirely via `continue` statement
- Non-HTTP(S) protocols are rejected to prevent protocol-based XSS attacks
- The `rel="noopener noreferrer"` attribute is maintained for additional security when opening links in new tabs
- This addresses CWE-79 (Improper Neutralization of Input During Web Page Generation)

https://claude.ai/code/session_01TBUMd5Su5kSDxwwMXArebc