### PR TITLE
Add redirects for LLM metadata files

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,8 @@ const nextConfig: NextConfig = {
       { source: '/contact-us', destination: '/contact', permanent: true },
       { source: '/contactus', destination: '/contact', permanent: true },
       { source: '/media', destination: '/press', permanent: true },
+      { source: '/.well-known/llms.txt', destination: '/llms.txt', permanent: true },
+      { source: '/.well-known/llms-full.txt', destination: '/llms-full.txt', permanent: true },
     ]
   },
 }


### PR DESCRIPTION
## Summary
Added URL redirects to serve LLM metadata files from the `.well-known` directory, which is a standard location for machine-readable metadata that tools and services can discover.

## Changes
- Added redirect from `/.well-known/llms.txt` to `/llms.txt`
- Added redirect from `/.well-known/llms-full.txt` to `/llms-full.txt`

## Details
These redirects enable LLM tools and crawlers to discover metadata about the site by following the standard `.well-known` convention. The actual metadata files are served from the root directory, with the `.well-known` paths redirecting to them using permanent (301) redirects.

https://claude.ai/code/session_01Wq5WEe2UAi531ce886BeYo