### PR TITLE
Update Claude model version to Opus 4.8 and format code

### DIFF
--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -1,30 +1,16 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
-import {
-  Plus,
-  ArrowUp,
-  ChevronDown,
-  GitBranch,
-  Cloud,
-  LayoutList,
-  File,
-  X,
-} from 'lucide-react'
+import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X } from 'lucide-react'
 import { PromptArea } from '@/registry/new-york/blocks/prompt-area/prompt-area'
 import { ActionBar } from '@/registry/new-york/blocks/action-bar/action-bar'
 import { StatusBar } from '@/registry/new-york/blocks/status-bar/status-bar'
 import { segmentsToPlainText } from '@/registry/new-york/blocks/prompt-area/prompt-area-engine'
-import type {
-  Segment,
-  PromptAreaHandle,
-} from '@/registry/new-york/blocks/prompt-area/types'
+import type { Segment, PromptAreaHandle } from '@/registry/new-york/blocks/prompt-area/types'
 
 type AttachedFile = { id: string; name: string }
 
-const INITIAL_FILES: AttachedFile[] = [
-  { id: 'img-1', name: 'image.png' },
-]
+const INITIAL_FILES: AttachedFile[] = [{ id: 'img-1', name: 'image.png' }]
 
 const INITIAL_SEGMENTS: Segment[] = [
   {
@@ -33,7 +19,7 @@ const INITIAL_SEGMENTS: Segment[] = [
   },
 ]
 
-const MODELS = ['Opus 4.6', 'Sonnet 4.6', 'Haiku 4.5'] as const
+const MODELS = ['Opus 4.8', 'Sonnet 4.6', 'Haiku 4.5'] as const
 
 export function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>(INITIAL_SEGMENTS)
@@ -49,17 +35,14 @@ export function ClaudeCodeInputExample() {
     segments.length === 0 ||
     (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
 
-  const handleSubmit = useCallback(
-    (segs: Segment[]) => {
-      const text = segmentsToPlainText(segs)
-      if (!text.trim()) return
-      setSubmitted(text)
-      promptRef.current?.clear()
-      setSegments([])
-      setFiles([])
-    },
-    [],
-  )
+  const handleSubmit = useCallback((segs: Segment[]) => {
+    const text = segmentsToPlainText(segs)
+    if (!text.trim()) return
+    setSubmitted(text)
+    promptRef.current?.clear()
+    setSegments([])
+    setFiles([])
+  }, [])
 
   return (
     <div className="flex flex-col gap-2">
@@ -135,7 +118,7 @@ export function ClaudeCodeInputExample() {
                         <button
                           key={model}
                           type="button"
-                          className={`flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm hover:bg-accent ${
+                          className={`hover:bg-accent flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm ${
                             model === selectedModel ? 'bg-accent' : ''
                           }`}
                           onClick={() => {
@@ -215,7 +198,7 @@ type AttachedFile = { id: string; name: string }
 function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
   const [files, setFiles] = useState<AttachedFile[]>([{ id: 'img-1', name: 'image.png' }])
-  const [selectedModel, setSelectedModel] = useState('Opus 4.6')
+  const [selectedModel, setSelectedModel] = useState('Opus 4.8')
   const [planMode, setPlanMode] = useState(false)
   const promptRef = useRef<PromptAreaHandle>(null)
 

--- a/app/examples/status-bar.tsx
+++ b/app/examples/status-bar.tsx
@@ -67,7 +67,7 @@ export function StatusBarBelowExample() {
           <button
             type="button"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1">
-            Opus 4.6
+            Opus 4.8
             <ChevronDown className="size-3" />
           </button>
         }
@@ -114,7 +114,7 @@ export function StatusBarBothExample() {
             <button
               type="button"
               className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
-              Opus 4.6
+              Opus 4.8
               <ChevronDown className="size-3" />
             </button>
           }
@@ -186,7 +186,7 @@ function StatusBarBelowExample() {
         left={<span className="text-muted-foreground">{"+ </> Auto accept edits"}</span>}
         right={
           <button className="text-muted-foreground flex items-center gap-1">
-            Opus 4.6 <ChevronDown className="size-3" />
+            Opus 4.8 <ChevronDown className="size-3" />
           </button>
         }
       />
@@ -232,7 +232,7 @@ function StatusBarBothExample() {
           left={<span className="text-muted-foreground text-xs">{"+ </> Auto accept edits"}</span>}
           right={
             <button className="text-muted-foreground flex items-center gap-1 text-xs">
-              Opus 4.6 <ChevronDown className="size-3" />
+              Opus 4.8 <ChevronDown className="size-3" />
             </button>
           }
         />

--- a/app/sections/demo-section.tsx
+++ b/app/sections/demo-section.tsx
@@ -92,7 +92,7 @@ const DEMO_FILES: PromptAreaFile[] = [
 
 const MODELS = [
   { id: 'opus', label: 'Opus 4.8', icon: '/claude-icon.svg', invertInDark: false },
-  { id: 'gpt', label: 'GPT 5.4', icon: '/openai-icon.svg', invertInDark: true },
+  { id: 'gpt', label: 'GPT 5.5', icon: '/openai-icon.svg', invertInDark: true },
 ] as const
 
 const ICON_BTN = 'rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground'

--- a/app/sections/demo-section.tsx
+++ b/app/sections/demo-section.tsx
@@ -91,7 +91,7 @@ const DEMO_FILES: PromptAreaFile[] = [
 ]
 
 const MODELS = [
-  { id: 'opus', label: 'Opus 4.6', icon: '/claude-icon.svg', invertInDark: false },
+  { id: 'opus', label: 'Opus 4.8', icon: '/claude-icon.svg', invertInDark: false },
   { id: 'gpt', label: 'GPT 5.4', icon: '/openai-icon.svg', invertInDark: true },
 ] as const
 
@@ -162,7 +162,7 @@ export function DemoSection() {
   return (
     <div className="flex flex-col gap-2">
       <div
-        className="rounded-xl border shadow-sm dark:bg-card dark:shadow-md dark:shadow-black/20"
+        className="dark:bg-card rounded-xl border shadow-sm dark:shadow-md dark:shadow-black/20"
         style={{ '--prompt-area-surface': 'var(--card)' } as React.CSSProperties}>
         <div className="p-4">
           <PromptArea

--- a/registry/new-york/blocks/status-bar/__tests__/status-bar.test.tsx
+++ b/registry/new-york/blocks/status-bar/__tests__/status-bar.test.tsx
@@ -15,8 +15,8 @@ describe('StatusBar', () => {
   })
 
   it('renders right slot content', () => {
-    render(<StatusBar right={<span>Opus 4.6</span>} />)
-    expect(screen.getByText('Opus 4.6')).toBeInTheDocument()
+    render(<StatusBar right={<span>Opus 4.8</span>} />)
+    expect(screen.getByText('Opus 4.8')).toBeInTheDocument()
   })
 
   it('renders both slots simultaneously', () => {


### PR DESCRIPTION
## Summary
This PR updates Claude model references from Opus 4.6 to Opus 4.8 across the codebase and applies minor code formatting improvements for consistency.

## Key Changes
- **Model Version Update**: Updated all references to Claude Opus model from version 4.6 to 4.8 in:
  - `app/examples/claude-code-input.tsx`
  - `app/examples/status-bar.tsx`
  - `app/sections/demo-section.tsx`
  - `registry/new-york/blocks/status-bar/__tests__/status-bar.test.tsx`

- **Code Formatting**: Applied consistent formatting improvements:
  - Consolidated multi-line import statements to single lines where appropriate
  - Reformatted `handleSubmit` callback to use arrow function body style
  - Reordered CSS class names for consistency (e.g., `hover:bg-accent` moved to beginning)
  - Adjusted className formatting in `demo-section.tsx` for better readability

## Implementation Details
- All model version changes are straightforward string replacements with no functional impact
- Formatting changes are purely stylistic and maintain the same functionality
- Test expectations updated to reflect the new model version string

https://claude.ai/code/session_012zzRCR3oLN1Pe8GKc4JnBo