### PR TITLE
Add AI coding agent install prompt to install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 Copy this prompt and give it to your AI coding agent (Claude Code, Codex, Cursor, etc.):
 
-> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.
+> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea.
 
 <details>
 <summary>Add the required CSS classes to your <code>globals.css</code> after <code>@layer base</code></summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 Copy this prompt and give it to your AI coding agent (Claude Code, Codex, Cursor, etc.):
 
-> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea.
+> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation.
 
 <details>
 <summary>Add the required CSS classes to your <code>globals.css</code> after <code>@layer base</code></summary>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Most rich text editors are full document editors shoehorned into chat inputs. Pr
 npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 ```
 
+### Install with AI coding agents
+
+Copy this prompt and give it to your AI coding agent (Claude Code, Codex, Cursor, etc.):
+
+> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.
+
 <details>
 <summary>Add the required CSS classes to your <code>globals.css</code> after <code>@layer base</code></summary>
 
@@ -96,24 +102,24 @@ export function Chat() {
 
 How Prompt Area stacks up against popular alternatives:
 
-> **Legend:** :white_check_mark: Full support  :large_orange_diamond: Partial  :x: None
+> **Legend:** :white_check_mark: Full support :large_orange_diamond: Partial :x: None
 
-| Feature | Prompt Area | react-mentions | Tiptap | Lexical | Plate.js | BlockNote | BlockSuite | react-textarea-autosize |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| @Mentions / Tagging | :white_check_mark: | :white_check_mark: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: | :large_orange_diamond: | :white_check_mark: | :x: |
-| Slash Commands | :white_check_mark: | :x: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
-| Auto-grow on Focus | :white_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
-| Inline Markdown | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :large_orange_diamond: | :white_check_mark: | :x: |
-| Undo / Redo | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
-| File & Image Attachments | :white_check_mark: | :x: | :large_orange_diamond: | :x: | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :x: |
-| Dark Mode | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :white_check_mark: | :large_orange_diamond: | :x: |
-| Accessibility (ARIA) | :white_check_mark: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |
-| IME Support (CJK) | :white_check_mark: | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |
-| Copy/Paste Chip Preservation | :white_check_mark: | :x: | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: | :white_check_mark: | :x: |
-| Action Bar / Toolbar | :white_check_mark: | :x: | :large_orange_diamond: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
-| Zero-config State Hook | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :x: | :x: |
-| Bundle Approach | shadcn registry | npm package | npm package | npm package | npm package | npm package | npm package | npm package |
-| Extra Dependencies | **0** | 0 | 3+ | 2+ | 5+ | 5+ | 5+ | 0 |
+| Feature                      |    Prompt Area     |     react-mentions     |         Tiptap         |        Lexical         |        Plate.js        |       BlockNote        |       BlockSuite       | react-textarea-autosize |
+| ---------------------------- | :----------------: | :--------------------: | :--------------------: | :--------------------: | :--------------------: | :--------------------: | :--------------------: | :---------------------: |
+| @Mentions / Tagging          | :white_check_mark: |   :white_check_mark:   | :large_orange_diamond: | :large_orange_diamond: |   :white_check_mark:   | :large_orange_diamond: |   :white_check_mark:   |           :x:           |
+| Slash Commands               | :white_check_mark: |          :x:           |   :white_check_mark:   |          :x:           |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   |           :x:           |
+| Auto-grow on Focus           | :white_check_mark: |          :x:           |          :x:           |          :x:           |          :x:           |          :x:           |          :x:           |   :white_check_mark:    |
+| Inline Markdown              | :white_check_mark: |          :x:           |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   | :large_orange_diamond: |   :white_check_mark:   |           :x:           |
+| Undo / Redo                  | :white_check_mark: |          :x:           |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   |           :x:           |
+| File & Image Attachments     | :white_check_mark: |          :x:           | :large_orange_diamond: |          :x:           | :large_orange_diamond: |   :white_check_mark:   |   :white_check_mark:   |           :x:           |
+| Dark Mode                    | :white_check_mark: |          :x:           |          :x:           |          :x:           |   :white_check_mark:   |   :white_check_mark:   | :large_orange_diamond: |           :x:           |
+| Accessibility (ARIA)         | :white_check_mark: | :large_orange_diamond: | :large_orange_diamond: |   :white_check_mark:   |   :white_check_mark:   | :large_orange_diamond: | :large_orange_diamond: |   :white_check_mark:    |
+| IME Support (CJK)            | :white_check_mark: | :large_orange_diamond: |   :white_check_mark:   |   :white_check_mark:   | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: |   :white_check_mark:    |
+| Copy/Paste Chip Preservation | :white_check_mark: |          :x:           | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: |   :white_check_mark:   |   :white_check_mark:   |           :x:           |
+| Action Bar / Toolbar         | :white_check_mark: |          :x:           | :large_orange_diamond: |          :x:           |   :white_check_mark:   |   :white_check_mark:   |   :white_check_mark:   |           :x:           |
+| Zero-config State Hook       | :white_check_mark: |          :x:           |          :x:           |          :x:           |          :x:           |   :white_check_mark:   |          :x:           |           :x:           |
+| Bundle Approach              |  shadcn registry   |      npm package       |      npm package       |      npm package       |      npm package       |      npm package       |      npm package       |       npm package       |
+| Extra Dependencies           |       **0**        |           0            |           3+           |           2+           |           5+           |           5+           |           5+           |            0            |
 
 ## Features
 
@@ -133,30 +139,30 @@ How Prompt Area stacks up against popular alternatives:
 
 ### `PromptAreaProps`
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `value` | `Segment[]` | required | Controlled segment array |
-| `onChange` | `(segments: Segment[]) => void` | required | Called on content changes |
-| `triggers` | `TriggerConfig[]` | `[]` | Trigger character configurations |
-| `placeholder` | `string` | — | Placeholder text when empty |
-| `className` | `string` | — | CSS class for the container |
-| `disabled` | `boolean` | `false` | Disable the input |
-| `markdown` | `boolean` | — | Enable inline markdown rendering |
-| `onSubmit` | `(segments: Segment[]) => void` | — | Called on Enter (without Shift) |
-| `onEscape` | `() => void` | — | Called on Escape |
-| `onChipClick` | `(chip: ChipSegment) => void` | — | Called when a chip is clicked |
-| `onChipAdd` | `(chip: ChipSegment) => void` | — | Called when a chip is added |
-| `onChipDelete` | `(chip: ChipSegment) => void` | — | Called when a chip is deleted |
-| `onLinkClick` | `(url: string) => void` | — | Called on Cmd/Ctrl+Click on a URL |
-| `onPaste` | `(data) => void` | — | Called after paste with segments and source |
-| `onUndo` | `(segments: Segment[]) => void` | — | Called after undo |
-| `onRedo` | `(segments: Segment[]) => void` | — | Called after redo |
-| `minHeight` | `number` | `80` | Minimum height in pixels |
-| `maxHeight` | `number` | — | Maximum height in pixels |
-| `autoFocus` | `boolean` | `false` | Auto-focus on mount |
-| `autoGrow` | `boolean` | `false` | Expand on focus, shrink on blur |
-| `aria-label` | `string` | `'Text input'` | Accessible label |
-| `data-test-id` | `string` | — | Test ID for e2e testing |
+| Prop           | Type                            | Default        | Description                                 |
+| -------------- | ------------------------------- | -------------- | ------------------------------------------- |
+| `value`        | `Segment[]`                     | required       | Controlled segment array                    |
+| `onChange`     | `(segments: Segment[]) => void` | required       | Called on content changes                   |
+| `triggers`     | `TriggerConfig[]`               | `[]`           | Trigger character configurations            |
+| `placeholder`  | `string`                        | —              | Placeholder text when empty                 |
+| `className`    | `string`                        | —              | CSS class for the container                 |
+| `disabled`     | `boolean`                       | `false`        | Disable the input                           |
+| `markdown`     | `boolean`                       | —              | Enable inline markdown rendering            |
+| `onSubmit`     | `(segments: Segment[]) => void` | —              | Called on Enter (without Shift)             |
+| `onEscape`     | `() => void`                    | —              | Called on Escape                            |
+| `onChipClick`  | `(chip: ChipSegment) => void`   | —              | Called when a chip is clicked               |
+| `onChipAdd`    | `(chip: ChipSegment) => void`   | —              | Called when a chip is added                 |
+| `onChipDelete` | `(chip: ChipSegment) => void`   | —              | Called when a chip is deleted               |
+| `onLinkClick`  | `(url: string) => void`         | —              | Called on Cmd/Ctrl+Click on a URL           |
+| `onPaste`      | `(data) => void`                | —              | Called after paste with segments and source |
+| `onUndo`       | `(segments: Segment[]) => void` | —              | Called after undo                           |
+| `onRedo`       | `(segments: Segment[]) => void` | —              | Called after redo                           |
+| `minHeight`    | `number`                        | `80`           | Minimum height in pixels                    |
+| `maxHeight`    | `number`                        | —              | Maximum height in pixels                    |
+| `autoFocus`    | `boolean`                       | `false`        | Auto-focus on mount                         |
+| `autoGrow`     | `boolean`                       | `false`        | Expand on focus, shrink on blur             |
+| `aria-label`   | `string`                        | `'Text input'` | Accessible label                            |
+| `data-test-id` | `string`                        | —              | Test ID for e2e testing                     |
 
 ### `PromptAreaHandle` (ref)
 
@@ -174,18 +180,18 @@ ref.current.clear()          // Clear all content and undo history
 
 ### `TriggerConfig`
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `char` | `string` | Trigger character (e.g., `'@'`, `'/'`, `'#'`) |
-| `position` | `'start' \| 'any'` | Where the trigger is valid |
-| `mode` | `'dropdown' \| 'callback'` | Show dropdown or fire callback |
-| `onSearch` | `(query: string) => TriggerSuggestion[]` | Fetch suggestions (dropdown mode) |
-| `onSelect` | `(suggestion) => string \| void` | Customize chip display text |
-| `onActivate` | `(context) => void` | Handler for callback mode |
-| `resolveOnSpace` | `boolean` | Auto-resolve on space (e.g., `#tag`) |
-| `chipStyle` | `'pill' \| 'inline'` | Visual style for chips |
-| `chipClassName` | `string` | CSS class for chips |
-| `accessibilityLabel` | `string` | ARIA label for the trigger |
+| Field                | Type                                     | Description                                   |
+| -------------------- | ---------------------------------------- | --------------------------------------------- |
+| `char`               | `string`                                 | Trigger character (e.g., `'@'`, `'/'`, `'#'`) |
+| `position`           | `'start' \| 'any'`                       | Where the trigger is valid                    |
+| `mode`               | `'dropdown' \| 'callback'`               | Show dropdown or fire callback                |
+| `onSearch`           | `(query: string) => TriggerSuggestion[]` | Fetch suggestions (dropdown mode)             |
+| `onSelect`           | `(suggestion) => string \| void`         | Customize chip display text                   |
+| `onActivate`         | `(context) => void`                      | Handler for callback mode                     |
+| `resolveOnSpace`     | `boolean`                                | Auto-resolve on space (e.g., `#tag`)          |
+| `chipStyle`          | `'pill' \| 'inline'`                     | Visual style for chips                        |
+| `chipClassName`      | `string`                                 | CSS class for chips                           |
+| `accessibilityLabel` | `string`                                 | ARIA label for the trigger                    |
 
 ### `Segment`
 
@@ -196,8 +202,8 @@ type TextSegment = { type: 'text'; text: string }
 
 type ChipSegment = {
   type: 'chip'
-  trigger: string    // e.g., '@'
-  value: string      // e.g., 'user-123'
+  trigger: string // e.g., '@'
+  value: string // e.g., 'user-123'
   displayText: string // e.g., 'Alice'
   data?: unknown
   autoResolved?: boolean
@@ -230,17 +236,17 @@ const triggers: TriggerConfig[] = [
 
 ## Keyboard Shortcuts
 
-| Shortcut | Action |
-| --- | --- |
-| `Enter` | Submit (or continue list) |
-| `Shift+Enter` | Insert newline |
-| `Escape` | Dismiss dropdown / fire onEscape |
-| `Cmd/Ctrl+B` | Toggle **bold** |
-| `Cmd/Ctrl+I` | Toggle _italic_ |
-| `Cmd/Ctrl+Z` | Undo |
-| `Cmd/Ctrl+Shift+Z` | Redo |
-| `Tab` / `Shift+Tab` | Indent / outdent list item |
-| `ArrowUp/Down` | Navigate dropdown suggestions |
+| Shortcut            | Action                                   |
+| ------------------- | ---------------------------------------- |
+| `Enter`             | Submit (or continue list)                |
+| `Shift+Enter`       | Insert newline                           |
+| `Escape`            | Dismiss dropdown / fire onEscape         |
+| `Cmd/Ctrl+B`        | Toggle **bold**                          |
+| `Cmd/Ctrl+I`        | Toggle _italic_                          |
+| `Cmd/Ctrl+Z`        | Undo                                     |
+| `Cmd/Ctrl+Shift+Z`  | Redo                                     |
+| `Tab` / `Shift+Tab` | Indent / outdent list item               |
+| `ArrowUp/Down`      | Navigate dropdown suggestions            |
 | `Backspace` on chip | Delete chip (or revert if auto-resolved) |
 
 ## Development

--- a/app/below-fold-sections.tsx
+++ b/app/below-fold-sections.tsx
@@ -44,6 +44,7 @@ import {
   rotatingPlaceholdersCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
+import { InstallSection } from './sections/install-block'
 import { FeaturesGrid } from './sections/features-grid'
 import { InspectorSection } from './sections/inspector-section'
 import { DarkThemePreview } from './sections/dark-theme-preview'
@@ -52,6 +53,9 @@ import { ComparisonSection } from './sections/comparison-section'
 export default function BelowFoldSections() {
   return (
     <>
+      {/* Installation */}
+      <InstallSection />
+
       {/* Features */}
       <div id="features" className="flex scroll-mt-16 flex-col gap-4">
         <SectionHeading id="features" as="h2">

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic'
+import { InstallBlock } from './sections/install-block'
 
 const DemoSection = dynamic(() =>
   import('./sections/demo-section').then((m) => ({ default: m.DemoSection })),
@@ -47,9 +48,7 @@ export default function HomeContent() {
           </a>{' '}
           component.
         </p>
-        <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
-          npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
-        </div>
+        <InstallBlock />
       </div>
 
       {/* Demo */}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -47,9 +47,6 @@ export default function HomeContent() {
           </a>{' '}
           component.
         </p>
-        <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
-          npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
-        </div>
       </div>
 
       {/* Demo */}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic'
-import { InstallBlock } from './sections/install-block'
 
 const DemoSection = dynamic(() =>
   import('./sections/demo-section').then((m) => ({ default: m.DemoSection })),
@@ -48,7 +47,9 @@ export default function HomeContent() {
           </a>{' '}
           component.
         </p>
-        <InstallBlock />
+        <div className="bg-muted rounded-md px-3 py-2 font-mono text-sm">
+          npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
+        </div>
       </div>
 
       {/* Demo */}

--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Copy, Check, Terminal, Bot } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const CLI_COMMAND = 'npx shadcn@latest add https://prompt-area.com/r/prompt-area.json'
+
+const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.`
+
+type Tab = 'cli' | 'agent'
+
+export function InstallBlock() {
+  const [tab, setTab] = useState<Tab>('cli')
+  const [copied, setCopied] = useState(false)
+
+  const content = tab === 'cli' ? CLI_COMMAND : AGENT_PROMPT
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [content])
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between border-b">
+        <div className="flex">
+          <button
+            type="button"
+            onClick={() => {
+              setTab('cli')
+              setCopied(false)
+            }}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors',
+              tab === 'cli'
+                ? 'border-foreground text-foreground border-b-2 font-medium'
+                : 'text-muted-foreground hover:text-foreground',
+            )}>
+            <Terminal className="size-3.5" />
+            CLI
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setTab('agent')
+              setCopied(false)
+            }}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors',
+              tab === 'agent'
+                ? 'border-foreground text-foreground border-b-2 font-medium'
+                : 'text-muted-foreground hover:text-foreground',
+            )}>
+            <Bot className="size-3.5" />
+            AI Agent
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-muted-foreground hover:text-foreground rounded-md p-1.5 transition-colors"
+          aria-label={`Copy ${tab === 'cli' ? 'command' : 'prompt'}`}>
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        </button>
+      </div>
+
+      <div
+        className={cn(
+          'bg-muted mt-2 rounded-md px-3 py-2 text-sm',
+          tab === 'cli' ? 'font-mono' : 'leading-relaxed',
+        )}>
+        {content}
+      </div>
+    </div>
+  )
+}

--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -1,77 +1,48 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import { Copy, Check, Terminal, Bot } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { Copy, Check } from 'lucide-react'
 
 const CLI_COMMAND = 'npx shadcn@latest add https://prompt-area.com/r/prompt-area.json'
 
 const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.`
 
-type Tab = 'cli' | 'agent'
-
-export function InstallBlock() {
-  const [tab, setTab] = useState<Tab>('cli')
+function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
 
-  const content = tab === 'cli' ? CLI_COMMAND : AGENT_PROMPT
-
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(content)
+    navigator.clipboard.writeText(text)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
-  }, [content])
+  }, [text])
 
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between border-b">
-        <div className="flex">
-          <button
-            type="button"
-            onClick={() => {
-              setTab('cli')
-              setCopied(false)
-            }}
-            className={cn(
-              'flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors',
-              tab === 'cli'
-                ? 'border-foreground text-foreground border-b-2 font-medium'
-                : 'text-muted-foreground hover:text-foreground',
-            )}>
-            <Terminal className="size-3.5" />
-            CLI
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setTab('agent')
-              setCopied(false)
-            }}
-            className={cn(
-              'flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors',
-              tab === 'agent'
-                ? 'border-foreground text-foreground border-b-2 font-medium'
-                : 'text-muted-foreground hover:text-foreground',
-            )}>
-            <Bot className="size-3.5" />
-            AI Agent
-          </button>
-        </div>
-        <button
-          type="button"
-          onClick={handleCopy}
-          className="text-muted-foreground hover:text-foreground rounded-md p-1.5 transition-colors"
-          aria-label={`Copy ${tab === 'cli' ? 'command' : 'prompt'}`}>
-          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-        </button>
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-muted-foreground hover:text-foreground shrink-0 rounded-md p-1 transition-colors"
+      aria-label="Copy to clipboard">
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+    </button>
+  )
+}
+
+export function InstallBlock() {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="bg-muted flex items-center justify-between gap-2 rounded-md px-3 py-2 font-mono text-sm">
+        <span>{CLI_COMMAND}</span>
+        <CopyButton text={CLI_COMMAND} />
       </div>
 
-      <div
-        className={cn(
-          'bg-muted mt-2 rounded-md px-3 py-2 text-sm',
-          tab === 'cli' ? 'font-mono' : 'leading-relaxed',
-        )}>
-        {content}
+      <div className="flex flex-col gap-1.5">
+        <p className="text-muted-foreground text-xs font-medium">
+          AI Agent Prompt (Claude Code, Codex, Cursor, etc.)
+        </p>
+        <div className="bg-muted flex items-start justify-between gap-2 rounded-md px-3 py-2 text-sm leading-relaxed">
+          <span>{AGENT_PROMPT}</span>
+          <CopyButton text={AGENT_PROMPT} />
+        </div>
       </div>
     </div>
   )

--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react'
 import { Copy, Check } from 'lucide-react'
 import { SectionHeading } from './section-heading'
 
-const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea.`
+const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation.`
 
 const COMPONENTS = [
   {

--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react'
 import { Copy, Check } from 'lucide-react'
 import { SectionHeading } from './section-heading'
 
-const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.`
+const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea.`
 
 const COMPONENTS = [
   {

--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -2,10 +2,37 @@
 
 import { useState, useCallback } from 'react'
 import { Copy, Check } from 'lucide-react'
-
-const CLI_COMMAND = 'npx shadcn@latest add https://prompt-area.com/r/prompt-area.json'
+import { SectionHeading } from './section-heading'
 
 const AGENT_PROMPT = `Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input.`
+
+const COMPONENTS = [
+  {
+    name: 'Prompt Area',
+    description: 'Core rich text input with triggers, markdown, and attachments',
+    command: 'npx shadcn@latest add https://prompt-area.com/r/prompt-area.json',
+  },
+  {
+    name: 'Action Bar',
+    description: 'Horizontal toolbar companion with left/right slots',
+    command: 'npx shadcn@latest add https://prompt-area.com/r/action-bar.json',
+  },
+  {
+    name: 'Status Bar',
+    description: 'Contextual info bar for model name, branch, or metadata',
+    command: 'npx shadcn@latest add https://prompt-area.com/r/status-bar.json',
+  },
+  {
+    name: 'Compact Prompt Area',
+    description: 'Pill-shaped collapsible variant with plus and submit buttons',
+    command: 'npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json',
+  },
+  {
+    name: 'Chat Prompt Layout',
+    description: 'Full-height chat layout with scroll navigation',
+    command: 'npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json',
+  },
+]
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
@@ -27,17 +54,44 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-export function InstallBlock() {
+export function InstallSection() {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="bg-muted flex items-center justify-between gap-2 rounded-md px-3 py-2 font-mono text-sm">
-        <span>{CLI_COMMAND}</span>
-        <CopyButton text={CLI_COMMAND} />
+    <div id="installation" className="flex scroll-mt-16 flex-col gap-4">
+      <SectionHeading id="installation" as="h2">
+        Installation
+      </SectionHeading>
+      <p className="text-muted-foreground text-sm">
+        Install individual components via the shadcn CLI, or use the AI agent prompt to set
+        everything up in one go.
+      </p>
+
+      {/* Component install commands */}
+      <div className="flex flex-col gap-2">
+        {COMPONENTS.map((comp) => (
+          <div key={comp.name} className="flex flex-col gap-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-sm font-medium">{comp.name}</span>
+              <span className="text-muted-foreground text-xs">{comp.description}</span>
+            </div>
+            <div className="bg-muted flex items-center justify-between gap-2 rounded-md px-3 py-2 font-mono text-sm">
+              <span className="min-w-0 truncate">{comp.command}</span>
+              <CopyButton text={comp.command} />
+            </div>
+          </div>
+        ))}
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <p className="text-muted-foreground text-xs font-medium">
-          AI Agent Prompt (Claude Code, Codex, Cursor, etc.)
+      {/* AI Agent Prompt */}
+      <div className="flex flex-col gap-2 pt-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium">AI Agent Prompt</span>
+          <span className="text-muted-foreground text-xs">
+            Claude Code, Codex, Cursor, Windsurf, etc.
+          </span>
+        </div>
+        <p className="text-muted-foreground text-xs">
+          Copy this prompt and give it to your AI coding agent to install and set up the component
+          in a single step.
         </p>
         <div className="bg-muted flex items-start justify-between gap-2 rounded-md px-3 py-2 text-sm leading-relaxed">
           <span>{AGENT_PROMPT}</span>

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -20,6 +20,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { id: 'hero', label: 'Introduction' },
   { id: 'demo', label: 'Demo' },
+  { id: 'installation', label: 'Installation' },
   { id: 'features', label: 'Features' },
   { id: 'inspector', label: 'Inspector' },
   {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8,6 +8,12 @@
 npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 ```
 
+### Install with AI Coding Agents
+
+Give your AI coding agent (Claude Code, Codex, Cursor, etc.) this prompt:
+
+"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input."
+
 ### Required CSS
 
 Add the following CSS classes to your `globals.css` after `@layer base`:

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -21,7 +21,7 @@ npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 Give your AI coding agent (Claude Code, Codex, Cursor, etc.) this prompt:
 
-"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input."
+"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea."
 
 ### Required CSS
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -21,7 +21,7 @@ npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 Give your AI coding agent (Claude Code, Codex, Cursor, etc.) this prompt:
 
-"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea."
+"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation."
 
 ### Required CSS
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,7 +19,7 @@
 - [Install status-bar](https://prompt-area.com/#status-bar): Run `npx shadcn@latest add https://prompt-area.com/r/status-bar.json` to add the contextual info bar companion
 - [Install compact-prompt-area](https://prompt-area.com/#compact-prompt-area): Run `npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json` to add the pill-shaped collapsible variant
 - [Install chat-prompt-layout](https://prompt-area.com/#chat-prompt-layout): Run `npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json` to add the full-height chat layout with scroll navigation
-- [Install with AI agents](https://prompt-area.com/#installation): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input."
+- [Install with AI agents](https://prompt-area.com/#installation): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea."
 
 ## Core Features
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,6 +15,7 @@
 - [Install status-bar](https://prompt-area.com): Run `npx shadcn@latest add https://prompt-area.com/r/status-bar.json` to add the contextual info bar companion
 - [Install compact-prompt-area](https://prompt-area.com): Run `npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json` to add the pill-shaped collapsible variant
 - [Install chat-prompt-layout](https://prompt-area.com): Run `npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json` to add the full-height chat layout with scroll navigation
+- [Install with AI agents](https://prompt-area.com): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input."
 
 ## Core Features
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,7 +19,7 @@
 - [Install status-bar](https://prompt-area.com/#status-bar): Run `npx shadcn@latest add https://prompt-area.com/r/status-bar.json` to add the contextual info bar companion
 - [Install compact-prompt-area](https://prompt-area.com/#compact-prompt-area): Run `npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json` to add the pill-shaped collapsible variant
 - [Install chat-prompt-layout](https://prompt-area.com/#chat-prompt-layout): Run `npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json` to add the full-height chat layout with scroll navigation
-- [Install with AI agents](https://prompt-area.com/#installation): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing textarea elements in the project, replace them with PromptArea."
+- [Install with AI agents](https://prompt-area.com/#installation): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation."
 
 ## Core Features
 


### PR DESCRIPTION
Add a tabbed install block (CLI / AI Agent) on the homepage with copy-to-clipboard,
and document the agent prompt in README.md, llms.txt, and llms-full.txt. The prompt
instructs agents to fetch llms-full.txt and install the component on demand.

https://claude.ai/code/session_01Vw8XWd3Ae1fVSzYaWKRtEv