### PR TITLE
Add "Prompt Area" header to navigation sidebar

### DIFF
--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -4,7 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { useActiveSection } from '@/hooks/use-active-section'
 import type { ReactNode } from 'react'
 import { usePathname } from 'next/navigation'
-import { ChevronRight, Github, Star } from 'lucide-react'
+import { ChevronRight, Github, Star, TextCursorInput } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/theme-toggle'
 
@@ -395,10 +395,15 @@ function NavSidebar() {
         'lg:translate-x-0',
         !isOpen && '-translate-x-full',
       )}>
+      <div className="flex items-center gap-2.5 px-4 pt-16 pb-2 lg:pt-6">
+        <TextCursorInput className="text-foreground size-5 shrink-0" />
+        <span className="text-foreground text-sm font-semibold tracking-tight">Prompt Area</span>
+      </div>
+
       <nav
         ref={navRef}
         aria-label="Page sections"
-        className="relative flex flex-1 flex-col gap-0.5 overflow-y-auto px-4 pt-16 pb-6 lg:pt-6">
+        className="relative flex flex-1 flex-col gap-0.5 overflow-y-auto px-4 pt-2 pb-6">
         <ActiveIndicator activeId={activeId} itemRefs={itemRefs} navRef={navRef} />
 
         {NAV_ITEMS.map((item, i) =>

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { useActiveSection } from '@/hooks/use-active-section'
 import type { ReactNode } from 'react'
 import { usePathname } from 'next/navigation'
+import Link from 'next/link'
 import { ChevronRight, Github, Star, TextCursorInput } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/theme-toggle'
@@ -395,10 +396,10 @@ function NavSidebar() {
         'lg:translate-x-0',
         !isOpen && '-translate-x-full',
       )}>
-      <a href="/" className="flex items-center gap-2.5 px-4 pt-16 pb-2 lg:pt-6 transition-opacity hover:opacity-70">
+      <Link href="/" className="flex items-center gap-2.5 px-4 pt-16 pb-2 lg:pt-6 transition-opacity hover:opacity-70">
         <TextCursorInput className="text-foreground size-5 shrink-0" />
         <span className="text-foreground text-sm font-semibold tracking-tight">Prompt Area</span>
-      </a>
+      </Link>
 
       <nav
         ref={navRef}

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -395,10 +395,10 @@ function NavSidebar() {
         'lg:translate-x-0',
         !isOpen && '-translate-x-full',
       )}>
-      <div className="flex items-center gap-2.5 px-4 pt-16 pb-2 lg:pt-6">
+      <a href="/" className="flex items-center gap-2.5 px-4 pt-16 pb-2 lg:pt-6 transition-opacity hover:opacity-70">
         <TextCursorInput className="text-foreground size-5 shrink-0" />
         <span className="text-foreground text-sm font-semibold tracking-tight">Prompt Area</span>
-      </div>
+      </a>
 
       <nav
         ref={navRef}


### PR DESCRIPTION
## Summary
Added a new header section labeled "Prompt Area" at the top of the navigation sidebar with an accompanying icon.

## Changes
- Imported `TextCursorInput` icon from lucide-react
- Added a new header div above the nav element containing:
  - `TextCursorInput` icon (5px size)
  - "Prompt Area" text label with semibold font styling
- Adjusted padding on the nav element:
  - Changed `pt-16` to `pt-2` to accommodate the new header section
  - Kept the header with `pt-16 pb-2` on larger screens (`lg:pt-6`)

## Implementation Details
The new header uses flexbox layout with consistent spacing (`gap-2.5`) and inherits the foreground color from the theme. The padding adjustments ensure proper visual hierarchy while maintaining responsive behavior across screen sizes.

https://claude.ai/code/session_01CgCFjEFQ8RZGy1dcH1SX8f