### PR TITLE
Add missing pages (about, contact, press, partners) and fix 404s

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'About',
+  description:
+    'Prompt Area is an open-source React textarea component built by Juma. Learn about the project and the team behind it.',
+  alternates: { canonical: 'https://prompt-area.com/about' },
+}
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-10 px-4 py-16">
+      <Link
+        href="/"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors">
+        <ArrowLeft className="size-3.5" />
+        Back to Prompt Area
+      </Link>
+
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">About</h1>
+        <p className="text-muted-foreground">The project, the team, and how to get involved.</p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">The Project</h2>
+        <p className="text-muted-foreground">
+          Prompt Area is an open-source React component for building rich text inputs in AI and chat
+          interfaces. It supports @mentions, /commands, #tags, inline markdown, file attachments,
+          undo/redo, and more &mdash; all in a single contentEditable textarea distributed through
+          the{' '}
+          <a
+            href="https://ui.shadcn.com/docs/registry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            shadcn registry
+          </a>{' '}
+          with zero extra dependencies.
+        </p>
+        <p className="text-muted-foreground">
+          The goal is to give developers a production-ready prompt input they can drop into any
+          Next.js or React project without pulling in a full rich-text framework.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Built by Juma</h2>
+        <p className="text-muted-foreground">
+          Prompt Area is built and maintained by{' '}
+          <a
+            href="https://juma.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            Juma
+          </a>{' '}
+          (formerly Team-GPT), an AI workspace for marketing teams. The component grew out of the
+          team&apos;s own need for a flexible, reliable prompt input while building collaborative AI
+          tools.
+        </p>
+        <p className="text-muted-foreground">
+          If you&apos;re curious about how marketing teams use AI day-to-day, check out{' '}
+          <a
+            href="https://juma.ai/flows"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            Juma Flows
+          </a>{' '}
+          &mdash; a growing collection of end-to-end AI chat workflows for things like campaign
+          analysis, brand voice guides, and channel ROI comparison.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Open Source</h2>
+        <p className="text-muted-foreground">
+          Prompt Area is released under the MIT license. Contributions, bug reports, and feature
+          requests are welcome on{' '}
+          <a
+            href="https://github.com/team-gpt/prompt-area"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            GitHub
+          </a>
+          . See the{' '}
+          <a
+            href="https://github.com/team-gpt/prompt-area/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            contributing guide
+          </a>{' '}
+          to get started.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Contact',
+  description:
+    'Get in touch with the Prompt Area team. Report bugs, request features, or reach out to Juma for business inquiries.',
+  alternates: { canonical: 'https://prompt-area.com/contact' },
+}
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-10 px-4 py-16">
+      <Link
+        href="/"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors">
+        <ArrowLeft className="size-3.5" />
+        Back to Prompt Area
+      </Link>
+
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">Contact</h1>
+        <p className="text-muted-foreground">
+          Have a question, bug report, or feature request? Here&apos;s how to reach us.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Bug Reports &amp; Feature Requests</h2>
+        <p className="text-muted-foreground">
+          The best way to report a bug or request a feature is through{' '}
+          <a
+            href="https://github.com/team-gpt/prompt-area/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            GitHub Issues
+          </a>
+          . Please include a clear description and steps to reproduce if you&apos;re reporting a
+          bug.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Business Inquiries</h2>
+        <p className="text-muted-foreground">
+          For partnerships, enterprise support, or other business inquiries, reach out through{' '}
+          <a
+            href="https://juma.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            Juma
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -433,6 +433,18 @@ export default function HomeContent() {
       <footer className="border-border text-muted-foreground border-t pt-6 text-center text-xs">
         <div className="flex items-center justify-center gap-3">
           <a
+            href="/about"
+            className="hover:text-foreground underline underline-offset-4 transition-colors">
+            About
+          </a>
+          <span aria-hidden="true">&middot;</span>
+          <a
+            href="/contact"
+            className="hover:text-foreground underline underline-offset-4 transition-colors">
+            Contact
+          </a>
+          <span aria-hidden="true">&middot;</span>
+          <a
             href="/llms.txt"
             className="hover:text-foreground underline underline-offset-4 transition-colors">
             llms.txt

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+}
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-16">
+      <Link
+        href="/"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors">
+        <ArrowLeft className="size-3.5" />
+        Back to Prompt Area
+      </Link>
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">404</h1>
+        <p className="text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="text-foreground hover:text-foreground/80 text-sm font-medium underline underline-offset-4 transition-colors">
+        Go back to Prompt Area
+      </Link>
+    </div>
+  )
+}

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Partners',
+  description:
+    'Partnership opportunities with Prompt Area and Juma. Integrate the rich textarea component into your product.',
+  alternates: { canonical: 'https://prompt-area.com/partners' },
+}
+
+export default function PartnersPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-10 px-4 py-16">
+      <Link
+        href="/"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors">
+        <ArrowLeft className="size-3.5" />
+        Back to Prompt Area
+      </Link>
+
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">Partners</h1>
+        <p className="text-muted-foreground">
+          Interested in integrating Prompt Area or partnering with Juma?
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Integration Partners</h2>
+        <p className="text-muted-foreground">
+          If you&apos;re building AI-powered chat products and need a production-grade prompt input,
+          Prompt Area is available as a{' '}
+          <a
+            href="https://ui.shadcn.com/docs/registry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            shadcn registry
+          </a>{' '}
+          component. Install it with a single command and customize it to fit your product.
+        </p>
+        <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
+          npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Technology Partners</h2>
+        <p className="text-muted-foreground">
+          We&apos;re open to collaborations with component libraries, design systems, and AI
+          frameworks. If Prompt Area fits into your ecosystem, let&apos;s talk.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Get in Touch</h2>
+        <p className="text-muted-foreground">
+          For partnership inquiries, reach out through{' '}
+          <a
+            href="https://juma.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            juma.ai
+          </a>{' '}
+          or open a discussion on{' '}
+          <a
+            href="https://github.com/team-gpt/prompt-area"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            GitHub
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'Press',
+  description: 'Press resources and media information for Prompt Area and Juma.',
+  alternates: { canonical: 'https://prompt-area.com/press' },
+}
+
+export default function PressPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-10 px-4 py-16">
+      <Link
+        href="/"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm transition-colors">
+        <ArrowLeft className="size-3.5" />
+        Back to Prompt Area
+      </Link>
+
+      <div className="flex flex-col gap-3">
+        <h1 className="text-3xl font-bold tracking-tight">Press</h1>
+        <p className="text-muted-foreground">
+          Media resources and information about Prompt Area and Juma.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">About Prompt Area</h2>
+        <p className="text-muted-foreground">
+          Prompt Area is an open-source React component that provides a production-grade rich text
+          input for AI and chat interfaces. It supports @mentions, /commands, #tags, inline
+          markdown, file attachments, and more. Distributed as a{' '}
+          <a
+            href="https://ui.shadcn.com/docs/registry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            shadcn registry
+          </a>{' '}
+          component with zero extra dependencies, it can be installed in any Next.js or React
+          project with a single command.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">About Juma</h2>
+        <p className="text-muted-foreground">
+          <a
+            href="https://juma.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            Juma
+          </a>{' '}
+          (formerly Team-GPT) is an AI workspace for marketing teams. The team builds collaborative
+          AI tools that help marketers work with models like GPT, Claude, and Gemini from a single
+          interface. Prompt Area was created as part of that effort and open-sourced for the
+          community.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Media Contact</h2>
+        <p className="text-muted-foreground">
+          For press inquiries, please reach out through{' '}
+          <a
+            href="https://juma.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4">
+            juma.ai
+          </a>
+          .
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-xl font-semibold">Resources</h2>
+        <ul className="text-muted-foreground list-inside list-disc space-y-1">
+          <li>
+            <a
+              href="https://github.com/team-gpt/prompt-area"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline underline-offset-4">
+              GitHub Repository
+            </a>
+          </li>
+          <li>
+            <Link href="/" className="font-medium underline underline-offset-4">
+              Interactive Demo
+            </Link>
+          </li>
+          <li>
+            <a
+              href="https://juma.ai/flows"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline underline-offset-4">
+              Juma Flows
+            </a>{' '}
+            &mdash; end-to-end AI chat workflows for marketing
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,5 +8,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 1,
     },
+    {
+      url: 'https://prompt-area.com/about',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://prompt-area.com/contact',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://prompt-area.com/press',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: 'https://prompt-area.com/partners',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
   ]
 }

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
 import { ChevronRight, Github, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/theme-toggle'
@@ -336,6 +337,43 @@ function ActiveIndicator({ activeId, itemRefs, navRef }: ActiveIndicatorProps) {
 }
 
 // ---------------------------------------------------------------------------
+// PageLinks — static page navigation links
+// ---------------------------------------------------------------------------
+
+const PAGE_LINKS = [
+  { href: '/about', label: 'About' },
+  { href: '/contact', label: 'Contact' },
+] as const
+
+function PageLinks() {
+  const pathname = usePathname()
+  const visible = useSidebarVisible()
+
+  return (
+    <div className="border-sidebar-border flex flex-col gap-0.5 border-t px-4 py-3">
+      {PAGE_LINKS.map((link) => (
+        <a
+          key={link.href}
+          href={link.href}
+          className={cn(
+            'rounded-md px-3 py-2.5 text-sm transition-all duration-150 lg:py-1.5',
+            'hover:text-foreground hover:translate-x-0.5',
+            pathname === link.href ? 'text-foreground font-medium' : 'text-muted-foreground',
+          )}
+          style={{
+            opacity: visible ? 1 : 0,
+            transform: visible ? 'translateX(0)' : 'translateX(-12px)',
+            transition: 'opacity 300ms ease-out, transform 300ms ease-out, color 150ms',
+            transitionDelay: visible ? '300ms' : '0ms',
+          }}>
+          {link.label}
+        </a>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // NavSidebar — the panel
 // ---------------------------------------------------------------------------
 
@@ -412,6 +450,8 @@ function NavSidebar() {
           ),
         )}
       </nav>
+
+      <PageLinks />
 
       <div className="border-sidebar-border flex flex-col gap-3 border-t px-4 py-3">
         <a

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,18 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  /* config options here */
   devIndicators: {
     position: 'bottom-right',
+  },
+  async redirects() {
+    return [
+      { source: '/about-us', destination: '/about', permanent: true },
+      { source: '/team', destination: '/about', permanent: true },
+      { source: '/our-team', destination: '/about', permanent: true },
+      { source: '/contact-us', destination: '/contact', permanent: true },
+      { source: '/contactus', destination: '/contact', permanent: true },
+      { source: '/media', destination: '/press', permanent: true },
+    ]
   },
 }
 


### PR DESCRIPTION
Google Analytics showed users hitting 404 on /about, /team, /contact,
/press, /media, /partners and variants. This adds:

- Real pages: /about, /contact, /press, /partners
- Permanent redirects for duplicates (e.g. /team → /about)
- Custom 404 page with back-to-home link
- Sitemap and footer updates for discoverability

https://claude.ai/code/session_018HaJ9tAnfY2H1Fmvx76FYc