### PR TITLE
Add Claude Code–style input example component

### DIFF
--- a/app/below-fold-sections.tsx
+++ b/app/below-fold-sections.tsx
@@ -318,16 +318,27 @@ export default function BelowFoldSections() {
       </div>
 
       {/* Claude Code–style Input */}
-      <div id="claude-code-input" className="flex scroll-mt-16 flex-col gap-2">
-        <SectionHeading id="claude-code-input">Claude Code–Style Input</SectionHeading>
-        <p className="text-muted-foreground text-xs">
-          A complete composition combining PromptArea, ActionBar, and StatusBar to replicate a
-          Claude Code–style chat input. File chip above the input, a &ldquo;Plan mode&rdquo; toggle
-          and model selector in the action bar, and project/branch context in the status bar.
-        </p>
-        <ExampleShowcase code={claudeCodeInputCode}>
-          <ClaudeCodeInputExample />
-        </ExampleShowcase>
+      <div className="flex flex-col gap-6">
+        <div id="claude-code-input" className="flex scroll-mt-16 flex-col gap-3">
+          <SectionHeading id="claude-code-input" as="h2">
+            Claude Code–Style
+          </SectionHeading>
+          <p className="text-muted-foreground">
+            A complete composition combining PromptArea, ActionBar, and StatusBar to replicate a
+            Claude Code–style chat input. Independently installable components composed together.
+          </p>
+        </div>
+
+        <div id="claude-code-input-demo" className="flex scroll-mt-16 flex-col gap-2">
+          <SectionHeading id="claude-code-input-demo">Demo</SectionHeading>
+          <p className="text-muted-foreground text-xs">
+            File chip above the input, a &ldquo;Plan mode&rdquo; toggle and model selector in the
+            action bar, and project/branch context in the status bar.
+          </p>
+          <ExampleShowcase code={claudeCodeInputCode}>
+            <ClaudeCodeInputExample />
+          </ExampleShowcase>
+        </div>
       </div>
 
       {/* Compact Prompt Area */}

--- a/app/below-fold-sections.tsx
+++ b/app/below-fold-sections.tsx
@@ -42,6 +42,8 @@ import {
   dxHelpersCode,
   RotatingPlaceholdersExample,
   rotatingPlaceholdersCode,
+  ClaudeCodeInputExample,
+  claudeCodeInputCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
 import { InstallSection } from './sections/install-block'
@@ -313,6 +315,19 @@ export default function BelowFoldSections() {
             <StatusBarBothExample />
           </ExampleShowcase>
         </div>
+      </div>
+
+      {/* Claude Code–style Input */}
+      <div id="claude-code-input" className="flex scroll-mt-16 flex-col gap-2">
+        <SectionHeading id="claude-code-input">Claude Code–Style Input</SectionHeading>
+        <p className="text-muted-foreground text-xs">
+          A complete composition combining PromptArea, ActionBar, and StatusBar to replicate a
+          Claude Code–style chat input. File chip above the input, a &ldquo;Plan mode&rdquo; toggle
+          and model selector in the action bar, and project/branch context in the status bar.
+        </p>
+        <ExampleShowcase code={claudeCodeInputCode}>
+          <ClaudeCodeInputExample />
+        </ExampleShowcase>
       </div>
 
       {/* Compact Prompt Area */}

--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+import {
+  Plus,
+  ArrowUp,
+  ChevronDown,
+  GitBranch,
+  Cloud,
+  LayoutList,
+} from 'lucide-react'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
+import { StatusBar } from '@/registry/new-york/blocks/status-bar/status-bar'
+import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
+import type {
+  Segment,
+  PromptAreaHandle,
+  PromptAreaFile,
+} from '@/registry/new-york/blocks/prompt-area/types'
+
+const INITIAL_FILES: PromptAreaFile[] = [
+  { id: 'img-1', name: 'image.png', size: 240_000, type: 'image/png' },
+]
+
+const INITIAL_SEGMENTS: Segment[] = [
+  {
+    type: 'text',
+    text: "Let's replicate the spacing and general UI/UX of this input.",
+  },
+]
+
+const MODELS = ['Opus 4.6', 'Sonnet 4.6', 'Haiku 4.5'] as const
+
+export function ClaudeCodeInputExample() {
+  const [segments, setSegments] = useState<Segment[]>(INITIAL_SEGMENTS)
+  const [files, setFiles] = useState<PromptAreaFile[]>(INITIAL_FILES)
+  const [submitted, setSubmitted] = useState('')
+  const [selectedModel, setSelectedModel] = useState<string>(MODELS[0])
+  const [modelMenuOpen, setModelMenuOpen] = useState(false)
+  const [planMode, setPlanMode] = useState(false)
+  const promptRef = useRef<PromptAreaHandle>(null)
+  const modelMenuRef = useRef<HTMLDivElement>(null)
+
+  const isEmpty =
+    segments.length === 0 ||
+    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
+
+  const handleSubmit = useCallback(
+    (segs: Segment[]) => {
+      const text = segmentsToPlainText(segs)
+      if (!text.trim()) return
+      setSubmitted(text)
+      promptRef.current?.clear()
+      setSegments([])
+      setFiles([])
+    },
+    [],
+  )
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Main input container */}
+      <div className="rounded-xl border">
+        <div className="p-4 pb-2">
+          <PromptArea
+            ref={promptRef}
+            value={segments}
+            onChange={setSegments}
+            placeholder="Ask anything..."
+            onSubmit={handleSubmit}
+            autoGrow
+            minHeight={48}
+            maxHeight={280}
+            files={files}
+            filePosition="above"
+            onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
+          />
+          <ActionBar
+            className="pt-1.5"
+            left={
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-lg transition-colors"
+                  aria-label="Add attachment">
+                  <Plus className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPlanMode((v) => !v)}
+                  className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    planMode
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground hover:text-foreground'
+                  }`}>
+                  <LayoutList className="size-3.5" />
+                  Plan mode
+                </button>
+              </div>
+            }
+            right={
+              <div className="flex items-center gap-2">
+                {/* Model selector */}
+                <div className="relative" ref={modelMenuRef}>
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
+                    onClick={() => setModelMenuOpen((v) => !v)}>
+                    {selectedModel}
+                    <ChevronDown className="size-3" />
+                  </button>
+                  {modelMenuOpen && (
+                    <div className="bg-popover absolute right-0 bottom-full z-10 mb-1 flex w-max flex-col rounded-md border p-1 shadow-md">
+                      {MODELS.map((model) => (
+                        <button
+                          key={model}
+                          type="button"
+                          className={`flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm hover:bg-accent ${
+                            model === selectedModel ? 'bg-accent' : ''
+                          }`}
+                          onClick={() => {
+                            setSelectedModel(model)
+                            setModelMenuOpen(false)
+                          }}>
+                          {model}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Submit button */}
+                <button
+                  type="button"
+                  onClick={() => handleSubmit(segments)}
+                  disabled={isEmpty}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                  aria-label="Send message">
+                  <ArrowUp className="size-4" />
+                </button>
+              </div>
+            }
+          />
+        </div>
+
+        {/* Status bar */}
+        <StatusBar
+          className="rounded-b-xl border-t px-4 py-2"
+          left={
+            <div className="flex items-center gap-2">
+              <span className="bg-muted rounded px-2 py-0.5 text-xs font-medium">prompt-area</span>
+              <div className="text-muted-foreground flex items-center gap-1">
+                <GitBranch className="size-3" />
+                <span className="text-xs">main</span>
+              </div>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center rounded transition-colors"
+                aria-label="Add project">
+                <Plus className="size-3" />
+              </button>
+            </div>
+          }
+          right={
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors">
+              <Cloud className="size-3" />
+              Default
+              <ChevronDown className="size-3" />
+            </button>
+          }
+        />
+      </div>
+
+      {submitted && (
+        <div className="bg-muted/50 rounded-lg border p-3">
+          <div className="text-muted-foreground mb-1 text-xs font-medium">Submitted:</div>
+          <div className="text-sm">{submitted}</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const claudeCodeInputCode = `import { useCallback, useRef, useState } from 'react'
+import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList } from 'lucide-react'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
+import { StatusBar } from '@/registry/new-york/blocks/status-bar/status-bar'
+import type { Segment, PromptAreaHandle, PromptAreaFile } from '@/registry/new-york/blocks/prompt-area/types'
+
+const INITIAL_FILES: PromptAreaFile[] = [
+  { id: 'img-1', name: 'image.png', size: 240_000, type: 'image/png' },
+]
+
+function ClaudeCodeInputExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [files, setFiles] = useState<PromptAreaFile[]>(INITIAL_FILES)
+  const [selectedModel, setSelectedModel] = useState('Opus 4.6')
+  const [planMode, setPlanMode] = useState(false)
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const isEmpty = segments.length === 0 ||
+    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
+
+  const handleSubmit = useCallback((segs: Segment[]) => {
+    promptRef.current?.clear()
+    setSegments([])
+    setFiles([])
+  }, [])
+
+  return (
+    <div className="rounded-xl border">
+      <div className="p-4 pb-2">
+        <PromptArea
+          ref={promptRef}
+          value={segments}
+          onChange={setSegments}
+          placeholder="Ask anything..."
+          onSubmit={handleSubmit}
+          autoGrow
+          minHeight={48}
+          maxHeight={280}
+          files={files}
+          filePosition="above"
+          onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
+        />
+        <ActionBar
+          className="pt-1.5"
+          left={
+            <div className="flex items-center gap-1.5">
+              <button aria-label="Add attachment" className="size-8 rounded-lg ...">
+                <Plus className="size-4" />
+              </button>
+              <button
+                onClick={() => setPlanMode((v) => !v)}
+                className={\`rounded-full px-3 py-1.5 text-xs font-medium \${
+                  planMode ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+                }\`}>
+                <LayoutList className="size-3.5" />
+                Plan mode
+              </button>
+            </div>
+          }
+          right={
+            <div className="flex items-center gap-2">
+              <button className="text-muted-foreground text-xs">
+                {selectedModel} <ChevronDown className="size-3" />
+              </button>
+              <button
+                onClick={() => handleSubmit(segments)}
+                disabled={isEmpty}
+                className="bg-primary text-primary-foreground size-8 rounded-full"
+                aria-label="Send message">
+                <ArrowUp className="size-4" />
+              </button>
+            </div>
+          }
+        />
+      </div>
+      <StatusBar
+        className="rounded-b-xl border-t px-4 py-2"
+        left={
+          <div className="flex items-center gap-2">
+            <span className="bg-muted rounded px-2 py-0.5 text-xs font-medium">prompt-area</span>
+            <GitBranch className="size-3" />
+            <span className="text-xs">main</span>
+            <button aria-label="Add project"><Plus className="size-3" /></button>
+          </div>
+        }
+        right={
+          <button className="text-muted-foreground text-xs">
+            <Cloud className="size-3" /> Default <ChevronDown className="size-3" />
+          </button>
+        }
+      />
+    </div>
+  )
+}`

--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -8,6 +8,8 @@ import {
   GitBranch,
   Cloud,
   LayoutList,
+  File,
+  X,
 } from 'lucide-react'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
@@ -16,11 +18,12 @@ import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prom
 import type {
   Segment,
   PromptAreaHandle,
-  PromptAreaFile,
 } from '@/registry/new-york/blocks/prompt-area/types'
 
-const INITIAL_FILES: PromptAreaFile[] = [
-  { id: 'img-1', name: 'image.png', size: 240_000, type: 'image/png' },
+type AttachedFile = { id: string; name: string }
+
+const INITIAL_FILES: AttachedFile[] = [
+  { id: 'img-1', name: 'image.png' },
 ]
 
 const INITIAL_SEGMENTS: Segment[] = [
@@ -34,7 +37,7 @@ const MODELS = ['Opus 4.6', 'Sonnet 4.6', 'Haiku 4.5'] as const
 
 export function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>(INITIAL_SEGMENTS)
-  const [files, setFiles] = useState<PromptAreaFile[]>(INITIAL_FILES)
+  const [files, setFiles] = useState<AttachedFile[]>(INITIAL_FILES)
   const [submitted, setSubmitted] = useState('')
   const [selectedModel, setSelectedModel] = useState<string>(MODELS[0])
   const [modelMenuOpen, setModelMenuOpen] = useState(false)
@@ -63,6 +66,25 @@ export function ClaudeCodeInputExample() {
       {/* Main input container */}
       <div className="rounded-xl border">
         <div className="p-4 pb-2">
+          {files.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-1.5">
+              {files.map((file) => (
+                <span
+                  key={file.id}
+                  className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs">
+                  <File className="size-3.5" />
+                  {file.name}
+                  <button
+                    type="button"
+                    className="hover:text-foreground -mr-0.5 rounded transition-colors"
+                    aria-label={`Remove ${file.name}`}
+                    onClick={() => setFiles((prev) => prev.filter((x) => x.id !== file.id))}>
+                    <X className="size-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
           <PromptArea
             ref={promptRef}
             value={segments}
@@ -72,9 +94,6 @@ export function ClaudeCodeInputExample() {
             autoGrow
             minHeight={48}
             maxHeight={280}
-            files={files}
-            filePosition="above"
-            onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
           />
           <ActionBar
             className="pt-1.5"
@@ -185,62 +204,59 @@ export function ClaudeCodeInputExample() {
 }
 
 export const claudeCodeInputCode = `import { useCallback, useRef, useState } from 'react'
-import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList } from 'lucide-react'
+import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X } from 'lucide-react'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
 import { StatusBar } from '@/registry/new-york/blocks/status-bar/status-bar'
-import type { Segment, PromptAreaHandle, PromptAreaFile } from '@/registry/new-york/blocks/prompt-area/types'
+import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 
-const INITIAL_FILES: PromptAreaFile[] = [
-  { id: 'img-1', name: 'image.png', size: 240_000, type: 'image/png' },
-]
+type AttachedFile = { id: string; name: string }
 
 function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
-  const [files, setFiles] = useState<PromptAreaFile[]>(INITIAL_FILES)
+  const [files, setFiles] = useState<AttachedFile[]>([{ id: 'img-1', name: 'image.png' }])
   const [selectedModel, setSelectedModel] = useState('Opus 4.6')
   const [planMode, setPlanMode] = useState(false)
   const promptRef = useRef<PromptAreaHandle>(null)
 
-  const isEmpty = segments.length === 0 ||
-    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
-
-  const handleSubmit = useCallback((segs: Segment[]) => {
-    promptRef.current?.clear()
-    setSegments([])
-    setFiles([])
-  }, [])
-
   return (
     <div className="rounded-xl border">
       <div className="p-4 pb-2">
+        {/* Compact file chips */}
+        {files.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {files.map((file) => (
+              <span key={file.id} className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs">
+                <File className="size-3.5" />
+                {file.name}
+                <button onClick={() => setFiles((prev) => prev.filter((x) => x.id !== file.id))}>
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
         <PromptArea
           ref={promptRef}
           value={segments}
           onChange={setSegments}
           placeholder="Ask anything..."
-          onSubmit={handleSubmit}
+          onSubmit={(segs) => { promptRef.current?.clear(); setSegments([]); setFiles([]) }}
           autoGrow
           minHeight={48}
           maxHeight={280}
-          files={files}
-          filePosition="above"
-          onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
         />
         <ActionBar
           className="pt-1.5"
           left={
             <div className="flex items-center gap-1.5">
-              <button aria-label="Add attachment" className="size-8 rounded-lg ...">
-                <Plus className="size-4" />
-              </button>
+              <button className="size-8 rounded-lg"><Plus className="size-4" /></button>
               <button
                 onClick={() => setPlanMode((v) => !v)}
                 className={\`rounded-full px-3 py-1.5 text-xs font-medium \${
                   planMode ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
                 }\`}>
-                <LayoutList className="size-3.5" />
-                Plan mode
+                <LayoutList className="size-3.5" /> Plan mode
               </button>
             </div>
           }
@@ -249,11 +265,7 @@ function ClaudeCodeInputExample() {
               <button className="text-muted-foreground text-xs">
                 {selectedModel} <ChevronDown className="size-3" />
               </button>
-              <button
-                onClick={() => handleSubmit(segments)}
-                disabled={isEmpty}
-                className="bg-primary text-primary-foreground size-8 rounded-full"
-                aria-label="Send message">
+              <button className="bg-primary text-primary-foreground size-8 rounded-full">
                 <ArrowUp className="size-4" />
               </button>
             </div>
@@ -265,9 +277,8 @@ function ClaudeCodeInputExample() {
         left={
           <div className="flex items-center gap-2">
             <span className="bg-muted rounded px-2 py-0.5 text-xs font-medium">prompt-area</span>
-            <GitBranch className="size-3" />
-            <span className="text-xs">main</span>
-            <button aria-label="Add project"><Plus className="size-3" /></button>
+            <GitBranch className="size-3" /> <span className="text-xs">main</span>
+            <button><Plus className="size-3" /></button>
           </div>
         }
         right={

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -23,3 +23,4 @@ export { CompactPromptAreaExample, compactPromptAreaCode } from './compact-promp
 export { ChatPromptLayoutExample, chatPromptLayoutCode } from './chat-prompt-layout'
 export { DxHelpersExample, dxHelpersCode } from './dx-helpers'
 export { RotatingPlaceholdersExample, rotatingPlaceholdersCode } from './rotating-placeholders'
+export { ClaudeCodeInputExample, claudeCodeInputCode } from './claude-code-input'

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -60,7 +60,11 @@ const NAV_ITEMS: NavItem[] = [
       { id: 'status-bar-both', label: 'Combined' },
     ],
   },
-  { id: 'claude-code-input', label: 'Claude Code–Style' },
+  {
+    id: 'claude-code-input',
+    label: 'Claude Code–Style',
+    children: [{ id: 'claude-code-input-demo', label: 'Demo' }],
+  },
   {
     id: 'compact-prompt-area',
     label: 'Compact Prompt Area',

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -60,6 +60,7 @@ const NAV_ITEMS: NavItem[] = [
       { id: 'status-bar-both', label: 'Combined' },
     ],
   },
+  { id: 'claude-code-input', label: 'Claude Code–Style' },
   {
     id: 'compact-prompt-area',
     label: 'Compact Prompt Area',


### PR DESCRIPTION
## Summary
This PR adds a new example component that demonstrates a complete Claude Code–style chat input interface by composing existing PromptArea, ActionBar, and StatusBar components together.

## Key Changes
- **New example component** (`app/examples/claude-code-input.tsx`): A fully functional Claude Code–style input featuring:
  - File attachment chips with removal capability
  - Expandable prompt area with auto-grow behavior
  - Model selector dropdown (Opus 4.6, Sonnet 4.6, Haiku 4.5)
  - "Plan mode" toggle button
  - Submit button with disabled state
  - Status bar showing project context (branch, project name) and deployment status
  - Form submission handling with state management

- **Updated exports** (`app/examples/index.ts`): Exported the new component and its code snippet for documentation

- **Added documentation section** (`app/below-fold-sections.tsx`): New section showcasing the Claude Code–style input with description and interactive demo

- **Updated navigation** (`components/nav-sidebar.tsx`): Added navigation entry for the new example under a "Claude Code–Style" section

## Implementation Details
- The component uses React hooks (useState, useRef, useCallback) for state management
- Integrates with existing PromptArea, ActionBar, and StatusBar components from the registry
- Includes a code snippet export for documentation/reference purposes
- Demonstrates composition of multiple UI blocks to create a cohesive interface
- Includes proper accessibility attributes (aria-labels) and keyboard interaction support

https://claude.ai/code/session_01UWxriUfnyuNGCMRMBTGQgT