### PR TITLE
Add CSS custom properties to dark theme preview sections

### DIFF
--- a/app/sections/dark-theme-preview.tsx
+++ b/app/sections/dark-theme-preview.tsx
@@ -23,7 +23,20 @@ export function DarkThemePreview() {
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="rounded-lg border p-4">
         <p className="text-muted-foreground mb-2 text-xs font-medium">Light</p>
-        <div className="rounded-lg border bg-white p-3 text-[oklch(0.145_0_0)]">
+        <div
+          className="rounded-lg border bg-white p-3 text-[oklch(0.145_0_0)]"
+          style={
+            {
+              '--popover': 'oklch(1 0 0)',
+              '--popover-foreground': 'oklch(0.145 0 0)',
+              '--foreground': 'oklch(0.145 0 0)',
+              '--accent': 'oklch(0.97 0 0)',
+              '--accent-foreground': 'oklch(0.205 0 0)',
+              '--muted-foreground': 'oklch(0.556 0 0)',
+              '--border': 'oklch(0.922 0 0)',
+              '--secondary': 'oklch(0.97 0 0)',
+            } as React.CSSProperties
+          }>
           <PromptArea
             value={lightSegments}
             onChange={setLightSegments}
@@ -35,7 +48,20 @@ export function DarkThemePreview() {
       </div>
       <div className="rounded-lg border p-4">
         <p className="text-muted-foreground mb-2 text-xs font-medium">Dark</p>
-        <div className="dark rounded-lg border border-[oklch(1_0_0/10%)] bg-[oklch(0.145_0_0)] p-3 text-[oklch(0.985_0_0)]">
+        <div
+          className="dark rounded-lg border border-[oklch(1_0_0/10%)] bg-[oklch(0.145_0_0)] p-3 text-[oklch(0.985_0_0)]"
+          style={
+            {
+              '--popover': 'oklch(0.205 0 0)',
+              '--popover-foreground': 'oklch(0.985 0 0)',
+              '--foreground': 'oklch(0.985 0 0)',
+              '--accent': 'oklch(0.269 0 0)',
+              '--accent-foreground': 'oklch(0.985 0 0)',
+              '--muted-foreground': 'oklch(0.708 0 0)',
+              '--border': 'oklch(1 0 0 / 10%)',
+              '--secondary': 'oklch(0.269 0 0)',
+            } as React.CSSProperties
+          }>
           <PromptArea
             value={darkSegments}
             onChange={setDarkSegments}

--- a/app/sections/dark-theme-preview.tsx
+++ b/app/sections/dark-theme-preview.tsx
@@ -9,13 +9,26 @@ export function DarkThemePreview() {
   const [lightSegments, setLightSegments] = useState<Segment[]>([])
   const [darkSegments, setDarkSegments] = useState<Segment[]>([])
 
-  const triggers: TriggerConfig[] = [
+  const searchUsers = (q: string) =>
+    USERS.filter((u) => u.label.toLowerCase().includes(q.toLowerCase()))
+
+  const lightTriggers: TriggerConfig[] = [
     {
       char: '@',
       position: 'any',
       mode: 'dropdown',
-      chipClassName: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
-      onSearch: (q) => USERS.filter((u) => u.label.toLowerCase().includes(q.toLowerCase())),
+      chipClassName: 'bg-blue-100 text-blue-700',
+      onSearch: searchUsers,
+    },
+  ]
+
+  const darkTriggers: TriggerConfig[] = [
+    {
+      char: '@',
+      position: 'any',
+      mode: 'dropdown',
+      chipClassName: 'bg-blue-900 text-blue-300',
+      onSearch: searchUsers,
     },
   ]
 
@@ -40,7 +53,7 @@ export function DarkThemePreview() {
           <PromptArea
             value={lightSegments}
             onChange={setLightSegments}
-            triggers={triggers}
+            triggers={lightTriggers}
             placeholder="Type @ to mention..."
             minHeight={48}
           />
@@ -65,7 +78,7 @@ export function DarkThemePreview() {
           <PromptArea
             value={darkSegments}
             onChange={setDarkSegments}
-            triggers={triggers}
+            triggers={darkTriggers}
             placeholder="Type @ to mention..."
             minHeight={48}
           />


### PR DESCRIPTION
## Summary
This PR adds inline CSS custom properties (CSS variables) to the light and dark theme preview containers in the dark theme preview component. These variables define the color scheme for each theme variant.

## Key Changes
- **Light theme preview**: Added 7 CSS custom properties (`--popover`, `--popover-foreground`, `--foreground`, `--accent`, `--accent-foreground`, `--muted-foreground`, `--border`, `--secondary`) with light color values in oklch format
- **Dark theme preview**: Added the same 7 CSS custom properties with corresponding dark color values in oklch format
- Both sets of variables are applied via inline `style` props with proper TypeScript typing (`as React.CSSProperties`)

## Implementation Details
- All color values use the oklch color space format for consistency with the existing design system
- The light theme uses high lightness values (0.97-1.0) for backgrounds and low values (0.145) for text
- The dark theme uses low lightness values (0.145-0.269) for backgrounds and high values (0.985) for text
- These CSS variables will cascade to child components within each preview section, allowing them to reference theme-specific colors

https://claude.ai/code/session_014D2JiAC7ZP7DsjDhwj34eS