### PR TITLE
Fix chat prompt layout and JSX syntax issues

### DIFF
--- a/app/examples/chat-prompt-layout.tsx
+++ b/app/examples/chat-prompt-layout.tsx
@@ -135,11 +135,14 @@ import { ArrowUp } from 'lucide-react'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
 import { ChatPromptLayout } from '@/registry/new-york/blocks/chat-prompt-layout/chat-prompt-layout'
+import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
 import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
+
+type Message = { id: number; role: 'user' | 'assistant'; content: string }
 
 function ChatPromptLayoutExample() {
   const [segments, setSegments] = useState<Segment[]>([])
-  const [messages, setMessages] = useState<Message[]>(initialMessages)
+  const [messages, setMessages] = useState<Message[]>([])
   const promptRef = useRef<PromptAreaHandle>(null)
 
   const isEmpty = segments.length === 0 ||
@@ -147,10 +150,11 @@ function ChatPromptLayoutExample() {
 
   const handleSubmit = useCallback(() => {
     if (isEmpty) return
+    const text = segmentsToPlainText(segments)
     setMessages(prev => [...prev, { id: Date.now(), role: 'user', content: text }])
     promptRef.current?.clear()
     setSegments([])
-  }, [isEmpty])
+  }, [isEmpty, segments])
 
   return (
     <ChatPromptLayout
@@ -179,7 +183,15 @@ function ChatPromptLayoutExample() {
     >
       <div className="mx-auto max-w-3xl space-y-4 p-4">
         {messages.map(msg => (
-          <ChatBubble key={msg.id} role={msg.role}>{msg.content}</ChatBubble>
+          <div key={msg.id} className={\`flex \${msg.role === 'user' ? 'justify-end' : 'justify-start'}\`}>
+            <div className={\`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm \${
+              msg.role === 'user'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-foreground'
+            }\`}>
+              {msg.content}
+            </div>
+          </div>
         ))}
       </div>
     </ChatPromptLayout>

--- a/app/examples/status-bar.tsx
+++ b/app/examples/status-bar.tsx
@@ -183,7 +183,7 @@ function StatusBarBelowExample() {
       </div>
       <StatusBar
         className="border-t"
-        left={<span className="text-muted-foreground">+ </> Auto accept edits</span>}
+        left={<span className="text-muted-foreground">{"+ </> Auto accept edits"}</span>}
         right={
           <button className="text-muted-foreground flex items-center gap-1">
             Opus 4.6 <ChevronDown className="size-3" />
@@ -229,7 +229,7 @@ function StatusBarBothExample() {
           minHeight={48}
         />
         <ActionBar
-          left={<span className="text-muted-foreground text-xs">+ </> Auto accept edits</span>}
+          left={<span className="text-muted-foreground text-xs">{"+ </> Auto accept edits"}</span>}
           right={
             <button className="text-muted-foreground flex items-center gap-1 text-xs">
               Opus 4.6 <ChevronDown className="size-3" />


### PR DESCRIPTION
## Summary
This PR fixes functional issues in the chat prompt layout example and corrects JSX syntax errors in the status bar examples.

## Key Changes

- **Chat Prompt Layout Example**
  - Added import for `segmentsToPlainText` utility function from prompt-area-engine
  - Defined `Message` type locally instead of relying on external definition
  - Changed initial messages state from `initialMessages` to empty array `[]`
  - Updated `handleSubmit` to convert segments to plain text before adding to messages
  - Fixed dependency array in `handleSubmit` callback to include `segments`
  - Replaced `ChatBubble` component with custom message bubble implementation that properly styles user vs assistant messages with different alignments and colors

- **Status Bar Examples**
  - Fixed JSX syntax errors by wrapping string literals containing JSX-like syntax (`"+ </> Auto accept edits"`) in curly braces to prevent parsing issues
  - Applied fix to both `StatusBarBelowExample` and `StatusBarBothExample` components

## Notable Implementation Details
The chat message rendering now uses a custom div-based bubble component instead of the `ChatBubble` component, with proper styling for user messages (right-aligned, primary background) and assistant messages (left-aligned, muted background).

https://claude.ai/code/session_014BpTwCuC4QLrvUEX4fPvpe