### PR TITLE
Add rotating placeholders example to PromptArea component

### DIFF
--- a/app/below-fold-sections.tsx
+++ b/app/below-fold-sections.tsx
@@ -40,6 +40,8 @@ import {
   chatPromptLayoutCode,
   DxHelpersExample,
   dxHelpersCode,
+  RotatingPlaceholdersExample,
+  rotatingPlaceholdersCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
 import { FeaturesGrid } from './sections/features-grid'
@@ -106,6 +108,17 @@ export default function BelowFoldSections() {
           <p className="text-muted-foreground text-xs">Simple text input with Enter to submit.</p>
           <ExampleShowcase code={basicCode}>
             <BasicExample />
+          </ExampleShowcase>
+        </div>
+
+        <div id="example-rotating-placeholders" className="flex scroll-mt-16 flex-col gap-2">
+          <SectionHeading id="example-rotating-placeholders">Rotating Placeholders</SectionHeading>
+          <p className="text-muted-foreground text-xs">
+            Pass an array of strings to <code>placeholder</code> to cycle through them with a smooth
+            animation. Great for hinting at what the input can do.
+          </p>
+          <ExampleShowcase code={rotatingPlaceholdersCode}>
+            <RotatingPlaceholdersExample />
           </ExampleShowcase>
         </div>
 

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -22,3 +22,4 @@ export {
 export { CompactPromptAreaExample, compactPromptAreaCode } from './compact-prompt-area'
 export { ChatPromptLayoutExample, chatPromptLayoutCode } from './chat-prompt-layout'
 export { DxHelpersExample, dxHelpersCode } from './dx-helpers'
+export { RotatingPlaceholdersExample, rotatingPlaceholdersCode } from './rotating-placeholders'

--- a/app/examples/rotating-placeholders.tsx
+++ b/app/examples/rotating-placeholders.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState } from 'react'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
+
+export function RotatingPlaceholdersExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  return (
+    <div className="rounded-lg border p-4">
+      <PromptArea
+        value={segments}
+        onChange={setSegments}
+        placeholder={[
+          'Ask a question...',
+          'Write a story...',
+          'Summarize an article...',
+          'Generate some code...',
+        ]}
+        onSubmit={() => {
+          setSegments([])
+        }}
+        minHeight={48}
+      />
+    </div>
+  )
+}
+
+export const rotatingPlaceholdersCode = `import { useState } from 'react'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import type { Segment } from '@/registry/new-york/blocks/prompt-area/types'
+
+function RotatingPlaceholdersExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  return (
+    <PromptArea
+      value={segments}
+      onChange={setSegments}
+      placeholder={[
+        'Ask a question...',
+        'Write a story...',
+        'Summarize an article...',
+        'Generate some code...',
+      ]}
+      onSubmit={() => { setSegments([]) }}
+      minHeight={48}
+    />
+  )
+}`


### PR DESCRIPTION
## Summary
Added a new example demonstrating the rotating placeholders feature for the PromptArea component, allowing developers to see how to cycle through multiple placeholder texts with smooth animations.

## Changes
- **New example file** (`app/examples/rotating-placeholders.tsx`): Created a complete example component showing how to pass an array of strings to the `placeholder` prop to create rotating placeholder text
- **Updated exports** (`app/examples/index.ts`): Exported the new `RotatingPlaceholdersExample` component and code snippet
- **Added documentation section** (`app/below-fold-sections.tsx`): Integrated the new example into the documentation with a descriptive heading and explanation of the feature's use case

## Implementation Details
- The example demonstrates passing an array of placeholder strings: `['Ask a question...', 'Write a story...', 'Summarize an article...', 'Generate some code...']`
- Includes both a functional component example and a code snippet for documentation purposes
- Clears the input segments on submit to show the placeholder cycling in action
- Includes helpful description text explaining that this feature is useful for hinting at input capabilities

https://claude.ai/code/session_016HamZFwQckqEzG3Ca4xPFA