### PR TITLE
Update copy-paste snippets to show the submit/reset cycle

### DIFF
--- a/app/examples/action-bar-full.tsx
+++ b/app/examples/action-bar-full.tsx
@@ -219,7 +219,7 @@ export function ActionBarFullExample() {
 }
 
 export const actionBarFullCode = `import { useCallback, useRef, useState } from 'react'
-import { PlusCircle, AtSign, SquareSlash, Hash, Mic, ArrowUp, Code, Type } from 'lucide-react'
+import { PlusCircle, AtSign, SquareSlash, Hash, Mic, ArrowUp, Code, Type, RotateCcw } from 'lucide-react'
 import { PromptArea } from '@/components/prompt-area'
 import { ActionBar } from '@/components/action-bar'
 import type { Segment, TriggerConfig, PromptAreaHandle } from '@/components/types'
@@ -232,6 +232,8 @@ const triggers: TriggerConfig[] = [
 
 function ActionBarFullExample() {
   const [segments, setSegments] = useState<Segment[]>([])
+  // Snapshot of the last submission so Reset can restore it for another send.
+  const [submitted, setSubmitted] = useState<Segment[] | null>(null)
   const [markdownEnabled, setMarkdownEnabled] = useState(false)
   const promptRef = useRef<PromptAreaHandle>(null)
 
@@ -240,9 +242,15 @@ function ActionBarFullExample() {
 
   const handleSubmit = useCallback(() => {
     if (isEmpty) return
+    setSubmitted(segments)
     promptRef.current?.clear()
     setSegments([])
-  }, [isEmpty])
+  }, [isEmpty, segments])
+  const reset = () => {
+    if (submitted) setSegments(submitted)
+    setSubmitted(null)
+    promptRef.current?.focus()
+  }
 
   const insertTrigger = useCallback((char: string) => {
     promptRef.current?.focus()
@@ -286,6 +294,14 @@ function ActionBarFullExample() {
           </>
         }
       />
+      {submitted && (
+        <div className="bg-muted/50 mt-2 flex items-center justify-between rounded-lg border p-3 text-sm">
+          <span className="text-muted-foreground">Submitted — clear to send again.</span>
+          <button onClick={reset} className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs" aria-label="Reset">
+            <RotateCcw className="size-3.5" /> Reset
+          </button>
+        </div>
+      )}
     </div>
   )
 }`

--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -175,20 +175,36 @@ export function ClaudeCodeInputExample() {
 }
 
 export const claudeCodeInputCode = `import { useCallback, useRef, useState } from 'react'
-import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X } from 'lucide-react'
+import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X, RotateCcw } from 'lucide-react'
 import { PromptArea } from '@/components/prompt-area'
 import { ActionBar } from '@/components/action-bar'
 import { StatusBar } from '@/components/status-bar'
 import type { Segment, PromptAreaHandle } from '@/components/types'
 
 type AttachedFile = { id: string; name: string }
+const INITIAL_FILES: AttachedFile[] = [{ id: 'img-1', name: 'image.png' }]
 
 function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
-  const [files, setFiles] = useState<AttachedFile[]>([{ id: 'img-1', name: 'image.png' }])
+  const [files, setFiles] = useState<AttachedFile[]>(INITIAL_FILES)
+  // Snapshot of the last submission so Reset can restore it for another send.
+  const [submitted, setSubmitted] = useState<{ segments: Segment[]; files: AttachedFile[] } | null>(null)
   const [selectedModel, setSelectedModel] = useState('Opus 4.8')
   const [planMode, setPlanMode] = useState(false)
   const promptRef = useRef<PromptAreaHandle>(null)
+
+  const submit = (segs: Segment[]) => {
+    if (!segs.length) return
+    setSubmitted({ segments: segs, files })
+    promptRef.current?.clear()
+    setSegments([])
+    setFiles([])
+  }
+  const reset = () => {
+    if (submitted) { setSegments(submitted.segments); setFiles(submitted.files) }
+    setSubmitted(null)
+    promptRef.current?.focus()
+  }
 
   return (
     <div className="rounded-xl border">
@@ -212,7 +228,7 @@ function ClaudeCodeInputExample() {
           value={segments}
           onChange={setSegments}
           placeholder="Ask anything..."
-          onSubmit={(segs) => { promptRef.current?.clear(); setSegments([]); setFiles([]) }}
+          onSubmit={submit}
           autoGrow
           minHeight={48}
           maxHeight={280}
@@ -236,7 +252,7 @@ function ClaudeCodeInputExample() {
               <button className="text-muted-foreground text-xs">
                 {selectedModel} <ChevronDown className="size-3" />
               </button>
-              <button className="bg-primary text-primary-foreground size-8 rounded-full">
+              <button onClick={() => submit(segments)} className="bg-primary text-primary-foreground size-8 rounded-full">
                 <ArrowUp className="size-4" />
               </button>
             </div>
@@ -258,6 +274,14 @@ function ClaudeCodeInputExample() {
           </button>
         }
       />
+      {submitted && (
+        <div className="bg-muted/50 m-2 flex items-center justify-between rounded-lg border p-3 text-sm">
+          <span className="text-muted-foreground">Submitted — clear to send again.</span>
+          <button onClick={reset} className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs" aria-label="Reset">
+            <RotateCcw className="size-3.5" /> Reset
+          </button>
+        </div>
+      )}
     </div>
   )
 }`

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -337,7 +337,7 @@ export function CodexInputExample({
 }
 
 export const codexInputCode = `import { useCallback, useEffect, useRef, useState } from 'react'
-import { Plus, Hand, Zap, Mic, ArrowUp, ChevronDown, FolderGit2, Laptop, GitBranch } from 'lucide-react'
+import { Plus, Hand, Zap, Mic, ArrowUp, ChevronDown, FolderGit2, Laptop, GitBranch, RotateCcw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PromptArea } from '@/components/prompt-area'
 import { ActionBar } from '@/components/action-bar'
@@ -351,11 +351,25 @@ const MENU_ITEM = 'flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-le
 
 function CodexInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
+  // Snapshot of the last submission so Reset can restore it for another send.
+  const [submitted, setSubmitted] = useState<Segment[] | null>(null)
   const [model, setModel] = useState({ version: '5.5', effort: 'Extra High' })
   const [openMenu, setOpenMenu] = useState<string | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const promptRef = useRef<PromptAreaHandle>(null)
   const toggleMenu = (id: string) => setOpenMenu((cur) => (cur === id ? null : id))
+
+  const submit = (segs: Segment[]) => {
+    if (!segs.length) return
+    setSubmitted(segs)
+    promptRef.current?.clear()
+    setSegments([])
+  }
+  const reset = () => {
+    if (submitted) setSegments(submitted)
+    setSubmitted(null)
+    promptRef.current?.focus()
+  }
 
   // Close the open menu on outside click — one root ref covers every dropdown.
   useEffect(() => {
@@ -379,7 +393,7 @@ function CodexInputExample() {
             value={segments}
             onChange={setSegments}
             placeholder="Do anything"
-            onSubmit={() => { promptRef.current?.clear(); setSegments([]) }}
+            onSubmit={submit}
             autoGrow
             minHeight={40}
             maxHeight={280}
@@ -428,7 +442,7 @@ function CodexInputExample() {
                 </div>
                 <button className={ICON_BTN} aria-label="Voice input"><Mic className="size-4" /></button>
                 <button
-                  onClick={() => { promptRef.current?.clear(); setSegments([]) }}
+                  onClick={() => submit(segments)}
                   className="bg-black text-white hover:bg-[#1a1a1a] disabled:bg-[#dadada] disabled:text-[#7a7a7a] dark:bg-white dark:text-black dark:hover:bg-neutral-200 dark:disabled:bg-[#969696] dark:disabled:text-[#2d2d2d] flex size-8 items-center justify-center rounded-full disabled:cursor-not-allowed"
                   aria-label="Send">
                   <ArrowUp className="size-4" />
@@ -455,6 +469,18 @@ function CodexInputExample() {
           </button>
         </div>
       </div>
+
+      {submitted && (
+        <div className="bg-muted/50 mt-2 flex items-center justify-between rounded-lg border p-3 text-sm">
+          <span className="text-muted-foreground">Submitted — clear to send again.</span>
+          <button
+            onClick={reset}
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+            aria-label="Reset">
+            <RotateCcw className="size-3.5" /> Reset
+          </button>
+        </div>
+      )}
     </div>
   )
 }`

--- a/app/examples/compact-prompt-area.tsx
+++ b/app/examples/compact-prompt-area.tsx
@@ -63,7 +63,7 @@ export function CompactPromptAreaExample() {
 }
 
 export const compactPromptAreaCode = `import { useCallback, useRef, useState } from 'react'
-import { Mic } from 'lucide-react'
+import { Mic, RotateCcw } from 'lucide-react'
 import { CompactPromptArea } from '@/components/compact-prompt-area'
 import { segmentsToPlainText } from '@/components/prompt-area-engine'
 import type { Segment, TriggerConfig, PromptAreaHandle } from '@/components/types'
@@ -75,30 +75,48 @@ const triggers: TriggerConfig[] = [
 
 function CompactPromptAreaExample() {
   const [segments, setSegments] = useState<Segment[]>([])
+  // Snapshot of the last submission so Reset can restore it for another send.
+  const [submitted, setSubmitted] = useState<Segment[] | null>(null)
   const promptRef = useRef<PromptAreaHandle>(null)
 
   const handleSubmit = useCallback((segs: Segment[]) => {
     const text = segmentsToPlainText(segs)
     if (!text.trim()) return
     sendMessage(text)
+    setSubmitted(segs)
     promptRef.current?.clear()
     setSegments([])
   }, [])
+  const reset = () => {
+    if (submitted) setSegments(submitted)
+    setSubmitted(null)
+    promptRef.current?.focus()
+  }
 
   return (
-    <CompactPromptArea
-      ref={promptRef}
-      value={segments}
-      onChange={setSegments}
-      triggers={triggers}
-      placeholder="Ask anything..."
-      onSubmit={handleSubmit}
-      onPlusClick={() => console.log('Plus clicked')}
-      beforeSubmitSlot={
-        <button aria-label="Voice input">
-          <Mic className="size-4" />
-        </button>
-      }
-    />
+    <div className="flex flex-col gap-2">
+      <CompactPromptArea
+        ref={promptRef}
+        value={segments}
+        onChange={setSegments}
+        triggers={triggers}
+        placeholder="Ask anything..."
+        onSubmit={handleSubmit}
+        onPlusClick={() => console.log('Plus clicked')}
+        beforeSubmitSlot={
+          <button aria-label="Voice input">
+            <Mic className="size-4" />
+          </button>
+        }
+      />
+      {submitted && (
+        <div className="bg-muted/50 flex items-center justify-between rounded-lg border p-3 text-sm">
+          <span className="text-muted-foreground">Submitted — clear to send again.</span>
+          <button onClick={reset} className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs" aria-label="Reset">
+            <RotateCcw className="size-3.5" /> Reset
+          </button>
+        </div>
+      )}
+    </div>
   )
 }`


### PR DESCRIPTION
## Why

Follow-up to #127. The snippet-update commit was pushed just after #127's merge was cut, so it never landed on `main`. The Code-tab snippets still clear the input on submit with no Reset, so they no longer match the live examples merged in #127.

## What

Updates the four Code-tab snippets (Codex, Claude Code, Compact, Action Bar) to demonstrate the full submit → reset cycle:
- Inline `submitted` snapshot captured on submit, restored on Reset (so the input comes back for another send).
- A small "Submitted — Reset" row.
- Kept self-contained (inline state, not referencing the extracted hook/component) since each snippet is a single-file copy-paste demo.

Lint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)