### PR TITLE
Add pnpm release script (one-command tag-driven release)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,21 @@ pnpm package:check    # Validate package exports & types
 
 A pre-commit hook (via Lefthook) will automatically lint and format staged files.
 
+## Releasing
+
+The npm version is driven by the GitHub release tag — they stay in sync
+automatically. To cut a release:
+
+```bash
+pnpm release 0.4.0          # creates the v0.4.0 GitHub release
+pnpm release 0.4.0 --dry-run  # preview without creating anything
+```
+
+This creates a `v0.4.0` GitHub Release, which triggers
+[`release.yml`](.github/workflows/release.yml) to publish `prompt-area@0.4.0`
+to npm and commit the version back to `main`. A one-time `NPM_TOKEN` repo
+secret (an npm Automation token) is required for the publish to authenticate.
+
 ## Code Style
 
 - Code is formatted with Prettier — run `pnpm format` to auto-fix

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "package:build": "pnpm --filter prompt-area build",
     "package:typecheck": "pnpm --filter prompt-area typecheck",
     "package:check": "pnpm --filter prompt-area lint:exports",
+    "release": "node scripts/release.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepare": "lefthook install",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,121 @@
+// Cut a release in one command.
+//
+//   pnpm release <version> [--yes] [--dry-run]
+//   pnpm release 0.4.0
+//   pnpm release v1.0.0 --yes
+//
+// Creates a GitHub Release whose tag drives the npm version. The Release
+// workflow (.github/workflows/release.yml) then publishes
+// prompt-area@<version> to npm and commits the version back to main.
+//
+// This script never touches package.json or npm directly — the tag is the
+// single source of truth, the workflow does the rest.
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { createInterface } from 'node:readline/promises'
+import { stdin, stdout, argv, exit } from 'node:process'
+
+const REPO = 'just-marketing/prompt-area'
+
+function sh(file, args, opts = {}) {
+  return execFileSync(file, args, { encoding: 'utf8', ...opts }).trim()
+}
+function fail(msg) {
+  console.error(`\n✖ ${msg}\n`)
+  exit(1)
+}
+
+const args = argv.slice(2)
+const flags = new Set(args.filter((a) => a.startsWith('-')))
+const yes = flags.has('--yes') || flags.has('-y')
+const dryRun = flags.has('--dry-run')
+const raw = args.find((a) => !a.startsWith('-'))
+
+if (!raw) fail('Usage: pnpm release <version> [--yes] [--dry-run]   (e.g. pnpm release 0.4.0)')
+
+// Normalize: drop a leading v, coerce X.Y -> X.Y.0
+let version = raw.replace(/^v/, '')
+if (/^\d+\.\d+$/.test(version)) version += '.0'
+if (!/^\d+\.\d+\.\d+([.-].+)?$/.test(version)) {
+  fail(`'${raw}' is not a semver version. Try e.g. 0.4.0 or v1.0.0.`)
+}
+const tag = `v${version}`
+
+// gh must be available and authenticated
+try {
+  sh('gh', ['auth', 'status'])
+} catch {
+  fail('GitHub CLI is not authenticated. Run: gh auth login')
+}
+
+// Refuse if the tag already exists on the remote
+const existing = sh('git', [
+  'ls-remote',
+  '--tags',
+  'origin',
+  `refs/tags/${tag}`,
+  `refs/tags/${version}`,
+])
+if (existing) fail(`A tag for ${version} already exists on origin. Pick a higher version.`)
+
+// Context + a basic "must go up" guard against accidental downgrades
+const pkgVersion = JSON.parse(readFileSync('packages/prompt-area/package.json', 'utf8')).version
+let npmVersion = null
+try {
+  npmVersion = sh('npm', ['view', 'prompt-area', 'version'])
+} catch {
+  /* not published yet */
+}
+
+const core = (v) => v.split('-')[0].split('.').map(Number)
+function isHigher(a, b) {
+  const [x, y] = [core(a), core(b)]
+  for (let i = 0; i < 3; i++) if (x[i] !== y[i]) return x[i] > y[i]
+  return a.includes('-') ? false : b.includes('-') // equal core: release > prerelease
+}
+if (npmVersion && !isHigher(version, npmVersion) && !flags.has('--force')) {
+  fail(`${version} is not higher than the published ${npmVersion}. Use --force to override.`)
+}
+
+console.log(`\n  release       ${tag}`)
+console.log(`  npm current   ${npmVersion ?? 'unpublished'}`)
+console.log(`  package.json  ${pkgVersion}`)
+console.log(`  target        ${REPO} @ main`)
+console.log(
+  `\n  → creates GitHub release ${tag} → publishes prompt-area@${version} → syncs package.json on main\n`,
+)
+
+if (dryRun) {
+  console.log('  (dry run — nothing created)\n')
+  exit(0)
+}
+
+if (!yes) {
+  if (!stdin.isTTY) fail('Not a TTY; re-run with --yes to confirm non-interactively.')
+  const rl = createInterface({ input: stdin, output: stdout })
+  const ans = (await rl.question('  Continue? (y/N) ')).trim().toLowerCase()
+  rl.close()
+  if (ans !== 'y' && ans !== 'yes') {
+    console.log('  Aborted.\n')
+    exit(0)
+  }
+}
+
+sh(
+  'gh',
+  [
+    'release',
+    'create',
+    tag,
+    '--repo',
+    REPO,
+    '--target',
+    'main',
+    '--title',
+    tag,
+    '--generate-notes',
+  ],
+  { stdio: 'inherit' },
+)
+console.log(`\n✓ Created release ${tag}. Track the publish:`)
+console.log(`  https://github.com/${REPO}/actions/workflows/release.yml\n`)


### PR DESCRIPTION
Adds a `pnpm release <version>` command so you never hand-type the tag.

```bash
pnpm release 0.4.0            # creates v0.4.0 → publishes prompt-area@0.4.0
pnpm release 0.4.0 --dry-run  # preview, creates nothing
```

It creates a `vX.Y.Z` GitHub Release (the tag drives the npm version via `release.yml`, which also syncs `package.json` back to main).

Guards: semver validation + `0.3`→`0.3.0` coercion, refuses an existing tag, refuses a non-increasing version (`--force` to override), prints a summary and confirms (`--yes` to skip). Documented in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)