### PR TITLE
Add Codex-style input example with stacked composer and context tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ registry/new-york/blocks/
 
 app/
 ├── page.tsx              # Landing page
-├── examples/             # 18 interactive demos
+├── examples/             # 20+ interactive demos
 └── sections/             # Landing page sections
 ```
 

--- a/app/below-fold-sections.tsx
+++ b/app/below-fold-sections.tsx
@@ -44,6 +44,8 @@ import {
   rotatingPlaceholdersCode,
   ClaudeCodeInputExample,
   claudeCodeInputCode,
+  CodexInputExample,
+  codexInputCode,
 } from './examples'
 import { SectionHeading } from './sections/section-heading'
 import { InstallSection } from './sections/install-block'
@@ -337,6 +339,33 @@ export default function BelowFoldSections() {
           </p>
           <ExampleShowcase code={claudeCodeInputCode}>
             <ClaudeCodeInputExample />
+          </ExampleShowcase>
+        </div>
+      </div>
+
+      {/* Codex–style Input */}
+      <div className="flex flex-col gap-6">
+        <div id="codex-input" className="flex scroll-mt-16 flex-col gap-3">
+          <SectionHeading id="codex-input" as="h2">
+            Codex–Style
+          </SectionHeading>
+          <p className="text-muted-foreground">
+            A stacked composer that mirrors an OpenAI Codex–style cloud-agent input: a large rounded
+            card with a permissions menu and reasoning-effort model selector, layered over a context
+            tray of repository, environment, and branch selectors. Built by composing PromptArea and
+            ActionBar.
+          </p>
+        </div>
+
+        <div id="codex-input-demo" className="flex scroll-mt-16 flex-col gap-2">
+          <SectionHeading id="codex-input-demo">Demo</SectionHeading>
+          <p className="text-muted-foreground text-xs">
+            A &ldquo;Do anything&rdquo; prompt with a permissions pill and a lightning model
+            selector in the toolbar, plus a peeking context tray with repository, environment, and
+            branch dropdowns.
+          </p>
+          <ExampleShowcase code={codexInputCode}>
+            <CodexInputExample />
           </ExampleShowcase>
         </div>
       </div>

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -1,0 +1,454 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Plus,
+  Hand,
+  Zap,
+  Mic,
+  ArrowUp,
+  ChevronDown,
+  FolderGit2,
+  Laptop,
+  GitBranch,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
+import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
+import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
+
+// ---------------------------------------------------------------------------
+// Option data (representative placeholders)
+// ---------------------------------------------------------------------------
+
+const PERMISSIONS = ['Default permissions', 'Read only', 'Full access'] as const
+type Permission = (typeof PERMISSIONS)[number]
+
+const MODELS = [
+  { id: 'gpt-5.5-xhigh', version: '5.5', effort: 'Extra High' },
+  { id: 'gpt-5.5-high', version: '5.5', effort: 'High' },
+  { id: 'gpt-5.5-medium', version: '5.5', effort: 'Medium' },
+  { id: 'gpt-5.1-high', version: '5.1', effort: 'High' },
+] as const
+type Model = (typeof MODELS)[number]
+
+const REPOS = ['team-gpt-enterprise', 'team-gpt-web', 'team-gpt-infra'] as const
+const ENVIRONMENTS = ['Work locally', 'Cloud sandbox', 'Staging'] as const
+const BRANCHES = ['cursor/prod-data-memoization-layer', 'main', 'release/2026-06'] as const
+
+// Shared class fragments (mirrors the repo's ICON_BTN / MENU_ITEM convention).
+const TOOLBAR_PILL =
+  'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm transition-colors'
+const ICON_BTN =
+  'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
+const TRAY_PILL =
+  'text-muted-foreground hover:bg-accent hover:text-foreground flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
+const MENU =
+  'bg-popover absolute z-20 flex max-h-[240px] flex-col overflow-auto rounded-xl border p-1 shadow-md'
+const MENU_ITEM =
+  'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent'
+
+export function CodexInputExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [submitted, setSubmitted] = useState('')
+
+  const [permission, setPermission] = useState<Permission>(PERMISSIONS[0])
+  const [model, setModel] = useState<Model>(MODELS[0])
+  const [repo, setRepo] = useState<string>(REPOS[0])
+  const [environment, setEnvironment] = useState<string>(ENVIRONMENTS[0])
+  const [branch, setBranch] = useState<string>(BRANCHES[0])
+
+  // Single source of truth for which dropdown is open — only one at a time.
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const isEmpty =
+    segments.length === 0 ||
+    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
+
+  // Close the open menu on outside click or Escape. One root ref wraps every
+  // dropdown; clicking a different trigger swaps menus via toggleMenu.
+  useEffect(() => {
+    if (!openMenu) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpenMenu(null)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenu(null)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [openMenu])
+
+  const toggleMenu = useCallback((id: string) => {
+    setOpenMenu((cur) => (cur === id ? null : id))
+  }, [])
+
+  const handleSubmit = useCallback((segs: Segment[]) => {
+    const text = segmentsToPlainText(segs)
+    if (!text.trim()) return
+    setSubmitted(text)
+    promptRef.current?.clear()
+    setSegments([])
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-2" ref={rootRef}>
+      {/* Stacked composer + context tray */}
+      <div className="relative flex flex-col">
+        {/* Foreground composer card */}
+        <div
+          className="bg-card relative z-10 rounded-[28px] border shadow-sm"
+          style={{ '--prompt-area-surface': 'var(--card)' } as React.CSSProperties}>
+          <div className="px-4 pt-4 pb-2">
+            <PromptArea
+              ref={promptRef}
+              value={segments}
+              onChange={setSegments}
+              placeholder="Do anything"
+              onSubmit={handleSubmit}
+              autoGrow
+              minHeight={52}
+              maxHeight={280}
+            />
+            <ActionBar
+              className="pt-2"
+              left={
+                <div className="flex items-center gap-0.5">
+                  <button type="button" className={ICON_BTN} aria-label="Add attachment">
+                    <Plus className="size-4" />
+                  </button>
+
+                  {/* Permissions */}
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => toggleMenu('permissions')}
+                      aria-haspopup="menu"
+                      aria-expanded={openMenu === 'permissions'}
+                      className={TOOLBAR_PILL}>
+                      <Hand className="size-4" />
+                      {permission}
+                      <ChevronDown className="size-3.5 opacity-60" />
+                    </button>
+                    {openMenu === 'permissions' && (
+                      <div role="menu" className={cn(MENU, 'bottom-full left-0 mb-1.5 w-48')}>
+                        {PERMISSIONS.map((p) => (
+                          <button
+                            key={p}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={p === permission}
+                            className={cn(MENU_ITEM, p === permission && 'bg-accent')}
+                            onClick={() => {
+                              setPermission(p)
+                              setOpenMenu(null)
+                            }}>
+                            <Hand className="size-4 shrink-0" />
+                            {p}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              }
+              right={
+                <div className="flex items-center gap-0.5">
+                  {/* Reasoning-effort model selector */}
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => toggleMenu('model')}
+                      aria-haspopup="menu"
+                      aria-expanded={openMenu === 'model'}
+                      className={TOOLBAR_PILL}>
+                      <Zap className="size-4" />
+                      <span className="text-foreground font-semibold">{model.version}</span>
+                      {model.effort}
+                      <ChevronDown className="size-3.5 opacity-60" />
+                    </button>
+                    {openMenu === 'model' && (
+                      <div role="menu" className={cn(MENU, 'right-0 bottom-full mb-1.5 w-52')}>
+                        {MODELS.map((m) => (
+                          <button
+                            key={m.id}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={m.id === model.id}
+                            className={cn(MENU_ITEM, m.id === model.id && 'bg-accent')}
+                            onClick={() => {
+                              setModel(m)
+                              setOpenMenu(null)
+                            }}>
+                            <Zap className="size-4 shrink-0" />
+                            <span className="text-foreground font-semibold">{m.version}</span>
+                            <span className="text-muted-foreground">{m.effort}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <button type="button" className={ICON_BTN} aria-label="Voice input">
+                    <Mic className="size-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => handleSubmit(segments)}
+                    disabled={isEmpty}
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                    aria-label="Send message">
+                    <ArrowUp className="size-4" />
+                  </button>
+                </div>
+              }
+            />
+          </div>
+        </div>
+
+        {/* Background context tray — peeks out below the composer card */}
+        <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+          <div className="flex flex-wrap items-center gap-0.5">
+            {/* Repository */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => toggleMenu('repo')}
+                aria-haspopup="menu"
+                aria-expanded={openMenu === 'repo'}
+                className={TRAY_PILL}>
+                <FolderGit2 className="size-3.5 shrink-0" />
+                {repo}
+                <ChevronDown className="size-3 shrink-0 opacity-60" />
+              </button>
+              {openMenu === 'repo' && (
+                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-56')}>
+                  {REPOS.map((r) => (
+                    <button
+                      key={r}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={r === repo}
+                      className={cn(MENU_ITEM, r === repo && 'bg-accent')}
+                      onClick={() => {
+                        setRepo(r)
+                        setOpenMenu(null)
+                      }}>
+                      <FolderGit2 className="size-3.5 shrink-0" />
+                      <span className="truncate">{r}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Environment */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => toggleMenu('environment')}
+                aria-haspopup="menu"
+                aria-expanded={openMenu === 'environment'}
+                className={TRAY_PILL}>
+                <Laptop className="size-3.5 shrink-0" />
+                {environment}
+                <ChevronDown className="size-3 shrink-0 opacity-60" />
+              </button>
+              {openMenu === 'environment' && (
+                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-48')}>
+                  {ENVIRONMENTS.map((env) => (
+                    <button
+                      key={env}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={env === environment}
+                      className={cn(MENU_ITEM, env === environment && 'bg-accent')}
+                      onClick={() => {
+                        setEnvironment(env)
+                        setOpenMenu(null)
+                      }}>
+                      <Laptop className="size-3.5 shrink-0" />
+                      {env}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Branch — truncated label */}
+            <div className="relative min-w-0">
+              <button
+                type="button"
+                onClick={() => toggleMenu('branch')}
+                aria-haspopup="menu"
+                aria-expanded={openMenu === 'branch'}
+                title={branch}
+                className={TRAY_PILL}>
+                <GitBranch className="size-3.5 shrink-0" />
+                <span className="truncate">{branch}</span>
+                <ChevronDown className="size-3 shrink-0 opacity-60" />
+              </button>
+              {openMenu === 'branch' && (
+                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-64')}>
+                  {BRANCHES.map((b) => (
+                    <button
+                      key={b}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={b === branch}
+                      className={cn(MENU_ITEM, b === branch && 'bg-accent')}
+                      onClick={() => {
+                        setBranch(b)
+                        setOpenMenu(null)
+                      }}>
+                      <GitBranch className="size-3.5 shrink-0" />
+                      <span className="truncate">{b}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {submitted && (
+        <div className="bg-muted/50 rounded-lg border p-3">
+          <div className="text-muted-foreground mb-1 text-xs font-medium">Submitted:</div>
+          <div className="text-sm">{submitted}</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const codexInputCode = `import { useCallback, useEffect, useRef, useState } from 'react'
+import { Plus, Hand, Zap, Mic, ArrowUp, ChevronDown, FolderGit2, Laptop, GitBranch } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
+import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
+import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
+
+const TOOLBAR_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm transition-colors'
+const ICON_BTN = 'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
+const TRAY_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
+const MENU = 'bg-popover absolute z-20 flex flex-col rounded-xl border p-1 shadow-md'
+const MENU_ITEM = 'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm hover:bg-accent'
+
+function CodexInputExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [model, setModel] = useState({ version: '5.5', effort: 'Extra High' })
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const promptRef = useRef<PromptAreaHandle>(null)
+  const toggleMenu = (id: string) => setOpenMenu((cur) => (cur === id ? null : id))
+
+  // Close the open menu on outside click — one root ref covers every dropdown.
+  useEffect(() => {
+    if (!openMenu) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpenMenu(null)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [openMenu])
+
+  return (
+    <div className="relative flex flex-col" ref={rootRef}>
+      {/* Foreground composer */}
+      <div
+        className="bg-card relative z-10 rounded-[28px] border shadow-sm"
+        style={{ '--prompt-area-surface': 'var(--card)' } as React.CSSProperties}>
+        <div className="px-4 pt-4 pb-2">
+          <PromptArea
+            ref={promptRef}
+            value={segments}
+            onChange={setSegments}
+            placeholder="Do anything"
+            onSubmit={() => { promptRef.current?.clear(); setSegments([]) }}
+            autoGrow
+            minHeight={52}
+            maxHeight={280}
+          />
+          <ActionBar
+            className="pt-2"
+            left={
+              <div className="flex items-center gap-0.5">
+                <button className={ICON_BTN} aria-label="Add"><Plus className="size-4" /></button>
+                <div className="relative">
+                  <button onClick={() => toggleMenu('permissions')} className={TOOLBAR_PILL}>
+                    <Hand className="size-4" /> Default permissions <ChevronDown className="size-3.5 opacity-60" />
+                  </button>
+                  {openMenu === 'permissions' && (
+                    <div className={cn(MENU, 'bottom-full left-0 mb-1.5 w-48')}>
+                      {['Default permissions', 'Read only', 'Full access'].map((p) => (
+                        <button key={p} className={MENU_ITEM} onClick={() => setOpenMenu(null)}>
+                          <Hand className="size-4" /> {p}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            }
+            right={
+              <div className="flex items-center gap-0.5">
+                <div className="relative">
+                  <button onClick={() => toggleMenu('model')} className={TOOLBAR_PILL}>
+                    <Zap className="size-4" />
+                    <span className="text-foreground font-semibold">{model.version}</span>
+                    {model.effort}
+                    <ChevronDown className="size-3.5 opacity-60" />
+                  </button>
+                  {openMenu === 'model' && (
+                    <div className={cn(MENU, 'right-0 bottom-full mb-1.5 w-52')}>
+                      {[{ version: '5.5', effort: 'Extra High' }, { version: '5.5', effort: 'High' }, { version: '5.1', effort: 'High' }].map((m, i) => (
+                        <button key={i} className={MENU_ITEM} onClick={() => { setModel(m); setOpenMenu(null) }}>
+                          <Zap className="size-4" />
+                          <span className="text-foreground font-semibold">{m.version}</span>
+                          <span className="text-muted-foreground">{m.effort}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
+                <button
+                  onClick={() => { promptRef.current?.clear(); setSegments([]) }}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full disabled:opacity-50"
+                  aria-label="Send">
+                  <ArrowUp className="size-4" />
+                </button>
+              </div>
+            }
+          />
+        </div>
+      </div>
+
+      {/* Background context tray — peeks out below the composer */}
+      <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+        <div className="flex flex-wrap items-center gap-0.5">
+          <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
+            <FolderGit2 className="size-3.5" /> team-gpt-enterprise <ChevronDown className="size-3 opacity-60" />
+          </button>
+          <button onClick={() => toggleMenu('environment')} className={TRAY_PILL}>
+            <Laptop className="size-3.5" /> Work locally <ChevronDown className="size-3 opacity-60" />
+          </button>
+          <button onClick={() => toggleMenu('branch')} className={cn(TRAY_PILL, 'min-w-0')} title="cursor/prod-data-memoization-layer">
+            <GitBranch className="size-3.5 shrink-0" />
+            <span className="truncate">cursor/prod-data-memoization-layer</span>
+            <ChevronDown className="size-3 shrink-0 opacity-60" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}`

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -198,7 +198,7 @@ export function CodexInputExample() {
               '--prompt-area-placeholder': 'oklch(0.7 0 0)',
             } as React.CSSProperties
           }>
-          <div className="px-4 pt-4 pb-2">
+          <div className="p-4">
             <PromptArea
               ref={promptRef}
               value={segments}
@@ -372,7 +372,7 @@ function CodexInputExample() {
       <div
         className="bg-card relative z-10 rounded-[28px] border shadow-sm"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
-        <div className="px-4 pt-4 pb-2">
+        <div className="p-4">
           <PromptArea
             ref={promptRef}
             value={segments}

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -265,7 +265,7 @@ export function CodexInputExample() {
                     type="button"
                     onClick={() => handleSubmit(segments)}
                     disabled={isEmpty}
-                    className="flex size-8 items-center justify-center rounded-full bg-[#dadada] text-[#7a7a7a] transition-colors hover:bg-[#cfcfcf] disabled:cursor-not-allowed dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3]"
+                    className="flex size-8 items-center justify-center rounded-full bg-black text-white transition-colors hover:bg-[#1a1a1a] disabled:cursor-not-allowed disabled:bg-[#dadada] disabled:text-[#7a7a7a] dark:bg-white dark:text-black dark:hover:bg-neutral-200 dark:disabled:bg-[#969696] dark:disabled:text-[#2d2d2d]"
                     aria-label="Send message">
                     <ArrowUp className="size-4" />
                   </button>
@@ -428,7 +428,7 @@ function CodexInputExample() {
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
                   onClick={() => { promptRef.current?.clear(); setSegments([]) }}
-                  className="bg-[#dadada] text-[#7a7a7a] hover:bg-[#cfcfcf] dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
+                  className="bg-black text-white hover:bg-[#1a1a1a] disabled:bg-[#dadada] disabled:text-[#7a7a7a] dark:bg-white dark:text-black dark:hover:bg-neutral-200 dark:disabled:bg-[#969696] dark:disabled:text-[#2d2d2d] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
                 </button>

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -191,14 +191,14 @@ export function CodexInputExample() {
       <div className="relative flex flex-col">
         {/* Foreground composer card */}
         <div
-          className="bg-card relative z-10 rounded-[24px] border shadow-sm dark:bg-[#2a2a2a]"
+          className="bg-card relative z-10 rounded-[24px] dark:bg-[#2d2d2d]"
           style={
             {
               '--prompt-area-surface': 'var(--card)',
               '--prompt-area-placeholder': 'oklch(0.7 0 0)',
             } as React.CSSProperties
           }>
-          <div className="p-2">
+          <div className="pt-[13.5px] pr-2 pb-2 pl-[13px]">
             <PromptArea
               ref={promptRef}
               value={segments}
@@ -276,7 +276,7 @@ export function CodexInputExample() {
         </div>
 
         {/* Background context tray — peeks out below the composer card */}
-        <div className="bg-muted -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5 dark:bg-[#242424]">
+        <div className="bg-muted -mt-5 rounded-b-[24px] px-1.5 pt-[27px] pb-[7px] dark:bg-[#1f1f1f]">
           <div className="flex flex-wrap items-center gap-0.5">
             <Menu<string>
               id="repo"
@@ -370,9 +370,9 @@ function CodexInputExample() {
     <div className="relative flex flex-col" ref={rootRef}>
       {/* Foreground composer */}
       <div
-        className="bg-card dark:bg-[#2a2a2a] relative z-10 rounded-[24px] border shadow-sm"
+        className="bg-card dark:bg-[#2d2d2d] relative z-10 rounded-[24px]"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
-        <div className="p-2">
+        <div className="pt-[13.5px] pr-2 pb-2 pl-[13px]">
           <PromptArea
             ref={promptRef}
             value={segments}
@@ -439,7 +439,7 @@ function CodexInputExample() {
       </div>
 
       {/* Background context tray — peeks out below the composer */}
-      <div className="bg-muted dark:bg-[#242424] -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
+      <div className="bg-muted dark:bg-[#1f1f1f] -mt-5 rounded-b-[24px] px-1.5 pt-[27px] pb-[7px]">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
             <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -265,7 +265,7 @@ export function CodexInputExample() {
                     type="button"
                     onClick={() => handleSubmit(segments)}
                     disabled={isEmpty}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed dark:bg-[#5a5a5a] dark:text-white dark:hover:bg-[#646464]"
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3]"
                     aria-label="Send message">
                     <ArrowUp className="size-4" />
                   </button>
@@ -428,7 +428,7 @@ function CodexInputExample() {
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
                   onClick={() => { promptRef.current?.clear(); setSegments([]) }}
-                  className="bg-primary text-primary-foreground hover:bg-primary/90 dark:bg-[#5a5a5a] dark:text-white dark:hover:bg-[#646464] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
                 </button>

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -198,7 +198,7 @@ export function CodexInputExample() {
               '--prompt-area-placeholder': 'oklch(0.7 0 0)',
             } as React.CSSProperties
           }>
-          <div className="p-4">
+          <div className="px-2 pt-4 pb-2">
             <PromptArea
               ref={promptRef}
               value={segments}
@@ -372,7 +372,7 @@ function CodexInputExample() {
       <div
         className="bg-card relative z-10 rounded-[28px] border shadow-sm"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
-        <div className="p-4">
+        <div className="px-2 pt-4 pb-2">
           <PromptArea
             ref={promptRef}
             value={segments}

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -192,7 +192,12 @@ export function CodexInputExample() {
         {/* Foreground composer card */}
         <div
           className="bg-card relative z-10 rounded-[28px] border shadow-sm"
-          style={{ '--prompt-area-surface': 'var(--card)' } as React.CSSProperties}>
+          style={
+            {
+              '--prompt-area-surface': 'var(--card)',
+              '--prompt-area-placeholder': 'oklch(0.7 0 0)',
+            } as React.CSSProperties
+          }>
           <div className="px-4 pt-4 pb-2">
             <PromptArea
               ref={promptRef}
@@ -201,7 +206,7 @@ export function CodexInputExample() {
               placeholder="Do anything"
               onSubmit={handleSubmit}
               autoGrow
-              minHeight={52}
+              minHeight={40}
               maxHeight={280}
             />
             <ActionBar
@@ -366,7 +371,7 @@ function CodexInputExample() {
       {/* Foreground composer */}
       <div
         className="bg-card relative z-10 rounded-[28px] border shadow-sm"
-        style={{ '--prompt-area-surface': 'var(--card)' } as React.CSSProperties}>
+        style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
         <div className="px-4 pt-4 pb-2">
           <PromptArea
             ref={promptRef}
@@ -375,7 +380,7 @@ function CodexInputExample() {
             placeholder="Do anything"
             onSubmit={() => { promptRef.current?.clear(); setSegments([]) }}
             autoGrow
-            minHeight={52}
+            minHeight={40}
             maxHeight={280}
           />
           <ActionBar

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -43,11 +43,11 @@ const BRANCHES = ['cursor/prod-data-memoization-layer', 'main', 'release/2026-06
 
 // Shared class fragments, following the per-example ICON_BTN / MENU_ITEM naming convention.
 const TOOLBAR_PILL =
-  'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
+  'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
 const ICON_BTN =
-  'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
+  'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex size-8 items-center justify-center rounded-full transition-colors'
 const TRAY_PILL =
-  'text-muted-foreground hover:bg-accent hover:text-foreground flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
+  'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
 const MENU =
   'bg-popover absolute z-20 flex max-h-[240px] flex-col overflow-auto rounded-xl border p-1 shadow-md'
 const MENU_ITEM =
@@ -191,7 +191,7 @@ export function CodexInputExample() {
       <div className="relative flex flex-col">
         {/* Foreground composer card */}
         <div
-          className="bg-card relative z-10 rounded-[24px] dark:bg-[#2d2d2d]"
+          className="bg-card relative z-10 rounded-[24px] border border-[#ececec] shadow-sm dark:border-0 dark:bg-[#2d2d2d] dark:shadow-none"
           style={
             {
               '--prompt-area-surface': 'var(--card)',
@@ -265,7 +265,7 @@ export function CodexInputExample() {
                     type="button"
                     onClick={() => handleSubmit(segments)}
                     disabled={isEmpty}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3]"
+                    className="flex size-8 items-center justify-center rounded-full bg-[#dadada] text-[#7a7a7a] transition-colors hover:bg-[#cfcfcf] disabled:cursor-not-allowed dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3]"
                     aria-label="Send message">
                     <ArrowUp className="size-4" />
                   </button>
@@ -276,7 +276,7 @@ export function CodexInputExample() {
         </div>
 
         {/* Background context tray — peeks out below the composer card */}
-        <div className="bg-muted -mt-5 rounded-b-[24px] px-1.5 pt-[27px] pb-[7px] dark:bg-[#1f1f1f]">
+        <div className="-mt-5 rounded-b-[24px] bg-[#f6f6f6] px-1.5 pt-[27px] pb-[7px] dark:bg-[#1f1f1f]">
           <div className="flex flex-wrap items-center gap-0.5">
             <Menu<string>
               id="repo"
@@ -316,9 +316,9 @@ export function CodexInputExample() {
               selected={branch}
               getKey={(b) => b}
               onSelect={setBranch}
-              renderLabel={(b) => <span className="truncate">{b}</span>}
+              renderLabel={(b) => <span className="min-w-0 truncate">{b}</span>}
               menuClass="top-full left-0 mt-1.5 w-64"
-              wrapperClass="min-w-0"
+              wrapperClass="min-w-0 max-w-[200px]"
               title={branch}
             />
           </div>
@@ -342,9 +342,9 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
 import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 
-const TOOLBAR_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
-const ICON_BTN = 'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
-const TRAY_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
+const TOOLBAR_PILL = 'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
+const ICON_BTN = 'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex size-8 items-center justify-center rounded-full transition-colors'
+const TRAY_PILL = 'text-[#8f9091] hover:bg-accent hover:text-foreground dark:text-muted-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
 const MENU = 'bg-popover absolute z-20 flex flex-col rounded-xl border p-1 shadow-md'
 const MENU_ITEM = 'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm hover:bg-accent'
 
@@ -370,7 +370,7 @@ function CodexInputExample() {
     <div className="relative flex flex-col" ref={rootRef}>
       {/* Foreground composer */}
       <div
-        className="bg-card dark:bg-[#2d2d2d] relative z-10 rounded-[24px]"
+        className="bg-card dark:bg-[#2d2d2d] relative z-10 rounded-[24px] border border-[#ececec] shadow-sm dark:border-0 dark:shadow-none"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
         <div className="pt-[13.5px] pr-2 pb-2 pl-[13px]">
           <PromptArea
@@ -428,7 +428,7 @@ function CodexInputExample() {
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
                   onClick={() => { promptRef.current?.clear(); setSegments([]) }}
-                  className="bg-primary text-primary-foreground hover:bg-primary/90 dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
+                  className="bg-[#dadada] text-[#7a7a7a] hover:bg-[#cfcfcf] dark:bg-[#969696] dark:text-[#2d2d2d] dark:hover:bg-[#a3a3a3] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
                 </button>
@@ -439,7 +439,7 @@ function CodexInputExample() {
       </div>
 
       {/* Background context tray — peeks out below the composer */}
-      <div className="bg-muted dark:bg-[#1f1f1f] -mt-5 rounded-b-[24px] px-1.5 pt-[27px] pb-[7px]">
+      <div className="bg-[#f6f6f6] dark:bg-[#1f1f1f] -mt-5 rounded-b-[24px] px-1.5 pt-[27px] pb-[7px]">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
             <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />
@@ -447,9 +447,9 @@ function CodexInputExample() {
           <button onClick={() => toggleMenu('environment')} className={TRAY_PILL}>
             <Laptop className="size-3.5" /> Work locally <ChevronDown className="size-3 opacity-60" />
           </button>
-          <button onClick={() => toggleMenu('branch')} className={cn(TRAY_PILL, 'min-w-0')} title="cursor/prod-data-memoization-layer">
+          <button onClick={() => toggleMenu('branch')} className={cn(TRAY_PILL, 'min-w-0 max-w-[200px]')} title="cursor/prod-data-memoization-layer">
             <GitBranch className="size-3.5 shrink-0" />
-            <span className="truncate">cursor/prod-data-memoization-layer</span>
+            <span className="min-w-0 truncate">cursor/prod-data-memoization-layer</span>
             <ChevronDown className="size-3 shrink-0 opacity-60" />
           </button>
         </div>

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -191,7 +191,7 @@ export function CodexInputExample() {
       <div className="relative flex flex-col">
         {/* Foreground composer card */}
         <div
-          className="bg-card relative z-10 rounded-[28px] border shadow-sm"
+          className="bg-card relative z-10 rounded-[24px] border shadow-sm"
           style={
             {
               '--prompt-area-surface': 'var(--card)',
@@ -276,7 +276,7 @@ export function CodexInputExample() {
         </div>
 
         {/* Background context tray — peeks out below the composer card */}
-        <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+        <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
           <div className="flex flex-wrap items-center gap-0.5">
             <Menu<string>
               id="repo"
@@ -370,7 +370,7 @@ function CodexInputExample() {
     <div className="relative flex flex-col" ref={rootRef}>
       {/* Foreground composer */}
       <div
-        className="bg-card relative z-10 rounded-[28px] border shadow-sm"
+        className="bg-card relative z-10 rounded-[24px] border shadow-sm"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
         <div className="px-2 pt-4 pb-2">
           <PromptArea
@@ -439,7 +439,7 @@ function CodexInputExample() {
       </div>
 
       {/* Background context tray — peeks out below the composer */}
-      <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+      <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
             <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -37,7 +37,7 @@ const MODELS = [
 ] as const
 type Model = (typeof MODELS)[number]
 
-const REPOS = ['team-gpt-enterprise', 'team-gpt-web', 'team-gpt-infra'] as const
+const REPOS = ['acme-enterprise', 'acme-web', 'acme-infra'] as const
 const ENVIRONMENTS = ['Work locally', 'Cloud sandbox', 'Staging'] as const
 const BRANCHES = ['cursor/prod-data-memoization-layer', 'main', 'release/2026-06'] as const
 
@@ -437,7 +437,7 @@ function CodexInputExample() {
       <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
-            <FolderGit2 className="size-3.5" /> team-gpt-enterprise <ChevronDown className="size-3 opacity-60" />
+            <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />
           </button>
           <button onClick={() => toggleMenu('environment')} className={TRAY_PILL}>
             <Laptop className="size-3.5" /> Work locally <ChevronDown className="size-3 opacity-60" />

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -198,7 +198,7 @@ export function CodexInputExample() {
               '--prompt-area-placeholder': 'oklch(0.7 0 0)',
             } as React.CSSProperties
           }>
-          <div className="px-2 pt-4 pb-2">
+          <div className="p-2">
             <PromptArea
               ref={promptRef}
               value={segments}
@@ -372,7 +372,7 @@ function CodexInputExample() {
       <div
         className="bg-card relative z-10 rounded-[24px] border shadow-sm"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
-        <div className="px-2 pt-4 pb-2">
+        <div className="p-2">
           <PromptArea
             ref={promptRef}
             value={segments}

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -43,7 +43,7 @@ const BRANCHES = ['cursor/prod-data-memoization-layer', 'main', 'release/2026-06
 
 // Shared class fragments, following the per-example ICON_BTN / MENU_ITEM naming convention.
 const TOOLBAR_PILL =
-  'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm transition-colors'
+  'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
 const ICON_BTN =
   'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
 const TRAY_PILL =
@@ -265,7 +265,7 @@ export function CodexInputExample() {
                     type="button"
                     onClick={() => handleSubmit(segments)}
                     disabled={isEmpty}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:opacity-50"
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed"
                     aria-label="Send message">
                     <ArrowUp className="size-4" />
                   </button>
@@ -276,7 +276,7 @@ export function CodexInputExample() {
         </div>
 
         {/* Background context tray — peeks out below the composer card */}
-        <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+        <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
           <div className="flex flex-wrap items-center gap-0.5">
             <Menu<string>
               id="repo"
@@ -342,7 +342,7 @@ import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
 import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 
-const TOOLBAR_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm transition-colors'
+const TOOLBAR_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] transition-colors'
 const ICON_BTN = 'text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-full transition-colors'
 const TRAY_PILL = 'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs transition-colors'
 const MENU = 'bg-popover absolute z-20 flex flex-col rounded-xl border p-1 shadow-md'
@@ -428,7 +428,7 @@ function CodexInputExample() {
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
                   onClick={() => { promptRef.current?.clear(); setSegments([]) }}
-                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full disabled:opacity-50"
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
                 </button>
@@ -439,7 +439,7 @@ function CodexInputExample() {
       </div>
 
       {/* Background context tray — peeks out below the composer */}
-      <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
+      <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
             <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -191,7 +191,7 @@ export function CodexInputExample() {
       <div className="relative flex flex-col">
         {/* Foreground composer card */}
         <div
-          className="bg-card relative z-10 rounded-[24px] border shadow-sm"
+          className="bg-card relative z-10 rounded-[24px] border shadow-sm dark:bg-[#2a2a2a]"
           style={
             {
               '--prompt-area-surface': 'var(--card)',
@@ -265,7 +265,7 @@ export function CodexInputExample() {
                     type="button"
                     onClick={() => handleSubmit(segments)}
                     disabled={isEmpty}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed"
+                    className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed dark:bg-[#5a5a5a] dark:text-white dark:hover:bg-[#646464]"
                     aria-label="Send message">
                     <ArrowUp className="size-4" />
                   </button>
@@ -276,7 +276,7 @@ export function CodexInputExample() {
         </div>
 
         {/* Background context tray — peeks out below the composer card */}
-        <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
+        <div className="bg-muted -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5 dark:bg-[#242424]">
           <div className="flex flex-wrap items-center gap-0.5">
             <Menu<string>
               id="repo"
@@ -370,7 +370,7 @@ function CodexInputExample() {
     <div className="relative flex flex-col" ref={rootRef}>
       {/* Foreground composer */}
       <div
-        className="bg-card relative z-10 rounded-[24px] border shadow-sm"
+        className="bg-card dark:bg-[#2a2a2a] relative z-10 rounded-[24px] border shadow-sm"
         style={{ '--prompt-area-surface': 'var(--card)', '--prompt-area-placeholder': 'oklch(0.7 0 0)' } as React.CSSProperties}>
         <div className="p-2">
           <PromptArea
@@ -428,7 +428,7 @@ function CodexInputExample() {
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
                   onClick={() => { promptRef.current?.clear(); setSegments([]) }}
-                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
+                  className="bg-primary text-primary-foreground hover:bg-primary/90 dark:bg-[#5a5a5a] dark:text-white dark:hover:bg-[#646464] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
                 </button>
@@ -439,7 +439,7 @@ function CodexInputExample() {
       </div>
 
       {/* Background context tray — peeks out below the composer */}
-      <div className="bg-muted dark:bg-muted/40 -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
+      <div className="bg-muted dark:bg-[#242424] -mt-5 rounded-b-[24px] border border-t-0 px-3 pt-7 pb-2.5">
         <div className="flex flex-wrap items-center gap-0.5">
           <button onClick={() => toggleMenu('repo')} className={TRAY_PILL}>
             <FolderGit2 className="size-3.5" /> acme-enterprise <ChevronDown className="size-3 opacity-60" />

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -11,11 +11,15 @@ import {
   FolderGit2,
   Laptop,
   GitBranch,
+  type LucideIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
-import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
+import {
+  segmentsToPlainText,
+  isSegmentsEmpty,
+} from '@/registry/new-york/blocks/prompt-area/segment-helpers'
 import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 
 // ---------------------------------------------------------------------------
@@ -37,7 +41,7 @@ const REPOS = ['team-gpt-enterprise', 'team-gpt-web', 'team-gpt-infra'] as const
 const ENVIRONMENTS = ['Work locally', 'Cloud sandbox', 'Staging'] as const
 const BRANCHES = ['cursor/prod-data-memoization-layer', 'main', 'release/2026-06'] as const
 
-// Shared class fragments (mirrors the repo's ICON_BTN / MENU_ITEM convention).
+// Shared class fragments, following the per-example ICON_BTN / MENU_ITEM naming convention.
 const TOOLBAR_PILL =
   'text-muted-foreground hover:bg-accent hover:text-foreground flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-sm transition-colors'
 const ICON_BTN =
@@ -48,6 +52,95 @@ const MENU =
   'bg-popover absolute z-20 flex max-h-[240px] flex-col overflow-auto rounded-xl border p-1 shadow-md'
 const MENU_ITEM =
   'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-accent'
+
+// One dropdown for every selector in the composer and tray. Collapsing the five
+// near-identical menus into a single component keeps the trigger markup, the
+// open/close wiring, and the selected-state styling in one place. The `toolbar`
+// and `tray` variants only differ in icon/chevron sizing and the trigger pill.
+const MENU_VARIANT = {
+  toolbar: {
+    pill: TOOLBAR_PILL,
+    triggerIcon: 'size-4',
+    chevron: 'size-3.5 opacity-60',
+    itemIcon: 'size-4 shrink-0',
+  },
+  tray: {
+    pill: TRAY_PILL,
+    triggerIcon: 'size-3.5 shrink-0',
+    chevron: 'size-3 shrink-0 opacity-60',
+    itemIcon: 'size-3.5 shrink-0',
+  },
+} as const
+
+function Menu<T>({
+  id,
+  openMenu,
+  setOpenMenu,
+  variant,
+  icon: Icon,
+  options,
+  selected,
+  getKey,
+  onSelect,
+  renderLabel,
+  menuClass,
+  wrapperClass,
+  title,
+}: {
+  id: string
+  openMenu: string | null
+  setOpenMenu: (next: string | null) => void
+  variant: keyof typeof MENU_VARIANT
+  icon: LucideIcon
+  options: readonly T[]
+  selected: T
+  getKey: (value: T) => string
+  onSelect: (value: T) => void
+  renderLabel: (value: T, inMenu: boolean) => React.ReactNode
+  menuClass: string
+  wrapperClass?: string
+  title?: string
+}) {
+  const v = MENU_VARIANT[variant]
+  const open = openMenu === id
+  return (
+    <div className={cn('relative', wrapperClass)}>
+      <button
+        type="button"
+        onClick={() => setOpenMenu(open ? null : id)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={title}
+        className={v.pill}>
+        <Icon className={v.triggerIcon} />
+        {renderLabel(selected, false)}
+        <ChevronDown className={v.chevron} />
+      </button>
+      {open && (
+        <div role="menu" className={cn(MENU, menuClass)}>
+          {options.map((option) => {
+            const active = getKey(option) === getKey(selected)
+            return (
+              <button
+                key={getKey(option)}
+                type="button"
+                role="menuitemradio"
+                aria-checked={active}
+                className={cn(MENU_ITEM, active && 'bg-accent')}
+                onClick={() => {
+                  onSelect(option)
+                  setOpenMenu(null)
+                }}>
+                <Icon className={v.itemIcon} />
+                {renderLabel(option, true)}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
 
 export function CodexInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
@@ -64,12 +157,10 @@ export function CodexInputExample() {
   const rootRef = useRef<HTMLDivElement>(null)
   const promptRef = useRef<PromptAreaHandle>(null)
 
-  const isEmpty =
-    segments.length === 0 ||
-    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
+  const isEmpty = isSegmentsEmpty(segments)
 
   // Close the open menu on outside click or Escape. One root ref wraps every
-  // dropdown; clicking a different trigger swaps menus via toggleMenu.
+  // dropdown; clicking a different trigger swaps menus.
   useEffect(() => {
     if (!openMenu) return
     const onDown = (e: MouseEvent) => {
@@ -85,10 +176,6 @@ export function CodexInputExample() {
       document.removeEventListener('keydown', onKey)
     }
   }, [openMenu])
-
-  const toggleMenu = useCallback((id: string) => {
-    setOpenMenu((cur) => (cur === id ? null : id))
-  }, [])
 
   const handleSubmit = useCallback((segs: Segment[]) => {
     const text = segmentsToPlainText(segs)
@@ -125,76 +212,45 @@ export function CodexInputExample() {
                     <Plus className="size-4" />
                   </button>
 
-                  {/* Permissions */}
-                  <div className="relative">
-                    <button
-                      type="button"
-                      onClick={() => toggleMenu('permissions')}
-                      aria-haspopup="menu"
-                      aria-expanded={openMenu === 'permissions'}
-                      className={TOOLBAR_PILL}>
-                      <Hand className="size-4" />
-                      {permission}
-                      <ChevronDown className="size-3.5 opacity-60" />
-                    </button>
-                    {openMenu === 'permissions' && (
-                      <div role="menu" className={cn(MENU, 'bottom-full left-0 mb-1.5 w-48')}>
-                        {PERMISSIONS.map((p) => (
-                          <button
-                            key={p}
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={p === permission}
-                            className={cn(MENU_ITEM, p === permission && 'bg-accent')}
-                            onClick={() => {
-                              setPermission(p)
-                              setOpenMenu(null)
-                            }}>
-                            <Hand className="size-4 shrink-0" />
-                            {p}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+                  <Menu<Permission>
+                    id="permissions"
+                    openMenu={openMenu}
+                    setOpenMenu={setOpenMenu}
+                    variant="toolbar"
+                    icon={Hand}
+                    options={PERMISSIONS}
+                    selected={permission}
+                    getKey={(p) => p}
+                    onSelect={setPermission}
+                    renderLabel={(p) => p}
+                    menuClass="bottom-full left-0 mb-1.5 w-48"
+                  />
                 </div>
               }
               right={
                 <div className="flex items-center gap-0.5">
-                  {/* Reasoning-effort model selector */}
-                  <div className="relative">
-                    <button
-                      type="button"
-                      onClick={() => toggleMenu('model')}
-                      aria-haspopup="menu"
-                      aria-expanded={openMenu === 'model'}
-                      className={TOOLBAR_PILL}>
-                      <Zap className="size-4" />
-                      <span className="text-foreground font-semibold">{model.version}</span>
-                      {model.effort}
-                      <ChevronDown className="size-3.5 opacity-60" />
-                    </button>
-                    {openMenu === 'model' && (
-                      <div role="menu" className={cn(MENU, 'right-0 bottom-full mb-1.5 w-52')}>
-                        {MODELS.map((m) => (
-                          <button
-                            key={m.id}
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={m.id === model.id}
-                            className={cn(MENU_ITEM, m.id === model.id && 'bg-accent')}
-                            onClick={() => {
-                              setModel(m)
-                              setOpenMenu(null)
-                            }}>
-                            <Zap className="size-4 shrink-0" />
-                            <span className="text-foreground font-semibold">{m.version}</span>
-                            <span className="text-muted-foreground">{m.effort}</span>
-                          </button>
-                        ))}
-                      </div>
+                  <Menu<Model>
+                    id="model"
+                    openMenu={openMenu}
+                    setOpenMenu={setOpenMenu}
+                    variant="toolbar"
+                    icon={Zap}
+                    options={MODELS}
+                    selected={model}
+                    getKey={(m) => m.id}
+                    onSelect={setModel}
+                    renderLabel={(m, inMenu) => (
+                      <>
+                        <span className="text-foreground font-semibold">{m.version}</span>
+                        {inMenu ? (
+                          <span className="text-muted-foreground">{m.effort}</span>
+                        ) : (
+                          m.effort
+                        )}
+                      </>
                     )}
-                  </div>
+                    menuClass="right-0 bottom-full mb-1.5 w-52"
+                  />
 
                   <button type="button" className={ICON_BTN} aria-label="Voice input">
                     <Mic className="size-4" />
@@ -217,105 +273,49 @@ export function CodexInputExample() {
         {/* Background context tray — peeks out below the composer card */}
         <div className="bg-muted/40 dark:bg-muted/20 -mt-5 rounded-b-[28px] border border-t-0 px-3 pt-7 pb-2.5">
           <div className="flex flex-wrap items-center gap-0.5">
-            {/* Repository */}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => toggleMenu('repo')}
-                aria-haspopup="menu"
-                aria-expanded={openMenu === 'repo'}
-                className={TRAY_PILL}>
-                <FolderGit2 className="size-3.5 shrink-0" />
-                {repo}
-                <ChevronDown className="size-3 shrink-0 opacity-60" />
-              </button>
-              {openMenu === 'repo' && (
-                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-56')}>
-                  {REPOS.map((r) => (
-                    <button
-                      key={r}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={r === repo}
-                      className={cn(MENU_ITEM, r === repo && 'bg-accent')}
-                      onClick={() => {
-                        setRepo(r)
-                        setOpenMenu(null)
-                      }}>
-                      <FolderGit2 className="size-3.5 shrink-0" />
-                      <span className="truncate">{r}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <Menu<string>
+              id="repo"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              variant="tray"
+              icon={FolderGit2}
+              options={REPOS}
+              selected={repo}
+              getKey={(r) => r}
+              onSelect={setRepo}
+              renderLabel={(r, inMenu) => (inMenu ? <span className="truncate">{r}</span> : r)}
+              menuClass="top-full left-0 mt-1.5 w-56"
+            />
 
-            {/* Environment */}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => toggleMenu('environment')}
-                aria-haspopup="menu"
-                aria-expanded={openMenu === 'environment'}
-                className={TRAY_PILL}>
-                <Laptop className="size-3.5 shrink-0" />
-                {environment}
-                <ChevronDown className="size-3 shrink-0 opacity-60" />
-              </button>
-              {openMenu === 'environment' && (
-                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-48')}>
-                  {ENVIRONMENTS.map((env) => (
-                    <button
-                      key={env}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={env === environment}
-                      className={cn(MENU_ITEM, env === environment && 'bg-accent')}
-                      onClick={() => {
-                        setEnvironment(env)
-                        setOpenMenu(null)
-                      }}>
-                      <Laptop className="size-3.5 shrink-0" />
-                      {env}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <Menu<string>
+              id="environment"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              variant="tray"
+              icon={Laptop}
+              options={ENVIRONMENTS}
+              selected={environment}
+              getKey={(env) => env}
+              onSelect={setEnvironment}
+              renderLabel={(env) => env}
+              menuClass="top-full left-0 mt-1.5 w-48"
+            />
 
-            {/* Branch — truncated label */}
-            <div className="relative min-w-0">
-              <button
-                type="button"
-                onClick={() => toggleMenu('branch')}
-                aria-haspopup="menu"
-                aria-expanded={openMenu === 'branch'}
-                title={branch}
-                className={TRAY_PILL}>
-                <GitBranch className="size-3.5 shrink-0" />
-                <span className="truncate">{branch}</span>
-                <ChevronDown className="size-3 shrink-0 opacity-60" />
-              </button>
-              {openMenu === 'branch' && (
-                <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-64')}>
-                  {BRANCHES.map((b) => (
-                    <button
-                      key={b}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={b === branch}
-                      className={cn(MENU_ITEM, b === branch && 'bg-accent')}
-                      onClick={() => {
-                        setBranch(b)
-                        setOpenMenu(null)
-                      }}>
-                      <GitBranch className="size-3.5 shrink-0" />
-                      <span className="truncate">{b}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <Menu<string>
+              id="branch"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              variant="tray"
+              icon={GitBranch}
+              options={BRANCHES}
+              selected={branch}
+              getKey={(b) => b}
+              onSelect={setBranch}
+              renderLabel={(b) => <span className="truncate">{b}</span>}
+              menuClass="top-full left-0 mt-1.5 w-64"
+              wrapperClass="min-w-0"
+              title={branch}
+            />
           </div>
         </div>
       </div>

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -24,3 +24,4 @@ export { ChatPromptLayoutExample, chatPromptLayoutCode } from './chat-prompt-lay
 export { DxHelpersExample, dxHelpersCode } from './dx-helpers'
 export { RotatingPlaceholdersExample, rotatingPlaceholdersCode } from './rotating-placeholders'
 export { ClaudeCodeInputExample, claudeCodeInputCode } from './claude-code-input'
+export { CodexInputExample, codexInputCode } from './codex-input'

--- a/components/nav-sidebar.tsx
+++ b/components/nav-sidebar.tsx
@@ -75,6 +75,11 @@ const NAV_ITEMS: NavItem[] = [
     children: [{ id: 'claude-code-input-demo', label: 'Demo' }],
   },
   {
+    id: 'codex-input',
+    label: 'Codex–Style',
+    children: [{ id: 'codex-input-demo', label: 'Demo' }],
+  },
+  {
     id: 'compact-prompt-area',
     label: 'Compact Prompt Area',
     children: [{ id: 'compact-prompt-area-demo', label: 'Demo' }],

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "pnpm": {
     "overrides": {
       "@types/react": "19.2.14",
-      "undici": ">=7.24.0",
+      "undici": ">=7.24.0 <8",
       "flatted": ">=3.4.2",
       "hono": ">=4.12.15",
       "@hono/node-server": ">=1.19.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@types/react': 19.2.14
-  undici: '>=7.24.0'
+  undici: '>=7.24.0 <8'
   flatted: '>=3.4.2'
   hono: '>=4.12.15'
   '@hono/node-server': '>=1.19.14'
@@ -3995,9 +3995,9 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
-    engines: {node: '>=22.19.0'}
+  undici@7.27.0:
+    resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -6974,7 +6974,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.3.0
+      undici: 7.27.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -8190,7 +8190,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.3.0: {}
+  undici@7.27.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -768,6 +768,18 @@ function ChatPromptLayoutExample() {
 }
 ```
 
+### Codex-Style Input
+
+A showcase composition (not a separately installable block) that replicates an OpenAI Codex–style cloud-agent composer. Built by composing `PromptArea` (with `autoGrow`) and `ActionBar`:
+
+- A large rounded composer card (`bg-card`, `rounded-[28px]`) holding a "Do anything" prompt and a bottom toolbar.
+- Toolbar: a `+` button and a permissions menu on the left; a reasoning-effort model selector (e.g. "5.5 · Extra High"), a microphone, and a circular send button on the right.
+- A stacked "context tray" that peeks out below the card with repository, environment, and branch dropdowns.
+- A single `openMenu` state drives all five dropdowns with one outside-click / Escape handler.
+- Fully theme-aware (light/dark) via CSS variables; no extra dependencies.
+
+See the live demo at https://prompt-area.com/#codex-input
+
 ## Rotating Placeholder
 
 When `placeholder` is passed as a `string[]`, the placeholder animates between items:

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -102,6 +102,8 @@ Plate.js is a Slate-based editor framework with 5+ dependencies. Prompt Area has
 - [Async Search](https://prompt-area.com/#example-async): Debounced async search with AbortController
 - [Markdown](https://prompt-area.com/#example-markdown): Inline bold, italic, URLs, and list formatting
 - [Copy & Paste](https://prompt-area.com/#example-copy-paste): Chip data preservation and trigger auto-resolution
+- [Claude Code–Style Input](https://prompt-area.com/#claude-code-input): Full composition of PromptArea, ActionBar, and StatusBar replicating a Claude Code–style chat input with plan mode and model selector
+- [Codex–Style Input](https://prompt-area.com/#codex-input): Stacked Codex-style composer with a permissions pill, reasoning-effort model selector, and a peeking repository/environment/branch context tray
 
 ## Companion Components
 

--- a/registry/new-york/blocks/prompt-area/animated-placeholder.tsx
+++ b/registry/new-york/blocks/prompt-area/animated-placeholder.tsx
@@ -23,7 +23,8 @@ export function AnimatedPlaceholder({ texts, interval = 3000 }: AnimatedPlacehol
 
   return (
     <div
-      className="text-muted-foreground pointer-events-none absolute top-0 left-0 overflow-hidden text-sm leading-relaxed select-none"
+      className="pointer-events-none absolute top-0 left-0 overflow-hidden text-sm leading-relaxed select-none"
+      style={{ color: 'var(--prompt-area-placeholder, var(--muted-foreground))' }}
       aria-hidden="true">
       <AnimatePresence mode="wait">
         <motion.div

--- a/registry/new-york/blocks/prompt-area/prompt-area.tsx
+++ b/registry/new-york/blocks/prompt-area/prompt-area.tsx
@@ -283,7 +283,8 @@ export function PromptArea({
             <div
               className="h-full w-full"
               style={{
-                background: 'linear-gradient(to bottom, transparent, color-mix(in srgb, var(--prompt-area-surface, var(--background)) 80%, transparent), var(--prompt-area-surface, var(--background)))',
+                background:
+                  'linear-gradient(to bottom, transparent, color-mix(in srgb, var(--prompt-area-surface, var(--background)) 80%, transparent), var(--prompt-area-surface, var(--background)))',
               }}
             />
           </div>
@@ -296,7 +297,8 @@ export function PromptArea({
             <AnimatedPlaceholder texts={placeholder} />
           ) : (
             <div
-              className="text-muted-foreground pointer-events-none absolute top-0 left-0 text-sm leading-relaxed select-none"
+              className="pointer-events-none absolute top-0 left-0 text-sm leading-relaxed select-none"
+              style={{ color: 'var(--prompt-area-placeholder, var(--muted-foreground))' }}
               aria-hidden="true">
               {placeholder}
             </div>

--- a/scripts/test-registry-install.sh
+++ b/scripts/test-registry-install.sh
@@ -29,6 +29,28 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Retry a network-dependent command (max 3 attempts, linear backoff). The fresh
+# install reaches external services — the npm registry, create-next-app, and
+# ui.shadcn.com during `shadcn init` — which occasionally drop the connection
+# mid-handshake. A transient TLS/socket failure shouldn't fail the whole job.
+retry() {
+  local max=3 n=1 status
+  while true; do
+    status=0
+    "$@" || status=$?
+    if (( status == 0 )); then
+      return 0
+    fi
+    if (( n >= max )); then
+      echo "   ✗ '$*' failed after ${max} attempts (exit ${status})." >&2
+      return "${status}"
+    fi
+    echo "   ⚠ '$*' failed (exit ${status}); retry ${n}/${max} in $((n * 5))s..." >&2
+    sleep $(( n * 5 ))
+    n=$(( n + 1 ))
+  done
+}
+
 # ── 1. Build the source app ──────────────────────────────────────
 echo "── Step 1: Building source app to verify it compiles cleanly..."
 cd "${REPO_ROOT}"
@@ -47,25 +69,30 @@ echo ""
 echo "── Step 3: Scaffolding fresh Next.js app..."
 cd "${TEST_DIR}"
 
-# Pipe newline to accept any interactive prompts (e.g. React Compiler)
-printf '\n' | npx --yes create-next-app@latest test-app \
-  --typescript \
-  --tailwind \
-  --eslint \
-  --app \
-  --src-dir \
-  --import-alias "@/*" \
-  --use-pnpm \
-  --no-turbopack \
-  --no-git \
-  2>&1 | tail -5
+# Pipe newline to accept any interactive prompts (e.g. React Compiler).
+# Wrapped in retry: create-next-app fetches packages over the network and can
+# hit transient socket drops; rm -rf keeps each attempt starting from a clean dir.
+scaffold_app() {
+  rm -rf test-app
+  printf '\n' | npx --yes create-next-app@latest test-app \
+    --typescript \
+    --tailwind \
+    --eslint \
+    --app \
+    --src-dir \
+    --import-alias "@/*" \
+    --use-pnpm \
+    --no-turbopack \
+    --no-git
+}
+retry scaffold_app
 cd test-app
 echo "   App created at ${TEST_DIR}/test-app"
 
 # ── 4. Init shadcn and install registry components ───────────────
 echo ""
 echo "── Step 4: Initializing shadcn..."
-pnpm dlx shadcn@latest init --yes --defaults 2>&1 | tail -5
+retry pnpm dlx shadcn@latest init --yes --defaults
 
 echo ""
 echo "── Step 5: Installing registry components..."
@@ -74,7 +101,7 @@ COMPONENTS=("prompt-area" "action-bar" "status-bar")
 
 for component in "${COMPONENTS[@]}"; do
   echo "   Installing ${component}..."
-  pnpm dlx shadcn@latest add "${REGISTRY_DIR}/${component}.json" --yes --overwrite 2>&1 | tail -3
+  retry pnpm dlx shadcn@latest add "${REGISTRY_DIR}/${component}.json" --yes --overwrite
   echo "   Done: ${component}"
 done
 
@@ -92,13 +119,13 @@ data['registryDependencies'] = []
 with open('${PATCHED_JSON}', 'w') as f:
     json.dump(data, f)
 "
-pnpm dlx shadcn@latest add "${PATCHED_JSON}" --yes --overwrite 2>&1 | tail -3
+retry pnpm dlx shadcn@latest add "${PATCHED_JSON}" --yes --overwrite
 echo "   Done: compact-prompt-area"
 
 # Install peer dependencies the components need
 echo ""
 echo "   Installing peer dependencies (lucide-react, framer-motion)..."
-pnpm add lucide-react framer-motion 2>&1 | tail -3
+retry pnpm add lucide-react framer-motion
 
 # ── 5. Verify installed files ────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
Adds a new interactive example showcasing a Codex-style cloud-agent input interface, demonstrating how to compose `PromptArea` and `ActionBar` blocks into a sophisticated multi-layered composer with context controls.

## Key Changes

- **New example component** (`app/examples/codex-input.tsx`): A fully-featured Codex-style input that includes:
  - A large rounded composer card with auto-growing prompt area
  - Toolbar with permissions menu (left) and reasoning-effort model selector (right)
  - Stacked context tray that peeks below the composer with repository, environment, and branch dropdowns
  - Single `openMenu` state managing all five dropdowns with unified outside-click and Escape handlers
  - Full theme awareness (light/dark) via CSS variables
  - Embedded code snippet for easy reference

- **Updated navigation and documentation**:
  - Added "Codex–Style" section to sidebar navigation with demo link
  - Integrated example into `below-fold-sections.tsx` with descriptive heading and demo showcase
  - Updated `app/examples/index.ts` to export the new component
  - Added documentation to `public/llms-full.txt` and `public/llms.txt`
  - Updated README to reflect 20+ interactive demos

Original
<img width="1000" height="233" alt="image" src="https://github.com/user-attachments/assets/2e971ce5-5be8-4164-b69d-2dbf3441b905" />
Prompt Area

<img width="804" height="181" alt="image" src="https://github.com/user-attachments/assets/ae6e4602-766b-4470-8f01-95d4b8f2268c" />


Original dark
<img width="1038" height="256" alt="image" src="https://github.com/user-attachments/assets/8e4b906b-fb08-48d2-8c49-a11fd6b7054a" />

Prompt Area Dark

<img width="773" height="169" alt="image" src="https://github.com/user-attachments/assets/396bdd66-f750-45f3-abe4-7206c279dc7c" />


## Implementation Details

- Uses representative placeholder data (PERMISSIONS, MODELS, REPOS, ENVIRONMENTS, BRANCHES)
- Demonstrates dropdown menu composition with proper ARIA attributes (`aria-haspopup`, `aria-expanded`, `role="menu"`)
- Implements efficient state management with a single `openMenu` string state instead of multiple boolean flags
- Includes visual feedback with truncation handling for long branch names
- Leverages existing `PromptArea` and `ActionBar` components for composition
- No additional dependencies beyond existing lucide-react icons and utility functions

https://claude.ai/code/session_01U8fM5D5FUq7D3FWN3joCQ8