### PR TITLE
Fix release script crash after creating the GitHub release

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -18,7 +18,9 @@ import { stdin, stdout, argv, exit } from 'node:process'
 const REPO = 'just-marketing/prompt-area'
 
 function sh(file, args, opts = {}) {
-  return execFileSync(file, args, { encoding: 'utf8', ...opts }).trim()
+  // With { stdio: 'inherit' } execFileSync returns null — guard before trimming.
+  const out = execFileSync(file, args, { encoding: 'utf8', ...opts })
+  return out == null ? '' : String(out).trim()
 }
 function fail(msg) {
   console.error(`\n✖ ${msg}\n`)


### PR DESCRIPTION
## Problem

`pnpm release <version>` created the GitHub release successfully, then crashed:

```
TypeError: Cannot read properties of null (reading 'trim')
    at sh (scripts/release.mjs:21)
```

The final `gh release create` call passes `{ stdio: 'inherit' }`. With inherited stdio, `execFileSync` returns `null`, and `sh()` called `.trim()` on it — so the script exited non-zero *after* the release was already created (confusing, looked like the release failed when it hadn't).

## Fix

Guard `sh()` against a `null` return:

```js
const out = execFileSync(file, args, { encoding: 'utf8', ...opts })
return out == null ? '' : String(out).trim()
```

Verified with `node --check` and `pnpm release 0.4.0 --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)