### PR TITLE
Fix Tailwind v3 install conflict: drop build-tool peer deps

### DIFF
--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.3.2
+
+### Fixed
+
+- **Installs cleanly alongside Tailwind v3 (or no Tailwind).** `tailwindcss` and
+  `tw-animate-css` are no longer declared as (optional) peer dependencies — they
+  are build-time tools, and an optional peer still triggers an npm `ERESOLVE`
+  conflict when the consumer has a non-matching version (e.g. Tailwind v3)
+  installed. The prebuilt `prompt-area/styles.css` is self-contained and works
+  with any stack; the optional `prompt-area/tailwind.css` preset still requires
+  Tailwind v4 in your own project (documented, not version-gated). No API or
+  runtime changes.
+
 ## 0.3.1
 
 ### Changed

--- a/packages/prompt-area/README.md
+++ b/packages/prompt-area/README.md
@@ -111,9 +111,11 @@ The components are client components and carry a `'use client'` boundary, so you
 ## Dependencies
 
 - **Peer:** `react`, `react-dom` (>= 18)
-- **Optional peer:** `tailwindcss` (>= 4) and `tw-animate-css` — only needed if
-  you use the `prompt-area/tailwind.css` preset. The prebuilt
-  `prompt-area/styles.css` needs neither.
+- **Tailwind is not a peer dependency.** The prebuilt `prompt-area/styles.css`
+  is self-contained and works with **any** stack — Tailwind v4, v3, or no
+  Tailwind at all. The optional `prompt-area/tailwind.css` preset uses Tailwind
+  v4 syntax, so it requires Tailwind v4 in your own project; if you're on v3 or
+  not using Tailwind, use `styles.css` (and theme via the CSS variables above).
 - **Runtime:** `clsx`, `tailwind-merge` — the two `cn` helpers, both already
   present in any shadcn/Tailwind project.
 

--- a/packages/prompt-area/package.json
+++ b/packages/prompt-area/package.json
@@ -79,17 +79,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
-    "react-dom": ">=18",
-    "tailwindcss": ">=4",
-    "tw-animate-css": ">=1"
-  },
-  "peerDependenciesMeta": {
-    "tailwindcss": {
-      "optional": true
-    },
-    "tw-animate-css": {
-      "optional": true
-    }
+    "react-dom": ">=18"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Problem

Consumers on **Tailwind v3** can't `npm install prompt-area` — they hit `ERESOLVE`. `tailwindcss` was declared as an *optional* peer dep (`>=4`), but `optional: true` only suppresses the *missing*-peer case; npm still version-checks a **present-but-mismatched** install, so a v3 app conflicts against `>=4`.

## Fix

`tailwindcss` and `tw-animate-css` are build-time tools, not runtime deps:
- The prebuilt `prompt-area/styles.css` is **self-contained** (0 `@tailwind` directives, animations baked in) and works with any stack — v4, v3, or no Tailwind.
- Only the optional `prompt-area/tailwind.css` preset needs the consumer's own Tailwind v4 — a documented requirement, not something to version-gate at install.

So both are removed from `peerDependencies` / `peerDependenciesMeta` (kept as **devDependencies** for the build). Installs now resolve cleanly regardless of the consumer's Tailwind version, with no `--legacy-peer-deps` workaround.

## Not changed

- No API or runtime changes. `clsx` + `tailwind-merge` remain real deps.
- The v4 preset is unchanged; v3 users theme via the documented CSS variables.

## Verification

- ✅ Package build + publint "All good!" / attw clean
- ✅ `styles.css` still self-contained (0 `@tailwind`, `@keyframes` present)
- ✅ Ships as **0.3.2** (CHANGELOG + README updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)