### PR TITLE
Add Rotating Placeholders example to navigation sidebar

### DIFF
--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -28,6 +28,7 @@ const NAV_ITEMS: NavItem[] = [
     children: [
       { id: 'example-dx-helpers', label: 'DX Helpers' },
       { id: 'example-basic', label: 'Basic' },
+      { id: 'example-rotating-placeholders', label: 'Rotating Placeholders' },
       { id: 'example-mentions', label: '@Mentions' },
       { id: 'example-commands', label: '/Commands' },
       { id: 'example-tags', label: '#Tags' },


### PR DESCRIPTION
## Summary
Added a new navigation item for the "Rotating Placeholders" example to the sidebar navigation menu.

## Changes
- Added `{ id: 'example-rotating-placeholders', label: 'Rotating Placeholders' }` to the NAV_ITEMS list in the examples section
- The new item is positioned between the "Basic" and "@Mentions" examples in the navigation hierarchy

## Details
This change exposes a new example component in the main navigation, allowing users to access the Rotating Placeholders example from the sidebar. The example follows the existing naming convention and structure of other example items.

https://claude.ai/code/session_019zfMqTD8BvFsNiUQ4BUM3b