### PR TITLE
chore(release): mark CHANGELOG 0.3.1

### DIFF
--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.3.1
 
 ### Changed
 


### PR DESCRIPTION
Promotes the `Unreleased` CHANGELOG entry to `0.3.1` ahead of cutting the release.

0.3.1 = the engine-dedup package-size reduction (smaller tarball, no API changes). Run `pnpm release 0.3.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)