### PR TITLE
Reduce prompt-area package size by deduping the engine build

### DIFF
--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- **Smaller package** — the framework-agnostic engine is now emitted once as a
+  shared chunk instead of being bundled into both the components and the
+  `prompt-area/helpers` entry. The published tarball dropped from ~36 kB to
+  ~33 kB (unpacked ~134 kB → ~117 kB), and the core `PromptArea` import is
+  ~14 kB gzipped. No API changes.
+
 ## 0.1.1
 
 ### Changed

--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -13,6 +13,18 @@ project adheres to [Semantic Versioning](https://semver.org/).
   ~33 kB (unpacked ~134 kB → ~117 kB), and the core `PromptArea` import is
   ~14 kB gzipped. No API changes.
 
+## 0.3.0
+
+First npm publish since `0.1.0`. `0.1.1` was tagged but never published, so
+its packaging changes (listed below) reached npm as part of this release. No
+`0.2.0` was ever released — the version jumped straight from `0.1.1` to `0.3.0`.
+
+### Changed
+
+- Install docs now show `pnpm` / `npm` / `yarn` side by side and clarify that
+  `react` and `react-dom` are peer dependencies. No functional or API changes
+  versus `0.1.1`.
+
 ## 0.1.1
 
 ### Changed

--- a/packages/prompt-area/scripts/preserve-directives.mjs
+++ b/packages/prompt-area/scripts/preserve-directives.mjs
@@ -1,35 +1,57 @@
 // Re-attaches the `'use client'` directive that esbuild strips while bundling.
 //
-// The library is built in two passes (see tsup.config.ts): the interactive
-// components/hooks (everything under dist/, including shared chunks) and the
-// framework-agnostic helpers (dist/helpers/, no directive). esbuild drops
-// module-level directives during bundling, so we prepend `'use client'` to
-// every emitted .js file except the server-safe helpers entry. This keeps the
-// client boundary intact for React Server Component consumers while leaving
-// `prompt-area/helpers` usable on the server.
+// The library builds all entries together with code splitting (see
+// tsup.config.ts), so the framework-agnostic engine is emitted once as a shared
+// chunk imported by both the client components and the server-safe `./helpers`
+// entry. esbuild drops module-level directives during bundling, so we re-attach
+// `'use client'` here — but only to the client surface.
+//
+// The server-safe set is the import closure of `dist/helpers/index.js`: the
+// helpers entry plus the React-free engine chunks it pulls in. Every other
+// emitted `.js` is part of the interactive surface and gets the directive. This
+// keeps `prompt-area/helpers` (and the shared engine it imports) callable from
+// React Server Components while marking the client boundary everywhere else.
 import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs'
-import { join, sep } from 'node:path'
+import { join, dirname, resolve } from 'node:path'
 
 const dist = join(process.cwd(), 'dist')
-const serverDir = join(dist, 'helpers') + sep
 const DIRECTIVE_RE = /^\s*['"`]use client['"`]/
+// Relative specifiers in `from './x.js'`, `import './x.js'`, and `import('./x.js')`.
+const IMPORT_RE = /(?:from|import)\s*\(?\s*['"](\.[^'"]+)['"]/g
 
-let patched = 0
-function walk(dir) {
+function allJsFiles(dir) {
+  const out = []
   for (const name of readdirSync(dir)) {
     const path = join(dir, name)
-    if (statSync(path).isDirectory()) {
-      walk(path)
-      continue
-    }
-    if (!path.endsWith('.js')) continue
-    if (path.startsWith(serverDir)) continue
-    const code = readFileSync(path, 'utf8')
-    if (DIRECTIVE_RE.test(code)) continue
-    writeFileSync(path, `'use client';\n${code}`)
-    patched++
+    if (statSync(path).isDirectory()) out.push(...allJsFiles(path))
+    else if (path.endsWith('.js')) out.push(path)
+  }
+  return out
+}
+
+// Build the server-safe closure: files reachable from the helpers entry.
+const serverSafe = new Set()
+const queue = [join(dist, 'helpers', 'index.js')]
+while (queue.length) {
+  const file = queue.pop()
+  if (serverSafe.has(file)) continue
+  serverSafe.add(file)
+  const code = readFileSync(file, 'utf8')
+  for (const [, spec] of code.matchAll(IMPORT_RE)) {
+    queue.push(resolve(dirname(file), spec))
   }
 }
 
-walk(dist)
-console.log(`preserve-directives: prepended 'use client' to ${patched} file(s)`)
+let patched = 0
+for (const path of allJsFiles(dist)) {
+  if (serverSafe.has(path)) continue
+  const code = readFileSync(path, 'utf8')
+  if (DIRECTIVE_RE.test(code)) continue
+  writeFileSync(path, `'use client';\n${code}`)
+  patched++
+}
+
+console.log(
+  `preserve-directives: prepended 'use client' to ${patched} file(s); ` +
+    `left ${serverSafe.size} server-safe file(s) untouched`,
+)

--- a/packages/prompt-area/tsup.config.ts
+++ b/packages/prompt-area/tsup.config.ts
@@ -3,27 +3,25 @@ import { defineConfig, type Options } from 'tsup'
 /**
  * Builds the library to ESM with per-entry `.d.ts` files.
  *
- * Two builds run so React Server Component boundaries are correct:
+ * All entries build together with code splitting on, so the framework-agnostic
+ * engine (segment + trigger utilities, markdown parsing, types) is emitted once
+ * as a shared chunk instead of being re-bundled into both the components and the
+ * `./helpers` entry. This keeps the JS and the `.d.ts` output free of
+ * duplication.
  *
- * 1. The interactive surface (components, hooks, and the convenience
- *    barrels that re-export them) is emitted with a `'use client'` banner.
- *    The whole prompt-input experience is client-side, so this is the right
- *    boundary and means consumers can render the components directly from a
- *    Server Component.
- * 2. The framework-agnostic helpers (segment + engine utilities, trigger
- *    presets, and types) are emitted from `./helpers` with no directive, so
- *    they stay importable and callable from Server Components.
- *
- * esbuild strips module-level directives while bundling, so the `'use client'`
- * markers are re-attached after the build by scripts/preserve-directives.mjs
- * (every output except the `helpers/` entry).
+ * React Server Component boundaries are restored afterwards by
+ * scripts/preserve-directives.mjs. esbuild strips module-level directives while
+ * bundling, so the script re-attaches `'use client'` to exactly the files that
+ * need it: the client entry barrels and any chunk that imports React. The shared
+ * engine chunk imports no React and is left untouched, which is what keeps
+ * `prompt-area/helpers` importable and callable from Server Components.
  *
  * `react`, `react-dom`, and the runtime dependencies are externalized
  * automatically by tsup. The `@/lib/utils` and `@/registry/new-york/blocks/*`
  * aliases (kept in source for shadcn-registry consumers) are resolved via the
  * package tsconfig `paths`, which esbuild honors during bundling.
  */
-const shared = {
+export default defineConfig({
   format: ['esm'],
   dts: true,
   treeshake: true,
@@ -33,24 +31,14 @@ const shared = {
   sourcemap: false,
   clean: false,
   external: ['react', 'react-dom', 'react/jsx-runtime'],
-} satisfies Options
-
-export default defineConfig([
-  {
-    ...shared,
-    entry: {
-      index: 'src/index.ts',
-      'prompt-area/index': 'src/prompt-area/index.ts',
-      'action-bar/index': 'src/action-bar/index.ts',
-      'status-bar/index': 'src/status-bar/index.ts',
-      'compact-prompt-area/index': 'src/compact-prompt-area/index.ts',
-      'chat-prompt-layout/index': 'src/chat-prompt-layout/index.ts',
-    },
-    splitting: true,
+  splitting: true,
+  entry: {
+    index: 'src/index.ts',
+    'prompt-area/index': 'src/prompt-area/index.ts',
+    'action-bar/index': 'src/action-bar/index.ts',
+    'status-bar/index': 'src/status-bar/index.ts',
+    'compact-prompt-area/index': 'src/compact-prompt-area/index.ts',
+    'chat-prompt-layout/index': 'src/chat-prompt-layout/index.ts',
+    'helpers/index': 'src/helpers/index.ts',
   },
-  {
-    ...shared,
-    entry: { 'helpers/index': 'src/helpers/index.ts' },
-    splitting: false,
-  },
-])
+} satisfies Options)


### PR DESCRIPTION
## Summary

The `prompt-area` package shipped its React-free engine (segment/trigger utils, markdown parser) **twice** — once in the component chunks and again inlined into the `./helpers` entry — because `helpers` was built as a separate tsup pass purely so the `'use client'` banner script could skip it.

This unifies the build so the engine is emitted **once** as a shared chunk imported by both `helpers` and the components, and rewrites the banner script to keep the RSC boundary correct.

| | Before | After | Δ |
|---|---|---|---|
| Packed (tarball) | 36.4 KB | **32.9 KB** | −3.5 KB (−10%) |
| Unpacked | 133.8 KB | **117.3 KB** | −16.5 KB (−12%) |

## Changes

- **`tsup.config.ts`** — merged the two build passes into one `splitting: true` build. Shared engine now emits once as chunks shared across all entries.
- **`scripts/preserve-directives.mjs`** — band every emitted `.js` **except the import closure of `helpers/index.js`**, instead of "everything except `dist/helpers/`". Keeps `helpers` *and* the shared engine chunk server-safe while marking all client surfaces.

Where the bytes came from:
- `helpers/index.d.ts`: 13.65 → 7.33 KB
- `prompt-area/index.d.ts`: 12.63 → 6.13 KB
- Engine JS no longer duplicated (~4.6 KB inlined in `helpers` → shared chunk)

## Verification

- ✅ RSC boundary intact: `helpers/index.js` + both engine chunks have **no** `'use client'` and import no React; all component entries/chunks are banded.
- ✅ Engine chunks confirmed **shared** between `helpers` and the client components (real dedup, not relocation).
- ✅ `publint` "All good!", `attw` green (ESM/bundler), `tsc --noEmit` clean, **662/662 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)