### PR TITLE
Add live in-browser example (Sandpack) + Try it Live docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ public/r/
 
 # npm package build output
 packages/*/dist/
+
+# example app build output
+examples/*/dist/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A production-grade `contentEditable` rich text input. Install it **two ways from the same source**: an [npm package](https://www.npmjs.com/package/prompt-area) (`npm install prompt-area`) or a [shadcn registry](https://ui.shadcn.com/docs/registry) component you copy into your repo. Dependency-light either way.
 
+**Try it live:** [open the example in CodeSandbox](https://codesandbox.io/s/github/just-marketing/prompt-area/tree/main/examples/basic) — a full Vite + React app you can edit in the browser ([source](examples/basic)).
+
 ![Prompt Area](public/opengraph-image.png)
 
 ## Why Prompt Area?

--- a/app/docs/quick-start/page.tsx
+++ b/app/docs/quick-start/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { CodeBlock } from '@/components/code-block'
 import { CodeTabs } from '@/components/code-tabs'
 import { DocsLead, DocsP, DocsH2, Callout } from '@/components/docs/docs-primitives'
+import { OpenInCodeSandbox } from '@/components/open-in-codesandbox'
 
 const SITE_URL = 'https://prompt-area.com'
 
@@ -21,6 +22,15 @@ export default function QuickStartPage() {
         Build a working chat input in a few steps — state, mentions, commands, and structured output
         you can send straight to a model.
       </DocsLead>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <OpenInCodeSandbox />
+        <Link
+          href="/docs/try-it-live"
+          className="text-muted-foreground hover:text-foreground text-sm font-medium underline underline-offset-4 transition-colors">
+          Try it live in the browser
+        </Link>
+      </div>
 
       <DocsH2 id="render-with-state">Render with state</DocsH2>
       <DocsP>

--- a/app/docs/try-it-live/page.tsx
+++ b/app/docs/try-it-live/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { DocsLead, DocsP, DocsH2 } from '@/components/docs/docs-primitives'
+import { OpenInCodeSandbox, CODESANDBOX_EMBED_URL } from '@/components/open-in-codesandbox'
+
+const SITE_URL = 'https://prompt-area.com'
+const SOURCE_URL = 'https://github.com/just-marketing/prompt-area/tree/main/examples/basic'
+
+export const metadata: Metadata = {
+  title: 'Try it Live',
+  description:
+    'Boot a full Vite + React app using prompt-area in CodeSandbox — no local setup. Edit the code and see @mentions, /commands, and #tags update live.',
+  alternates: { canonical: `${SITE_URL}/docs/try-it-live` },
+}
+
+export default function TryItLivePage() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold tracking-tight">Try it Live</h1>
+      <DocsLead>
+        A complete Vite + React + TypeScript app that installs{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">prompt-area</code> from npm
+        and renders a{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">PromptArea</code> with{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">@</code>/
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">/</code>/
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">#</code> triggers — running
+        entirely in your browser.
+      </DocsLead>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <OpenInCodeSandbox />
+        <a
+          href={SOURCE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground text-sm font-medium underline underline-offset-4 transition-colors">
+          View the source
+        </a>
+      </div>
+
+      <DocsH2 id="live-editor">Live editor</DocsH2>
+      <DocsP>
+        Edit <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">src/App.tsx</code> on
+        the left and the preview updates on the right. The first load installs dependencies, so give
+        it a few seconds.
+      </DocsP>
+      <iframe
+        title="Prompt Area — live example on CodeSandbox"
+        src={CODESANDBOX_EMBED_URL}
+        loading="lazy"
+        className="h-[600px] w-full overflow-hidden rounded-lg border"
+        allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+        sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+      />
+
+      <DocsH2 id="run-locally">Run it locally</DocsH2>
+      <DocsP>
+        Prefer your own editor? Clone the repo and run the example directly — it uses the published
+        package, so it works in any React project the same way:
+      </DocsP>
+      <pre className="bg-muted overflow-x-auto rounded-lg p-4 font-mono text-sm">
+        {`git clone https://github.com/just-marketing/prompt-area
+cd prompt-area/examples/basic
+npm install
+npm run dev`}
+      </pre>
+
+      <DocsP>
+        New to the API? Start with the{' '}
+        <Link
+          href="/docs/quick-start"
+          className="text-foreground font-medium underline underline-offset-4">
+          Quick Start
+        </Link>
+        .
+      </DocsP>
+    </>
+  )
+}

--- a/components/open-in-codesandbox.tsx
+++ b/components/open-in-codesandbox.tsx
@@ -1,0 +1,29 @@
+import { ArrowUpRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Single source of truth for the live example on CodeSandbox. CodeSandbox boots
+// the `examples/basic` folder straight from GitHub — running `npm install` and
+// the Vite dev server in the browser.
+const REPO_PATH = 'just-marketing/prompt-area/tree/main/examples/basic'
+
+/** Launches the full CodeSandbox editor in a new tab. */
+export const CODESANDBOX_URL = `https://codesandbox.io/s/github/${REPO_PATH}`
+
+/** Embeds the running example inline (preview + editor). */
+export const CODESANDBOX_EMBED_URL = `https://codesandbox.io/embed/github/${REPO_PATH}?module=/src/App.tsx&view=split&hidenavigation=1&theme=dark`
+
+export function OpenInCodeSandbox({ className }: { className?: string }) {
+  return (
+    <a
+      href={CODESANDBOX_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        'hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm font-medium transition-colors',
+        className,
+      )}>
+      Open in CodeSandbox
+      <ArrowUpRight className="size-3.5" />
+    </a>
+  )
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextTypescript from 'eslint-config-next/typescript'
 import reactHooks from 'eslint-plugin-react-hooks'
 
 const eslintConfig = [
-  { ignores: ['next-env.d.ts', '.next/**', '**/dist/**', 'public/r/**'] },
+  { ignores: ['next-env.d.ts', '.next/**', '**/dist/**', 'public/r/**', 'examples/**'] },
   ...nextCoreWebVitals,
   ...nextTypescript,
   {

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,24 @@
+# Prompt Area — basic live example
+
+A minimal **Vite + React + TypeScript** app that installs [`prompt-area`](https://www.npmjs.com/package/prompt-area) from npm and renders a `PromptArea` with `@`/`/`/`#` triggers.
+
+## Try it live
+
+[**Open in CodeSandbox →**](https://codesandbox.io/s/github/just-marketing/prompt-area/tree/main/examples/basic)
+
+CodeSandbox boots this folder straight from GitHub — `npm install` and the Vite dev server run in your browser, no local setup required.
+
+## Run locally
+
+```bash
+npm install
+npm run dev
+```
+
+## What it shows
+
+- Importing the self-contained stylesheet: `import 'prompt-area/styles.css'` (no Tailwind required)
+- Trigger-based chips via the `triggers` prop (`@` mentions, `/` commands, `#` tags)
+- Reading the submitted value with `segmentsToPlainText`
+
+See [`src/App.tsx`](./src/App.tsx) for the full component.

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prompt Area — live example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "prompt-area-example-basic",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "prompt-area": "^0.3.2",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import { PromptArea, segmentsToPlainText, type Segment, type TriggerConfig } from 'prompt-area'
+
+const USERS = [
+  { value: 'ada', label: 'Ada Lovelace', description: 'Mathematician' },
+  { value: 'grace', label: 'Grace Hopper', description: 'Compilers' },
+  { value: 'linus', label: 'Linus Torvalds', description: 'Kernel' },
+  { value: 'margaret', label: 'Margaret Hamilton', description: 'Apollo' },
+]
+
+const COMMANDS = [
+  { value: 'summarize', label: 'summarize', description: 'Condense the text' },
+  { value: 'translate', label: 'translate', description: 'Translate to another language' },
+  { value: 'explain', label: 'explain', description: 'Explain like I’m five' },
+]
+
+const TAGS = [
+  { value: 'bug', label: 'bug' },
+  { value: 'feature', label: 'feature' },
+  { value: 'docs', label: 'docs' },
+]
+
+const search = (items: { value: string; label: string; description?: string }[]) => (q: string) =>
+  items.filter((i) => i.label.toLowerCase().includes(q.toLowerCase()))
+
+const triggers: TriggerConfig[] = [
+  { char: '@', position: 'any', mode: 'dropdown', onSearch: search(USERS) },
+  { char: '/', position: 'start', mode: 'dropdown', onSearch: search(COMMANDS) },
+  { char: '#', position: 'any', mode: 'dropdown', onSearch: search(TAGS) },
+]
+
+export function App() {
+  const [value, setValue] = useState<Segment[]>([])
+  const [submitted, setSubmitted] = useState<string | null>(null)
+
+  return (
+    <main>
+      <header>
+        <h1>Prompt Area</h1>
+        <p>
+          A dependency-light rich-text prompt input. Type <kbd>@</kbd>, <kbd>/</kbd>, or{' '}
+          <kbd>#</kbd> to trigger chips, then press <kbd>Enter</kbd> to submit.
+        </p>
+      </header>
+
+      <PromptArea
+        value={value}
+        onChange={setValue}
+        triggers={triggers}
+        placeholder="Message… try @ada, /summarize, #bug"
+        minHeight={56}
+        autoGrow
+        onSubmit={(segments) => {
+          setSubmitted(segmentsToPlainText(segments))
+          setValue([])
+        }}
+      />
+
+      {submitted !== null && (
+        <section className="result">
+          <span className="result__label">Submitted</span>
+          <pre>{submitted || '(empty)'}</pre>
+        </section>
+      )}
+
+      <footer>
+        <a href="https://prompt-area.com" target="_blank" rel="noreferrer">
+          prompt-area.com
+        </a>
+        {' · '}
+        <a href="https://www.npmjs.com/package/prompt-area" target="_blank" rel="noreferrer">
+          npm
+        </a>
+      </footer>
+    </main>
+  )
+}

--- a/examples/basic/src/main.tsx
+++ b/examples/basic/src/main.tsx
@@ -1,0 +1,14 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
+
+// The prebuilt, self-contained stylesheet — works with any stack (no Tailwind
+// required). This is the only CSS the components need.
+import 'prompt-area/styles.css'
+import './styles.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/examples/basic/src/styles.css
+++ b/examples/basic/src/styles.css
@@ -1,0 +1,83 @@
+/* Page chrome only — the PromptArea itself is styled by `prompt-area/styles.css`.
+   These styles use the same CSS variable names as the component (shadcn-style),
+   so the demo theming stays consistent. */
+:root {
+  --background: #ffffff;
+  --foreground: #0a0a0a;
+  --muted-foreground: #71717a;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+main {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+
+header p {
+  margin: 0;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+kbd {
+  font: inherit;
+  font-size: 0.85em;
+  padding: 0.05em 0.4em;
+  border: 1px solid #e4e4e7;
+  border-bottom-width: 2px;
+  border-radius: 0.35rem;
+  background: #fafafa;
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.result__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+}
+
+.result pre {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.5rem;
+  background: #fafafa;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+footer {
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+
+footer a {
+  color: inherit;
+}

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Minimal Vite + React setup so CodeSandbox (and a local `npm run dev`) can boot
+// the example straight from this folder.
+export default defineConfig({
+  plugins: [react()],
+  // The example ships plain CSS and needs no PostCSS plugins. Pin an empty
+  // config so Vite doesn't walk up and pick one up from a parent directory.
+  css: { postcss: {} },
+})

--- a/lib/docs-navigation.ts
+++ b/lib/docs-navigation.ts
@@ -20,6 +20,7 @@ export const docsNavigation: NavSection[] = [
       { title: 'Introduction', href: '/docs' },
       { title: 'Installation', href: '/docs/installation' },
       { title: 'Quick Start', href: '/docs/quick-start' },
+      { title: 'Try it Live', href: '/docs/try-it-live' },
     ],
   },
   {

--- a/packages/prompt-area/README.md
+++ b/packages/prompt-area/README.md
@@ -11,6 +11,8 @@ Ships **two ways** from the same source:
 - **npm package** (this package) — `npm install prompt-area`, import the component and a stylesheet. Versioned, opinionated, batteries-included.
 - **[shadcn registry](https://prompt-area.com)** — `npx shadcn@latest add https://prompt-area.com/r/prompt-area.json` to copy the source into your project and own it.
 
+**Try it live:** [open the example in CodeSandbox](https://codesandbox.io/s/github/just-marketing/prompt-area/tree/main/examples/basic) — a full Vite + React app, no setup. ([source](https://github.com/just-marketing/prompt-area/tree/main/examples/basic))
+
 ## Install
 
 ```bash

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "examples"]
 }


### PR DESCRIPTION
## Summary

Adds a runnable, in-browser example of `prompt-area` and surfaces it across the docs + READMEs.

### New: `examples/basic`
A self-contained **Vite + React + TypeScript** app that installs `prompt-area` from npm and renders a `PromptArea` with `@`/`/`/`#` triggers. CodeSandbox boots it straight from the GitHub subfolder (`npm install` + Vite dev server in the browser); it also runs locally with `npm run dev`.

### Surfaced two ways (as requested)
- **New `/docs/try-it-live` page** — embedded CodeSandbox runtime (live, editable inline) + "Open in CodeSandbox" button + local-run instructions. Wired into the docs nav after Quick Start.
- **Buttons/links** — "Open in CodeSandbox" on the Quick Start page, and "Try it live" links in the root + package READMEs.

### Isolation (so the standalone example doesn't break root tooling)
- Excluded `examples/` from the root `tsconfig` and ESLint (the example has its own module setup).
- Pinned an empty PostCSS config in the example so Vite doesn't inherit the monorepo root's Tailwind PostCSS config.
- Gitignored the example's `dist/` (node_modules + lockfile already ignored).

## Verification
- ✅ Example **type-checks** against the published `prompt-area@0.3.2` types
- ✅ Example **builds with Vite** (42 modules; `prompt-area/styles.css` bundled) — and `npm install` resolved with **no peer-dep errors**, validating the 0.3.2 fix in a real consumer install
- ✅ Docs site: `tsc` clean, `eslint` 0 errors, **Next production build** generates `/docs/try-it-live`

## Note
The CodeSandbox embed/import URL assumes the `examples/basic` folder exists on `main`, so the live link goes green once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)