### PR TITLE
Update GitHub organization from team-gpt to just-marketing

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -81,7 +81,7 @@ export default function AboutPage() {
           Prompt Area is released under the MIT license. Contributions, bug reports, and feature
           requests are welcome on{' '}
           <a
-            href="https://github.com/team-gpt/prompt-area"
+            href="https://github.com/just-marketing/prompt-area"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium underline underline-offset-4">
@@ -89,7 +89,7 @@ export default function AboutPage() {
           </a>
           . See the{' '}
           <a
-            href="https://github.com/team-gpt/prompt-area/blob/main/CONTRIBUTING.md"
+            href="https://github.com/just-marketing/prompt-area/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium underline underline-offset-4">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -31,7 +31,7 @@ export default function ContactPage() {
         <p className="text-muted-foreground">
           The best way to report a bug or request a feature is through{' '}
           <a
-            href="https://github.com/team-gpt/prompt-area/issues"
+            href="https://github.com/just-marketing/prompt-area/issues"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium underline underline-offset-4">

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -45,7 +45,7 @@ export default function HomeContent() {
             Quick Start
           </a>
           <a
-            href="https://github.com/team-gpt/prompt-area"
+            href="https://github.com/just-marketing/prompt-area"
             target="_blank"
             rel="noopener noreferrer"
             className="border-input hover:bg-accent rounded-md border px-4 py-2 text-sm font-medium transition-colors">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
     'react textarea tags',
     'prompt area',
   ],
-  authors: [{ name: 'Juma.ai', url: 'https://github.com/team-gpt' }],
+  authors: [{ name: 'Juma.ai', url: 'https://github.com/just-marketing' }],
   creator: 'Juma.ai',
   openGraph: {
     type: 'website',
@@ -117,7 +117,7 @@ export default function RootLayout({
                     'The best React textarea component for AI chat interfaces. A production-grade contentEditable rich text input with @mentions, /commands, #tags, inline markdown, file attachments, and companion layout components. Zero extra dependencies.',
                   url: SITE_URL,
                   downloadUrl: `${SITE_URL}/r/prompt-area.json`,
-                  codeRepository: 'https://github.com/team-gpt/prompt-area',
+                  codeRepository: 'https://github.com/just-marketing/prompt-area',
                   programmingLanguage: ['TypeScript', 'React'],
                   runtimePlatform: 'Next.js',
                   license: 'https://opensource.org/licenses/MIT',
@@ -138,7 +138,7 @@ export default function RootLayout({
                     '@type': 'Organization',
                     name: 'Juma.ai',
                     url: 'https://juma.ai',
-                    sameAs: ['https://github.com/team-gpt'],
+                    sameAs: ['https://github.com/just-marketing'],
                   },
                   offers: {
                     '@type': 'Offer',
@@ -150,7 +150,7 @@ export default function RootLayout({
                   '@type': 'Organization',
                   name: 'Juma.ai',
                   url: 'https://juma.ai',
-                  sameAs: ['https://github.com/team-gpt'],
+                  sameAs: ['https://github.com/just-marketing'],
                   description:
                     'An AI workspace for marketing teams. Formerly known as Team-GPT. Creators of the Prompt Area open-source component.',
                 },

--- a/app/partners/page.tsx
+++ b/app/partners/page.tsx
@@ -66,7 +66,7 @@ export default function PartnersPage() {
           </a>{' '}
           or open a discussion on{' '}
           <a
-            href="https://github.com/team-gpt/prompt-area"
+            href="https://github.com/just-marketing/prompt-area"
             target="_blank"
             rel="noopener noreferrer"
             className="font-medium underline underline-offset-4">

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -80,7 +80,7 @@ export default function PressPage() {
         <ul className="text-muted-foreground list-inside list-disc space-y-1">
           <li>
             <a
-              href="https://github.com/team-gpt/prompt-area"
+              href="https://github.com/just-marketing/prompt-area"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium underline underline-offset-4">

--- a/app/sections/comparison-section.tsx
+++ b/app/sections/comparison-section.tsx
@@ -350,7 +350,7 @@ export function ComparisonSection() {
                   'bg-primary/5 border-primary/20',
                 )}>
                 <a
-                  href="https://github.com/team-gpt/prompt-area"
+                  href="https://github.com/just-marketing/prompt-area"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="decoration-muted-foreground/30 hover:decoration-foreground/50 text-xs font-semibold underline underline-offset-2">

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -447,7 +447,7 @@ function NavSidebar() {
 
       <div className="border-sidebar-border flex flex-col gap-2 border-t px-4 py-3">
         <a
-          href="https://github.com/team-gpt/prompt-area"
+          href="https://github.com/just-marketing/prompt-area"
           target="_blank"
           rel="noopener noreferrer"
           className={cn(

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -55,7 +55,7 @@ Plate.js is a Slate-based editor framework with 5+ dependencies. Prompt Area has
 
 - License: MIT
 - Author: Juma.ai (formerly Team-GPT)
-- Repository: https://github.com/team-gpt/prompt-area
+- Repository: https://github.com/just-marketing/prompt-area
 - Website: https://prompt-area.com
 - Install: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 - Stack: React, TypeScript, contentEditable, Tailwind CSS
@@ -68,7 +68,7 @@ Plate.js is a Slate-based editor framework with 5+ dependencies. Prompt Area has
 - [Contact](https://prompt-area.com/contact): Bug reporting, feature requests, and business inquiries
 - [Press](https://prompt-area.com/press): Media resources, project overview, and press contact
 - [Partners](https://prompt-area.com/partners): Integration partnerships and technology partner opportunities
-- [GitHub](https://github.com/team-gpt/prompt-area): Source code, issue tracker, and contribution guidelines
+- [GitHub](https://github.com/just-marketing/prompt-area): Source code, issue tracker, and contribution guidelines
 
 ## Installation
 
@@ -1076,5 +1076,5 @@ When you install `prompt-area`, the following modules are available:
 - Contact: https://prompt-area.com/contact
 - Press: https://prompt-area.com/press
 - Partners: https://prompt-area.com/partners
-- GitHub: https://github.com/team-gpt/prompt-area
+- GitHub: https://github.com/just-marketing/prompt-area
 - shadcn Registry: https://ui.shadcn.com/docs/registry

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -58,7 +58,7 @@ Plate.js is a Slate-based editor framework with 5+ dependencies. Prompt Area has
 - [Contact](https://prompt-area.com/contact): Bug reporting, feature requests, and business inquiries
 - [Press](https://prompt-area.com/press): Media resources, project overview, and press contact
 - [Partners](https://prompt-area.com/partners): Integration partnerships and technology partner opportunities
-- [GitHub Repository](https://github.com/team-gpt/prompt-area): Source code, issue tracker, and contribution guidelines for the prompt-area component
+- [GitHub Repository](https://github.com/just-marketing/prompt-area): Source code, issue tracker, and contribution guidelines for the prompt-area component
 - [shadcn Registry](https://ui.shadcn.com/docs/registry): Learn how shadcn registry distribution works for installing prompt-area into any Next.js or React project
 
 ## Installation

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "prompt-area",
-  "homepage": "https://github.com/team-gpt/prompt-area",
+  "homepage": "https://github.com/just-marketing/prompt-area",
   "items": [
     {
       "name": "prompt-area",


### PR DESCRIPTION
## Summary
This PR updates all references to the GitHub organization from `team-gpt` to `just-marketing` across the codebase, reflecting an organizational rebrand or repository migration.

## Key Changes
- Updated author and organization URLs in metadata from `https://github.com/team-gpt` to `https://github.com/just-marketing`
- Updated repository URLs in structured data (schema.org) from `team-gpt/prompt-area` to `just-marketing/prompt-area`
- Updated all internal links and references to GitHub repository across documentation pages:
  - About page
  - Contact page
  - Press page
  - Partners page
  - Home content
  - Comparison section
  - Navigation sidebar
- Updated public documentation files (`llms.txt`, `llms-full.txt`) with new repository URL
- Updated `registry.json` homepage reference to point to the new organization

## Files Modified
- `app/layout.tsx` - Metadata and structured data
- `app/about/page.tsx` - GitHub links
- `app/contact/page.tsx` - Issue tracker link
- `app/home-content.tsx` - GitHub repository link
- `app/partners/page.tsx` - GitHub discussion link
- `app/press/page.tsx` - GitHub repository link
- `app/sections/comparison-section.tsx` - GitHub link
- `components/nav-sidebar.tsx` - Navigation link
- `public/llms.txt` and `public/llms-full.txt` - Documentation
- `registry.json` - Registry configuration

All changes are consistent across the codebase, ensuring no broken links or outdated references remain.

https://claude.ai/code/session_01HTgfw4vrhvJ581XaRLXhDe