### PR TITLE
Refactor component install commands to use tabbed interface

### DIFF
--- a/app/sections/install-block.tsx
+++ b/app/sections/install-block.tsx
@@ -54,6 +54,38 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
+function ComponentInstallTabs() {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const active = COMPONENTS[activeIndex]
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-1" role="tablist">
+        {COMPONENTS.map((comp, i) => (
+          <button
+            key={comp.name}
+            type="button"
+            role="tab"
+            aria-selected={i === activeIndex}
+            onClick={() => setActiveIndex(i)}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              i === activeIndex
+                ? 'bg-foreground text-background'
+                : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+            }`}>
+            {comp.name}
+          </button>
+        ))}
+      </div>
+      <p className="text-muted-foreground text-xs">{active.description}</p>
+      <div className="bg-muted flex items-center justify-between gap-2 rounded-md px-3 py-2 font-mono text-sm">
+        <span className="min-w-0 truncate">{active.command}</span>
+        <CopyButton text={active.command} />
+      </div>
+    </div>
+  )
+}
+
 export function InstallSection() {
   return (
     <div id="installation" className="flex scroll-mt-16 flex-col gap-4">
@@ -65,21 +97,8 @@ export function InstallSection() {
         everything up in one go.
       </p>
 
-      {/* Component install commands */}
-      <div className="flex flex-col gap-2">
-        {COMPONENTS.map((comp) => (
-          <div key={comp.name} className="flex flex-col gap-1">
-            <div className="flex items-baseline gap-2">
-              <span className="text-sm font-medium">{comp.name}</span>
-              <span className="text-muted-foreground text-xs">{comp.description}</span>
-            </div>
-            <div className="bg-muted flex items-center justify-between gap-2 rounded-md px-3 py-2 font-mono text-sm">
-              <span className="min-w-0 truncate">{comp.command}</span>
-              <CopyButton text={comp.command} />
-            </div>
-          </div>
-        ))}
-      </div>
+      {/* Component install commands as tabs */}
+      <ComponentInstallTabs />
 
       {/* AI Agent Prompt */}
       <div className="flex flex-col gap-2 pt-2">


### PR DESCRIPTION
## Summary
Refactored the component installation commands section to use a tabbed interface instead of displaying all commands in a list format. This improves the user experience by reducing visual clutter and making it easier to navigate between different component installation options.

## Key Changes
- Created new `ComponentInstallTabs` component that manages tab state and displays one component's installation command at a time
- Replaced the previous list-based layout (which showed all components vertically) with a tab-based interface
- Tabs are implemented with proper accessibility attributes (`role="tab"`, `aria-selected`)
- Active tab styling uses foreground/background colors while inactive tabs use muted styling with hover states
- Component description and command are displayed below the tab list for the currently selected component

## Implementation Details
- Uses React `useState` hook to manage the active tab index
- Tab buttons include proper semantic HTML and ARIA attributes for accessibility
- Maintains the same copy-to-clipboard functionality via the existing `CopyButton` component
- Styling uses Tailwind CSS with responsive gap and padding utilities
- The active component's description and command are derived from the `COMPONENTS` array based on the active index

https://claude.ai/code/session_01C24V7Msogi3w1kjPjTou3S