### PR TITLE
Add Claude-style composer example to styles showcase

### DIFF
--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -148,9 +148,36 @@ function UsageRing({ pct }: { pct: number }) {
 }
 
 // The reasoning-effort control: a discrete Faster↔Smarter slider, mirroring
-// Claude Code's popover. Clicking a tick sets the level.
+// Claude Code's popover. Click anywhere on the track or drag the handle — it
+// snaps to the nearest level — and arrow keys nudge it for keyboard users.
 function EffortSlider({ value, onChange }: { value: Effort; onChange: (next: Effort) => void }) {
   const idx = EFFORTS.indexOf(value)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const pct = (idx / (EFFORTS.length - 1)) * 100
+
+  // Map a pointer x to the nearest step and commit it if it changed.
+  const setFromClientX = (clientX: number) => {
+    const el = trackRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width))
+    const next = Math.round(ratio * (EFFORTS.length - 1))
+    if (next !== idx) onChange(EFFORTS[next])
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    let next = idx
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = Math.max(0, idx - 1)
+    else if (e.key === 'ArrowRight' || e.key === 'ArrowUp')
+      next = Math.min(EFFORTS.length - 1, idx + 1)
+    else if (e.key === 'Home') next = 0
+    else if (e.key === 'End') next = EFFORTS.length - 1
+    else return
+    e.preventDefault()
+    if (next !== idx) onChange(EFFORTS[next])
+  }
+
   return (
     <div className="w-[232px] p-2">
       <div className="mb-2 flex items-center justify-between text-[14px] text-[#1f1e1d] dark:text-[#f5f4ee]">
@@ -163,30 +190,49 @@ function EffortSlider({ value, onChange }: { value: Effort; onChange: (next: Eff
         <span>Faster</span>
         <span>Smarter</span>
       </div>
-      <div className="relative mx-1 h-4">
-        <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-black/12 dark:bg-white/15" />
+      {/* Hit area is taller than the track so the handle is easy to grab. */}
+      <div
+        role="slider"
+        tabIndex={0}
+        aria-label="Effort"
+        aria-valuemin={0}
+        aria-valuemax={EFFORTS.length - 1}
+        aria-valuenow={idx}
+        aria-valuetext={value}
+        onKeyDown={onKeyDown}
+        onPointerDown={(e) => {
+          e.preventDefault()
+          e.currentTarget.setPointerCapture(e.pointerId)
+          setDragging(true)
+          setFromClientX(e.clientX)
+        }}
+        onPointerMove={(e) => dragging && setFromClientX(e.clientX)}
+        onPointerUp={(e) => {
+          setDragging(false)
+          e.currentTarget.releasePointerCapture(e.pointerId)
+        }}
+        className="relative mx-1 flex h-5 cursor-pointer touch-none items-center outline-none">
         <div
-          className="absolute top-1/2 left-0 h-[3px] -translate-y-1/2 rounded-full"
-          style={{ width: `${(idx / (EFFORTS.length - 1)) * 100}%`, background: ACCENT }}
-        />
-        <div className="absolute inset-0 flex items-center justify-between">
+          ref={trackRef}
+          className="relative h-[3px] w-full rounded-full bg-black/12 dark:bg-white/15">
+          <div
+            className="absolute inset-y-0 left-0 rounded-full"
+            style={{ width: `${pct}%`, background: ACCENT }}
+          />
           {EFFORTS.map((e, i) => (
-            <button
+            <span
               key={e}
-              type="button"
-              aria-label={e}
-              onClick={() => onChange(e)}
-              className="grid size-4 place-items-center">
-              {i === idx ? (
-                <span
-                  className="size-4 rounded-full border-2 bg-white shadow-sm dark:bg-[#30302e]"
-                  style={{ borderColor: ACCENT }}
-                />
-              ) : (
-                <span className="size-2 rounded-full bg-black/25 dark:bg-white/30" />
-              )}
-            </button>
+              className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-black/30 dark:bg-white/30"
+              style={{ left: `${(i / (EFFORTS.length - 1)) * 100}%` }}
+            />
           ))}
+          <span
+            className={cn(
+              'absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-white shadow-sm transition-transform dark:bg-[#30302e]',
+              dragging && 'scale-110',
+            )}
+            style={{ left: `${pct}%`, borderColor: ACCENT }}
+          />
         </div>
       </div>
     </div>
@@ -592,9 +638,31 @@ function UsageRing({ pct }: { pct: number }) {
   )
 }
 
-// Reasoning-effort control: a discrete Faster↔Smarter slider.
+// Reasoning-effort control: a discrete Faster↔Smarter slider. Click anywhere on
+// the track or drag the handle (snaps to the nearest level); arrows nudge it.
 function EffortSlider({ value, onChange }: { value: (typeof EFFORTS)[number]; onChange: (n: (typeof EFFORTS)[number]) => void }) {
   const idx = EFFORTS.indexOf(value)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const pct = (idx / (EFFORTS.length - 1)) * 100
+
+  const setFromClientX = (clientX: number) => {
+    const el = trackRef.current
+    if (!el) return
+    const ratio = Math.max(0, Math.min(1, (clientX - el.getBoundingClientRect().left) / el.clientWidth))
+    const next = Math.round(ratio * (EFFORTS.length - 1))
+    if (next !== idx) onChange(EFFORTS[next])
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    let next = idx
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = Math.max(0, idx - 1)
+    else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = Math.min(EFFORTS.length - 1, idx + 1)
+    else return
+    e.preventDefault()
+    if (next !== idx) onChange(EFFORTS[next])
+  }
+
   return (
     <div className="w-[232px] p-2">
       <div className="mb-2 flex items-center justify-between text-[14px]">
@@ -602,17 +670,20 @@ function EffortSlider({ value, onChange }: { value: (typeof EFFORTS)[number]; on
         <HelpCircle className={cn('size-3.5', MUTED)} />
       </div>
       <div className={cn('mb-2 flex justify-between text-[12px]', MUTED)}><span>Faster</span><span>Smarter</span></div>
-      <div className="relative mx-1 h-4">
-        <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-black/12 dark:bg-white/15" />
-        <div className="absolute top-1/2 left-0 h-[3px] -translate-y-1/2 rounded-full" style={{ width: \`\${(idx / (EFFORTS.length - 1)) * 100}%\`, background: ACCENT }} />
-        <div className="absolute inset-0 flex items-center justify-between">
+      <div
+        role="slider" tabIndex={0} aria-label="Effort"
+        aria-valuemin={0} aria-valuemax={EFFORTS.length - 1} aria-valuenow={idx} aria-valuetext={value}
+        onKeyDown={onKeyDown}
+        onPointerDown={(e) => { e.preventDefault(); e.currentTarget.setPointerCapture(e.pointerId); setDragging(true); setFromClientX(e.clientX) }}
+        onPointerMove={(e) => dragging && setFromClientX(e.clientX)}
+        onPointerUp={(e) => { setDragging(false); e.currentTarget.releasePointerCapture(e.pointerId) }}
+        className="relative mx-1 flex h-5 cursor-pointer touch-none items-center outline-none">
+        <div ref={trackRef} className="relative h-[3px] w-full rounded-full bg-black/12 dark:bg-white/15">
+          <div className="absolute inset-y-0 left-0 rounded-full" style={{ width: \`\${pct}%\`, background: ACCENT }} />
           {EFFORTS.map((e, i) => (
-            <button key={e} aria-label={e} onClick={() => onChange(e)} className="grid size-4 place-items-center">
-              {i === idx
-                ? <span className="size-4 rounded-full border-2 bg-white dark:bg-[#30302e]" style={{ borderColor: ACCENT }} />
-                : <span className="size-2 rounded-full bg-black/25 dark:bg-white/30" />}
-            </button>
+            <span key={e} className="absolute top-1/2 size-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-black/30 dark:bg-white/30" style={{ left: \`\${(i / (EFFORTS.length - 1)) * 100}%\` }} />
           ))}
+          <span className={cn('absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 bg-white shadow-sm transition-transform dark:bg-[#30302e]', dragging && 'scale-110')} style={{ left: \`\${pct}%\`, borderColor: ACCENT }} />
         </div>
       </div>
     </div>

--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -1,278 +1,783 @@
 'use client'
 
-import { useRef, useState } from 'react'
-import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X } from 'lucide-react'
-import { PromptArea, ActionBar, StatusBar, type Segment } from 'prompt-area'
+import { useEffect, useRef, useState } from 'react'
+import {
+  Cloud,
+  Plus,
+  Mic,
+  ChevronDown,
+  ChevronRight,
+  CornerDownLeft,
+  Check,
+  Settings,
+  ExternalLink,
+  HelpCircle,
+  Laptop,
+  ArrowRight,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  PromptArea,
+  ActionBar,
+  StatusBar,
+  isSegmentsEmpty,
+  type Segment,
+  type TriggerConfig,
+  type PromptAreaFile,
+} from 'prompt-area'
 import { useSubmittablePrompt } from './use-submittable-prompt'
 import { SubmittedPreview } from './submitted-preview'
 
-type AttachedFile = { id: string; name: string }
+// ---------------------------------------------------------------------------
+// Option data (representative placeholders)
+// ---------------------------------------------------------------------------
 
-const INITIAL_FILES: AttachedFile[] = [{ id: 'img-1', name: 'image.png' }]
+type CcModel = { id: string; name: string; shortcut?: string; unavailable?: boolean }
 
-const INITIAL_SEGMENTS: Segment[] = [
-  {
-    type: 'text',
-    text: "Let's replicate the spacing and general UI/UX of this input.",
-  },
+const MODELS: CcModel[] = [
+  { id: 'fable-5', name: 'Fable 5', unavailable: true },
+  { id: 'opus-4.8', name: 'Opus 4.8', shortcut: '1' },
+  { id: 'sonnet-4.6', name: 'Sonnet 4.6', shortcut: '2' },
+  { id: 'haiku-4.5', name: 'Haiku 4.5', shortcut: '3' },
 ]
 
-const MODELS = ['Opus 4.8', 'Sonnet 4.6', 'Haiku 4.5'] as const
+const PERMISSION_MODES = [
+  'Ask each time',
+  'Accept edits',
+  'Plan mode',
+  'Bypass permissions',
+] as const
+type Permission = (typeof PERMISSION_MODES)[number]
 
-export function ClaudeCodeInputExample() {
+const EFFORTS = ['Low', 'Medium', 'High', 'Max'] as const
+type Effort = (typeof EFFORTS)[number]
+
+const CLOUD_ENVS = ['Automated Testing Env', 'Default'] as const
+
+const USAGE: { label: string; meta: string; pct: number | null }[] = [
+  { label: '5-hour limit', meta: 'Resets 10:00 PM', pct: 7 },
+  { label: 'Weekly · all models', meta: 'Resets Jun 21', pct: 21 },
+  { label: 'Sonnet only', meta: 'Resets Jun 21', pct: 2 },
+  { label: 'Usage credits', meta: '$0.00 of $20.00', pct: null },
+]
+// Drives the usage donut in the control bar.
+const PLAN_PCT = 21
+
+// The blue Claude Code uses for usage meters and the dictation "recording" state.
+const ACCENT = '#2c7fff'
+
+// Shared class fragments, following the per-example naming convention. Colors are
+// pinned to Claude's warm neutral palette (light + dark) rather than the docs theme
+// so the composer reads as Claude Code on any page.
+const MUTED = 'text-[#8a887f] dark:text-[#92908a]'
+// Filled context chip (repo / environment row, above the input).
+const CHIP =
+  'inline-flex h-7 items-center gap-1.5 rounded-md bg-black/[0.05] px-2.5 text-[13px] text-[#37352f] transition-colors hover:bg-black/[0.08] aria-[expanded=true]:bg-black/[0.09] dark:bg-white/[0.07] dark:text-[#e8e6df] dark:hover:bg-white/[0.10] dark:aria-[expanded=true]:bg-white/[0.12]'
+// Ghost text control (control bar, below the input).
+const GHOST =
+  'inline-flex h-7 items-center gap-1 rounded-md px-2 text-[13px] text-[#5a5851] transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] aria-[expanded=true]:bg-black/[0.06] aria-[expanded=true]:text-[#1f1e1d] dark:text-[#b3b1a8] dark:hover:bg-white/[0.07] dark:hover:text-[#f5f4ee] dark:aria-[expanded=true]:bg-white/[0.08] dark:aria-[expanded=true]:text-[#f5f4ee]'
+// Ghost icon square.
+const GHOST_SQ =
+  'inline-flex size-7 shrink-0 items-center justify-center rounded-md text-[#5a5851] transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] dark:text-[#b3b1a8] dark:hover:bg-white/[0.07] dark:hover:text-[#f5f4ee]'
+// Popover panel + menu row.
+const PANEL =
+  'absolute z-30 flex flex-col rounded-xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e] dark:shadow-[0_12px_36px_rgba(0,0,0,0.55)]'
+const ROW =
+  'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[14px] text-[#1f1e1d] transition-colors hover:bg-black/[0.05] dark:text-[#f5f4ee] dark:hover:bg-white/[0.06]'
+const DIVIDER = 'mx-1 my-1 h-px bg-black/[0.08] dark:bg-white/10'
+
+// One open-state wrapper for every popover so only one is open at a time. The
+// `render` prop draws the trigger (each looks different); the panel shares chrome.
+function Popover({
+  id,
+  openMenu,
+  setOpenMenu,
+  panelClass,
+  render,
+  children,
+}: {
+  id: string
+  openMenu: string | null
+  setOpenMenu: (next: string | null) => void
+  panelClass: string
+  render: (open: boolean, toggle: () => void) => React.ReactNode
+  children: React.ReactNode
+}) {
+  const open = openMenu === id
+  return (
+    <div className="relative">
+      {render(open, () => setOpenMenu(open ? null : id))}
+      {open && (
+        <div role="menu" className={cn(PANEL, panelClass)}>
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// The small donut in the control bar — a faint track with an accent arc showing
+// how much of the plan window is used.
+function UsageRing({ pct }: { pct: number }) {
+  const r = 5
+  const c = 2 * Math.PI * r
+  return (
+    <svg width="14" height="14" viewBox="0 0 12 12" className="-rotate-90" aria-hidden>
+      <circle
+        cx="6"
+        cy="6"
+        r={r}
+        fill="none"
+        strokeWidth="2"
+        stroke="currentColor"
+        className="text-black/15 dark:text-white/20"
+      />
+      <circle
+        cx="6"
+        cy="6"
+        r={r}
+        fill="none"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={c * (1 - pct / 100)}
+        style={{ stroke: ACCENT }}
+      />
+    </svg>
+  )
+}
+
+// The reasoning-effort control: a discrete Faster↔Smarter slider, mirroring
+// Claude Code's popover. Clicking a tick sets the level.
+function EffortSlider({ value, onChange }: { value: Effort; onChange: (next: Effort) => void }) {
+  const idx = EFFORTS.indexOf(value)
+  return (
+    <div className="w-[232px] p-2">
+      <div className="mb-2 flex items-center justify-between text-[14px] text-[#1f1e1d] dark:text-[#f5f4ee]">
+        <span>
+          Effort <span className="font-medium">{value}</span>
+        </span>
+        <HelpCircle className={cn('size-3.5', MUTED)} />
+      </div>
+      <div className={cn('mb-2 flex justify-between text-[12px]', MUTED)}>
+        <span>Faster</span>
+        <span>Smarter</span>
+      </div>
+      <div className="relative mx-1 h-4">
+        <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-black/12 dark:bg-white/15" />
+        <div
+          className="absolute top-1/2 left-0 h-[3px] -translate-y-1/2 rounded-full"
+          style={{ width: `${(idx / (EFFORTS.length - 1)) * 100}%`, background: ACCENT }}
+        />
+        <div className="absolute inset-0 flex items-center justify-between">
+          {EFFORTS.map((e, i) => (
+            <button
+              key={e}
+              type="button"
+              aria-label={e}
+              onClick={() => onChange(e)}
+              className="grid size-4 place-items-center">
+              {i === idx ? (
+                <span
+                  className="size-4 rounded-full border-2 bg-white shadow-sm dark:bg-[#30302e]"
+                  style={{ borderColor: ACCENT }}
+                />
+              ) : (
+                <span className="size-2 rounded-full bg-black/25 dark:bg-white/30" />
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ClaudeCodeInputExample({
+  initialSegments = [],
+  initialFiles = [],
+  triggers,
+  markdown = false,
+}: {
+  initialSegments?: Segment[]
+  initialFiles?: PromptAreaFile[]
+  triggers?: TriggerConfig[]
+  markdown?: boolean
+} = {}) {
   const { segments, setSegments, files, setFiles, submitted, promptRef, submit, reset } =
-    useSubmittablePrompt<AttachedFile>({
-      initialSegments: INITIAL_SEGMENTS,
-      initialFiles: INITIAL_FILES,
-    })
-  const [selectedModel, setSelectedModel] = useState<string>(MODELS[0])
-  const [modelMenuOpen, setModelMenuOpen] = useState(false)
-  const [planMode, setPlanMode] = useState(false)
-  const modelMenuRef = useRef<HTMLDivElement>(null)
+    useSubmittablePrompt<PromptAreaFile>({ initialSegments, initialFiles })
 
-  const isEmpty =
-    segments.length === 0 ||
-    (segments.length === 1 && segments[0].type === 'text' && segments[0].text === '')
+  const [model, setModel] = useState<CcModel>(MODELS[1])
+  const [permission, setPermission] = useState<Permission>('Accept edits')
+  const [effort, setEffort] = useState<Effort>('High')
+  const [environment, setEnvironment] = useState<string>('Default')
+
+  // Single source of truth for which popover is open — only one at a time.
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const isEmpty = isSegmentsEmpty(segments)
+
+  // Close the open popover on outside click or Escape.
+  useEffect(() => {
+    if (!openMenu) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpenMenu(null)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenu(null)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [openMenu])
 
   return (
-    <div className="flex flex-col gap-2">
-      {/* Main input container */}
-      <div className="rounded-xl border">
-        <div className="p-4 pb-2">
-          {files.length > 0 && (
-            <div className="mb-2 flex flex-wrap gap-1.5">
-              {files.map((file) => (
-                <span
-                  key={file.id}
-                  className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs">
-                  <File className="size-3.5" />
-                  {file.name}
-                  <button
-                    type="button"
-                    className="hover:text-foreground -mr-0.5 rounded transition-colors"
-                    aria-label={`Remove ${file.name}`}
-                    onClick={() => setFiles((prev) => prev.filter((x) => x.id !== file.id))}>
-                    <X className="size-3" />
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
-          <PromptArea
-            ref={promptRef}
-            value={segments}
-            onChange={setSegments}
-            placeholder="Ask anything..."
-            onSubmit={submit}
-            autoGrow
-            minHeight={48}
-            maxHeight={280}
-          />
-          <ActionBar
-            className="pt-1.5"
-            left={
-              <div className="flex items-center gap-1.5">
+    <div className="flex flex-col gap-2" ref={rootRef}>
+      {/* Context row: environment + repository, above the input */}
+      <StatusBar
+        className="px-1 py-0"
+        left={
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Popover
+              id="env"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              panelClass="top-full left-0 mt-1.5 w-[264px]"
+              render={(open, toggle) => (
                 <button
                   type="button"
-                  className="text-muted-foreground hover:bg-accent hover:text-foreground flex size-8 items-center justify-center rounded-lg transition-colors"
-                  aria-label="Add attachment">
-                  <Plus className="size-4" />
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  onClick={toggle}
+                  className={CHIP}>
+                  <Cloud className="size-3.5" />
+                  <span className="max-w-[160px] truncate">{environment}</span>
                 </button>
-                <button
-                  type="button"
-                  onClick={() => setPlanMode((v) => !v)}
-                  className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                    planMode
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted text-muted-foreground hover:text-foreground'
-                  }`}>
-                  <LayoutList className="size-3.5" />
-                  Plan mode
-                </button>
+              )}>
+              <div className={cn(ROW, 'cursor-default opacity-45 hover:bg-transparent')}>
+                <Laptop className="size-4" />
+                <span className="flex-1">Local</span>
+                <span className={cn('text-[12px]', MUTED)}>Desktop only</span>
               </div>
-            }
-            right={
-              <div className="flex items-center gap-2">
-                {/* Model selector */}
-                <div className="relative" ref={modelMenuRef}>
-                  <button
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
-                    onClick={() => setModelMenuOpen((v) => !v)}>
-                    {selectedModel}
-                    <ChevronDown className="size-3" />
-                  </button>
-                  {modelMenuOpen && (
-                    <div className="bg-popover absolute right-0 bottom-full z-10 mb-1 flex w-max flex-col rounded-md border p-1 shadow-md">
-                      {MODELS.map((model) => (
-                        <button
-                          key={model}
-                          type="button"
-                          className={`hover:bg-accent flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm ${
-                            model === selectedModel ? 'bg-accent' : ''
-                          }`}
-                          onClick={() => {
-                            setSelectedModel(model)
-                            setModelMenuOpen(false)
-                          }}>
-                          {model}
-                        </button>
-                      ))}
+              <div className={DIVIDER} />
+              <div className={cn('px-2.5 pt-1 pb-1 text-[12px]', MUTED)}>Cloud</div>
+              {CLOUD_ENVS.map((env) => (
+                <button
+                  key={env}
+                  type="button"
+                  className={ROW}
+                  onClick={() => {
+                    setEnvironment(env)
+                    setOpenMenu(null)
+                  }}>
+                  <Cloud className="size-4" />
+                  <span className="flex-1 truncate">{env}</span>
+                  {env === environment && <Check className="size-3.5" />}
+                  <Settings className={cn('size-3.5', MUTED)} />
+                </button>
+              ))}
+              <button type="button" className={cn(ROW, MUTED)}>
+                <Plus className="size-4" />
+                Add cloud environment…
+              </button>
+              <div className={DIVIDER} />
+              <div className={cn('px-2.5 pt-1 pb-1 text-[12px]', MUTED)}>Remote Control</div>
+              <div className="px-2.5 py-1.5">
+                <div className="text-[14px] font-medium text-[#1f1e1d] dark:text-[#f5f4ee]">
+                  Set up Remote Control
+                </div>
+                <div className={cn('mt-0.5 flex items-start gap-1.5 text-[12px]', MUTED)}>
+                  <ExternalLink className="mt-0.5 size-3.5 shrink-0" />
+                  <span>
+                    Run{' '}
+                    <code className="rounded bg-black/[0.06] px-1 py-0.5 text-[11px] dark:bg-white/[0.08]">
+                      claude rc
+                    </code>{' '}
+                    on your machine to code from here.
+                  </span>
+                </div>
+              </div>
+            </Popover>
+
+            <button type="button" className={CHIP}>
+              <Plus className="size-3.5" />
+              Select repo…
+            </button>
+          </div>
+        }
+      />
+
+      {/* Input box with an inline return/send arrow */}
+      <div
+        onClick={() => promptRef.current?.focus()}
+        className={cn(
+          'cursor-text rounded-2xl border border-black/[0.08] bg-white transition-colors',
+          'shadow-[0_1px_2px_rgba(0,0,0,0.04)] focus-within:border-black/[0.16]',
+          'dark:border-white/[0.10] dark:bg-[#30302e] dark:shadow-none dark:focus-within:border-white/[0.18]',
+          '[--prompt-area-surface:#ffffff] dark:[--prompt-area-surface:#30302e]',
+          '[--prompt-area-placeholder:#8a887f] dark:[--prompt-area-placeholder:#92908a]',
+        )}>
+        <div className="flex items-end gap-1 py-1.5 pr-1.5 pl-3.5">
+          <div className="min-w-0 flex-1 py-1.5 text-[16px] leading-6 text-[#1f1e1d] dark:text-[#f5f4ee]">
+            <PromptArea
+              ref={promptRef}
+              value={segments}
+              onChange={setSegments}
+              triggers={triggers}
+              placeholder="Describe a task or ask a question"
+              onSubmit={submit}
+              markdown={markdown}
+              autoGrow
+              minHeight={28}
+              maxHeight={216}
+              files={files}
+              filePosition="above"
+              onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => submit(segments)}
+            disabled={isEmpty}
+            aria-label="Send"
+            className={cn(GHOST_SQ, 'self-end disabled:opacity-40 disabled:hover:bg-transparent')}>
+            <CornerDownLeft className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Control bar: permission + dictation on the left, model + effort + usage on the right */}
+      <ActionBar
+        className="px-1 pt-0"
+        left={
+          <div className="flex items-center gap-0.5">
+            <Popover
+              id="permission"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              panelClass="bottom-full left-0 mb-1.5 w-[208px]"
+              render={(open, toggle) => (
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  onClick={toggle}
+                  className={GHOST}>
+                  {permission}
+                </button>
+              )}>
+              {PERMISSION_MODES.map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  className={ROW}
+                  onClick={() => {
+                    setPermission(mode)
+                    setOpenMenu(null)
+                  }}>
+                  <span className="flex-1">{mode}</span>
+                  {mode === permission && <Check className="size-3.5" />}
+                </button>
+              ))}
+            </Popover>
+
+            <button type="button" className={GHOST_SQ} aria-label="Add">
+              <Plus className="size-4" />
+            </button>
+
+            {/* Dictation: press-and-hold mic + a settings chevron, grouped as one pill */}
+            <div className="inline-flex h-7 items-center text-[#5a5851] dark:text-[#b3b1a8]">
+              <button
+                type="button"
+                aria-label="Press and hold to record"
+                className="flex h-full items-center rounded-l-md pr-1 pl-2 transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] dark:hover:bg-white/[0.07] dark:hover:text-[#f5f4ee]">
+                <Mic className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label="Dictation settings"
+                className="flex h-full items-center rounded-r-md pr-1.5 pl-0.5 transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] dark:hover:bg-white/[0.07] dark:hover:text-[#f5f4ee]">
+                <ChevronDown className="size-3 opacity-70" />
+              </button>
+            </div>
+          </div>
+        }
+        right={
+          <div className="flex items-center gap-0.5">
+            <Popover
+              id="model"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              panelClass="bottom-full right-0 mb-1.5 w-[236px]"
+              render={(open, toggle) => (
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  onClick={toggle}
+                  className={GHOST}>
+                  {model.name}
+                </button>
+              )}>
+              <div className="flex items-center justify-between px-2.5 pt-1 pb-1.5">
+                <span className={cn('text-[12px]', MUTED)}>Models</span>
+                <span className="flex items-center gap-0.5">
+                  {['⇧', '⌘', 'I'].map((k) => (
+                    <kbd
+                      key={k}
+                      className={cn(
+                        'rounded bg-black/[0.06] px-1 py-0.5 text-[11px] dark:bg-white/[0.08]',
+                        MUTED,
+                      )}>
+                      {k}
+                    </kbd>
+                  ))}
+                </span>
+              </div>
+              {MODELS.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  disabled={m.unavailable}
+                  className={cn(ROW, m.unavailable && 'opacity-45 hover:bg-transparent')}
+                  onClick={() => {
+                    if (m.unavailable) return
+                    setModel(m)
+                    setOpenMenu(null)
+                  }}>
+                  <span className="flex-1">
+                    {m.name}
+                    {m.unavailable && (
+                      <span className={cn('ml-1.5', MUTED)}>Currently unavailable</span>
+                    )}
+                  </span>
+                  {m.id === model.id && <Check className="size-3.5" />}
+                  {m.shortcut && (
+                    <span className={cn('w-3 text-right text-[13px]', MUTED)}>{m.shortcut}</span>
+                  )}
+                </button>
+              ))}
+              <div className={DIVIDER} />
+              <button type="button" className={ROW}>
+                <span className="flex-1">More models</span>
+                <ChevronRight className={cn('size-3.5', MUTED)} />
+              </button>
+            </Popover>
+
+            <Popover
+              id="effort"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              panelClass="bottom-full right-0 mb-1.5"
+              render={(open, toggle) => (
+                <button
+                  type="button"
+                  aria-haspopup="dialog"
+                  aria-expanded={open}
+                  onClick={toggle}
+                  className={GHOST}>
+                  {effort}
+                </button>
+              )}>
+              <EffortSlider value={effort} onChange={setEffort} />
+            </Popover>
+
+            <Popover
+              id="usage"
+              openMenu={openMenu}
+              setOpenMenu={setOpenMenu}
+              panelClass="bottom-full right-0 mb-1.5 w-[300px]"
+              render={(open, toggle) => (
+                <button
+                  type="button"
+                  aria-haspopup="dialog"
+                  aria-expanded={open}
+                  aria-label={`Usage: plan ${PLAN_PCT}%`}
+                  onClick={toggle}
+                  className={GHOST_SQ}>
+                  <UsageRing pct={PLAN_PCT} />
+                </button>
+              )}>
+              <div className="flex items-center justify-between px-2.5 pt-1 pb-1.5">
+                <span className={cn('text-[13px]', MUTED)}>Plan usage</span>
+                <ArrowRight className={cn('size-3.5', MUTED)} />
+              </div>
+              {USAGE.map((u) => (
+                <div key={u.label} className="px-2.5 py-1.5">
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span className="text-[#1f1e1d] dark:text-[#f5f4ee]">{u.label}</span>
+                    <span className={cn('flex items-center gap-3', MUTED)}>
+                      <span>{u.meta}</span>
+                      {u.pct != null && <span>{u.pct}%</span>}
+                    </span>
+                  </div>
+                  {u.pct != null && (
+                    <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                      <div
+                        className="h-full rounded-full"
+                        style={{ width: `${u.pct}%`, background: ACCENT }}
+                      />
                     </div>
                   )}
                 </div>
-
-                {/* Submit button */}
-                <button
-                  type="button"
-                  onClick={() => submit(segments)}
-                  disabled={isEmpty}
-                  className="bg-primary text-primary-foreground hover:bg-primary/90 flex size-8 items-center justify-center rounded-full transition-colors disabled:opacity-50"
-                  aria-label="Send message">
-                  <ArrowUp className="size-4" />
-                </button>
-              </div>
-            }
-          />
-        </div>
-
-        {/* Status bar */}
-        <StatusBar
-          className="rounded-b-xl border-t px-4 py-2"
-          left={
-            <div className="flex items-center gap-2">
-              <span className="bg-muted rounded px-2 py-0.5 text-xs font-medium">prompt-area</span>
-              <div className="text-muted-foreground flex items-center gap-1">
-                <GitBranch className="size-3" />
-                <span className="text-xs">main</span>
-              </div>
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-foreground flex size-5 items-center justify-center rounded transition-colors"
-                aria-label="Add project">
-                <Plus className="size-3" />
-              </button>
-            </div>
-          }
-          right={
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors">
-              <Cloud className="size-3" />
-              Default
-              <ChevronDown className="size-3" />
-            </button>
-          }
-        />
-      </div>
+              ))}
+            </Popover>
+          </div>
+        }
+      />
 
       <SubmittedPreview text={submitted?.text} onReset={reset} />
     </div>
   )
 }
 
-export const claudeCodeInputCode = `import { useCallback, useRef, useState } from 'react'
-import { Plus, ArrowUp, ChevronDown, GitBranch, Cloud, LayoutList, File, X, RotateCcw } from 'lucide-react'
-import { PromptArea } from '@/components/prompt-area'
-import { ActionBar } from '@/components/action-bar'
-import { StatusBar } from '@/components/status-bar'
+export const claudeCodeInputCode = `import { useEffect, useRef, useState } from 'react'
+import { Cloud, Plus, Mic, ChevronDown, ChevronRight, CornerDownLeft, Check, Settings, ExternalLink, HelpCircle, Laptop, ArrowRight, RotateCcw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PromptArea, ActionBar, StatusBar, isSegmentsEmpty } from '@/components/prompt-area'
 import type { Segment, PromptAreaHandle } from '@/components/types'
 
-type AttachedFile = { id: string; name: string }
-const INITIAL_FILES: AttachedFile[] = [{ id: 'img-1', name: 'image.png' }]
+type CcModel = { id: string; name: string; shortcut?: string; unavailable?: boolean }
+const MODELS: CcModel[] = [
+  { id: 'fable-5', name: 'Fable 5', unavailable: true },
+  { id: 'opus-4.8', name: 'Opus 4.8', shortcut: '1' },
+  { id: 'sonnet-4.6', name: 'Sonnet 4.6', shortcut: '2' },
+  { id: 'haiku-4.5', name: 'Haiku 4.5', shortcut: '3' },
+]
+const PERMISSION_MODES = ['Ask each time', 'Accept edits', 'Plan mode', 'Bypass permissions'] as const
+const EFFORTS = ['Low', 'Medium', 'High', 'Max'] as const
+const CLOUD_ENVS = ['Automated Testing Env', 'Default'] as const
+const USAGE = [
+  { label: '5-hour limit', meta: 'Resets 10:00 PM', pct: 7 },
+  { label: 'Weekly · all models', meta: 'Resets Jun 21', pct: 21 },
+  { label: 'Sonnet only', meta: 'Resets Jun 21', pct: 2 },
+  { label: 'Usage credits', meta: '$0.00 of $20.00', pct: null as number | null },
+]
+const PLAN_PCT = 21
+const ACCENT = '#2c7fff' // usage meters + recording state
+
+const MUTED = 'text-[#8a887f] dark:text-[#92908a]'
+const CHIP = 'inline-flex h-7 items-center gap-1.5 rounded-md bg-black/[0.05] px-2.5 text-[13px] text-[#37352f] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.07] dark:text-[#e8e6df] dark:hover:bg-white/[0.10]'
+const GHOST = 'inline-flex h-7 items-center gap-1 rounded-md px-2 text-[13px] text-[#5a5851] transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] aria-[expanded=true]:bg-black/[0.06] dark:text-[#b3b1a8] dark:hover:bg-white/[0.07]'
+const GHOST_SQ = 'inline-flex size-7 shrink-0 items-center justify-center rounded-md text-[#5a5851] transition-colors hover:bg-black/[0.05] hover:text-[#1f1e1d] dark:text-[#b3b1a8] dark:hover:bg-white/[0.07]'
+const PANEL = 'absolute z-30 flex flex-col rounded-xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e]'
+const ROW = 'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-[14px] text-[#1f1e1d] transition-colors hover:bg-black/[0.05] dark:text-[#f5f4ee] dark:hover:bg-white/[0.06]'
+const DIVIDER = 'mx-1 my-1 h-px bg-black/[0.08] dark:bg-white/10'
+
+// One open-state wrapper for every popover so only one is open at a time.
+function Popover({ id, openMenu, setOpenMenu, panelClass, render, children }: {
+  id: string; openMenu: string | null; setOpenMenu: (n: string | null) => void
+  panelClass: string; render: (open: boolean, toggle: () => void) => React.ReactNode; children: React.ReactNode
+}) {
+  const open = openMenu === id
+  return (
+    <div className="relative">
+      {render(open, () => setOpenMenu(open ? null : id))}
+      {open && <div role="menu" className={cn(PANEL, panelClass)}>{children}</div>}
+    </div>
+  )
+}
+
+function UsageRing({ pct }: { pct: number }) {
+  const r = 5, c = 2 * Math.PI * r
+  return (
+    <svg width="14" height="14" viewBox="0 0 12 12" className="-rotate-90" aria-hidden>
+      <circle cx="6" cy="6" r={r} fill="none" strokeWidth="2" stroke="currentColor" className="text-black/15 dark:text-white/20" />
+      <circle cx="6" cy="6" r={r} fill="none" strokeWidth="2" strokeLinecap="round" strokeDasharray={c} strokeDashoffset={c * (1 - pct / 100)} style={{ stroke: ACCENT }} />
+    </svg>
+  )
+}
+
+// Reasoning-effort control: a discrete Faster↔Smarter slider.
+function EffortSlider({ value, onChange }: { value: (typeof EFFORTS)[number]; onChange: (n: (typeof EFFORTS)[number]) => void }) {
+  const idx = EFFORTS.indexOf(value)
+  return (
+    <div className="w-[232px] p-2">
+      <div className="mb-2 flex items-center justify-between text-[14px]">
+        <span>Effort <span className="font-medium">{value}</span></span>
+        <HelpCircle className={cn('size-3.5', MUTED)} />
+      </div>
+      <div className={cn('mb-2 flex justify-between text-[12px]', MUTED)}><span>Faster</span><span>Smarter</span></div>
+      <div className="relative mx-1 h-4">
+        <div className="absolute inset-x-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full bg-black/12 dark:bg-white/15" />
+        <div className="absolute top-1/2 left-0 h-[3px] -translate-y-1/2 rounded-full" style={{ width: \`\${(idx / (EFFORTS.length - 1)) * 100}%\`, background: ACCENT }} />
+        <div className="absolute inset-0 flex items-center justify-between">
+          {EFFORTS.map((e, i) => (
+            <button key={e} aria-label={e} onClick={() => onChange(e)} className="grid size-4 place-items-center">
+              {i === idx
+                ? <span className="size-4 rounded-full border-2 bg-white dark:bg-[#30302e]" style={{ borderColor: ACCENT }} />
+                : <span className="size-2 rounded-full bg-black/25 dark:bg-white/30" />}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 function ClaudeCodeInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
-  const [files, setFiles] = useState<AttachedFile[]>(INITIAL_FILES)
   // Snapshot of the last submission so Reset can restore it for another send.
-  const [submitted, setSubmitted] = useState<{ segments: Segment[]; files: AttachedFile[] } | null>(null)
-  const [selectedModel, setSelectedModel] = useState('Opus 4.8')
-  const [planMode, setPlanMode] = useState(false)
+  const [submitted, setSubmitted] = useState<Segment[] | null>(null)
+  const [model, setModel] = useState<CcModel>(MODELS[1])
+  const [permission, setPermission] = useState<(typeof PERMISSION_MODES)[number]>('Accept edits')
+  const [effort, setEffort] = useState<(typeof EFFORTS)[number]>('High')
+  const [environment, setEnvironment] = useState('Default')
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   const promptRef = useRef<PromptAreaHandle>(null)
 
+  const isEmpty = isSegmentsEmpty(segments)
+
   const submit = (segs: Segment[]) => {
-    if (!segs.length) return
-    setSubmitted({ segments: segs, files })
-    promptRef.current?.clear()
-    setSegments([])
-    setFiles([])
+    if (isSegmentsEmpty(segs)) return
+    setSubmitted(segs); promptRef.current?.clear(); setSegments([])
   }
-  const reset = () => {
-    if (submitted) { setSegments(submitted.segments); setFiles(submitted.files) }
-    setSubmitted(null)
-    promptRef.current?.focus()
-  }
+  const reset = () => { if (submitted) setSegments(submitted); setSubmitted(null); promptRef.current?.focus() }
+
+  // Close the open popover on outside click.
+  useEffect(() => {
+    if (!openMenu) return
+    const onDown = (e: MouseEvent) => { if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpenMenu(null) }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [openMenu])
 
   return (
-    <div className="rounded-xl border">
-      <div className="p-4 pb-2">
-        {/* Compact file chips */}
-        {files.length > 0 && (
-          <div className="mb-2 flex flex-wrap gap-1.5">
-            {files.map((file) => (
-              <span key={file.id} className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs">
-                <File className="size-3.5" />
-                {file.name}
-                <button onClick={() => setFiles((prev) => prev.filter((x) => x.id !== file.id))}>
-                  <X className="size-3" />
-                </button>
-              </span>
+    <div className="flex flex-col gap-2" ref={rootRef}>
+      {/* Context row: environment + repository */}
+      <StatusBar className="px-1 py-0" left={
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Popover id="env" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="top-full left-0 mt-1.5 w-[264px]"
+            render={(open, toggle) => (
+              <button aria-haspopup="menu" aria-expanded={open} onClick={toggle} className={CHIP}>
+                <Cloud className="size-3.5" /><span className="max-w-[160px] truncate">{environment}</span>
+              </button>
+            )}>
+            <div className={cn(ROW, 'cursor-default opacity-45 hover:bg-transparent')}>
+              <Laptop className="size-4" /><span className="flex-1">Local</span><span className={cn('text-[12px]', MUTED)}>Desktop only</span>
+            </div>
+            <div className={DIVIDER} />
+            <div className={cn('px-2.5 pt-1 pb-1 text-[12px]', MUTED)}>Cloud</div>
+            {CLOUD_ENVS.map((env) => (
+              <button key={env} className={ROW} onClick={() => { setEnvironment(env); setOpenMenu(null) }}>
+                <Cloud className="size-4" /><span className="flex-1 truncate">{env}</span>
+                {env === environment && <Check className="size-3.5" />}<Settings className={cn('size-3.5', MUTED)} />
+              </button>
             ))}
+            <button className={cn(ROW, MUTED)}><Plus className="size-4" />Add cloud environment…</button>
+            <div className={DIVIDER} />
+            <div className={cn('px-2.5 pt-1 pb-1 text-[12px]', MUTED)}>Remote Control</div>
+            <div className="px-2.5 py-1.5">
+              <div className="text-[14px] font-medium">Set up Remote Control</div>
+              <div className={cn('mt-0.5 flex items-start gap-1.5 text-[12px]', MUTED)}>
+                <ExternalLink className="mt-0.5 size-3.5 shrink-0" />
+                <span>Run <code className="rounded bg-black/[0.06] px-1 py-0.5 text-[11px] dark:bg-white/[0.08]">claude rc</code> on your machine to code from here.</span>
+              </div>
+            </div>
+          </Popover>
+          <button className={CHIP}><Plus className="size-3.5" />Select repo…</button>
+        </div>
+      } />
+
+      {/* Input box with an inline return/send arrow */}
+      <div
+        onClick={() => promptRef.current?.focus()}
+        className={cn(
+          'cursor-text rounded-2xl border border-black/[0.08] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] focus-within:border-black/[0.16]',
+          'dark:border-white/[0.10] dark:bg-[#30302e] dark:focus-within:border-white/[0.18]',
+          '[--prompt-area-surface:#ffffff] dark:[--prompt-area-surface:#30302e]',
+          '[--prompt-area-placeholder:#8a887f] dark:[--prompt-area-placeholder:#92908a]',
+        )}>
+        <div className="flex items-end gap-1 py-1.5 pr-1.5 pl-3.5">
+          <div className="min-w-0 flex-1 py-1.5 text-[16px] leading-6">
+            <PromptArea ref={promptRef} value={segments} onChange={setSegments}
+              placeholder="Describe a task or ask a question" onSubmit={submit} autoGrow minHeight={28} maxHeight={216} />
           </div>
-        )}
-        <PromptArea
-          ref={promptRef}
-          value={segments}
-          onChange={setSegments}
-          placeholder="Ask anything..."
-          onSubmit={submit}
-          autoGrow
-          minHeight={48}
-          maxHeight={280}
-        />
-        <ActionBar
-          className="pt-1.5"
-          left={
-            <div className="flex items-center gap-1.5">
-              <button className="size-8 rounded-lg"><Plus className="size-4" /></button>
-              <button
-                onClick={() => setPlanMode((v) => !v)}
-                className={\`rounded-full px-3 py-1.5 text-xs font-medium \${
-                  planMode ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
-                }\`}>
-                <LayoutList className="size-3.5" /> Plan mode
-              </button>
-            </div>
-          }
-          right={
-            <div className="flex items-center gap-2">
-              <button className="text-muted-foreground text-xs">
-                {selectedModel} <ChevronDown className="size-3" />
-              </button>
-              <button onClick={() => submit(segments)} className="bg-primary text-primary-foreground size-8 rounded-full">
-                <ArrowUp className="size-4" />
-              </button>
-            </div>
-          }
-        />
+          <button onClick={() => submit(segments)} disabled={isEmpty} aria-label="Send"
+            className={cn(GHOST_SQ, 'self-end disabled:opacity-40 disabled:hover:bg-transparent')}>
+            <CornerDownLeft className="size-4" />
+          </button>
+        </div>
       </div>
-      <StatusBar
-        className="rounded-b-xl border-t px-4 py-2"
+
+      {/* Control bar */}
+      <ActionBar className="px-1 pt-0"
         left={
-          <div className="flex items-center gap-2">
-            <span className="bg-muted rounded px-2 py-0.5 text-xs font-medium">prompt-area</span>
-            <GitBranch className="size-3" /> <span className="text-xs">main</span>
-            <button><Plus className="size-3" /></button>
+          <div className="flex items-center gap-0.5">
+            <Popover id="permission" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="bottom-full left-0 mb-1.5 w-[208px]"
+              render={(open, toggle) => <button aria-haspopup="menu" aria-expanded={open} onClick={toggle} className={GHOST}>{permission}</button>}>
+              {PERMISSION_MODES.map((mode) => (
+                <button key={mode} className={ROW} onClick={() => { setPermission(mode); setOpenMenu(null) }}>
+                  <span className="flex-1">{mode}</span>{mode === permission && <Check className="size-3.5" />}
+                </button>
+              ))}
+            </Popover>
+            <button className={GHOST_SQ} aria-label="Add"><Plus className="size-4" /></button>
+            <div className="inline-flex h-7 items-center text-[#5a5851] dark:text-[#b3b1a8]">
+              <button aria-label="Press and hold to record" className="flex h-full items-center rounded-l-md pr-1 pl-2 hover:bg-black/[0.05] dark:hover:bg-white/[0.07]"><Mic className="size-4" /></button>
+              <button aria-label="Dictation settings" className="flex h-full items-center rounded-r-md pr-1.5 pl-0.5 hover:bg-black/[0.05] dark:hover:bg-white/[0.07]"><ChevronDown className="size-3 opacity-70" /></button>
+            </div>
           </div>
         }
         right={
-          <button className="text-muted-foreground text-xs">
-            <Cloud className="size-3" /> Default <ChevronDown className="size-3" />
-          </button>
+          <div className="flex items-center gap-0.5">
+            <Popover id="model" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="bottom-full right-0 mb-1.5 w-[236px]"
+              render={(open, toggle) => <button aria-haspopup="menu" aria-expanded={open} onClick={toggle} className={GHOST}>{model.name}</button>}>
+              <div className="flex items-center justify-between px-2.5 pt-1 pb-1.5">
+                <span className={cn('text-[12px]', MUTED)}>Models</span>
+                <span className="flex items-center gap-0.5">
+                  {['⇧', '⌘', 'I'].map((k) => <kbd key={k} className={cn('rounded bg-black/[0.06] px-1 py-0.5 text-[11px] dark:bg-white/[0.08]', MUTED)}>{k}</kbd>)}
+                </span>
+              </div>
+              {MODELS.map((m) => (
+                <button key={m.id} disabled={m.unavailable} className={cn(ROW, m.unavailable && 'opacity-45 hover:bg-transparent')}
+                  onClick={() => { if (!m.unavailable) { setModel(m); setOpenMenu(null) } }}>
+                  <span className="flex-1">{m.name}{m.unavailable && <span className={cn('ml-1.5', MUTED)}>Currently unavailable</span>}</span>
+                  {m.id === model.id && <Check className="size-3.5" />}
+                  {m.shortcut && <span className={cn('w-3 text-right text-[13px]', MUTED)}>{m.shortcut}</span>}
+                </button>
+              ))}
+              <div className={DIVIDER} />
+              <button className={ROW}><span className="flex-1">More models</span><ChevronRight className={cn('size-3.5', MUTED)} /></button>
+            </Popover>
+
+            <Popover id="effort" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="bottom-full right-0 mb-1.5"
+              render={(open, toggle) => <button aria-haspopup="dialog" aria-expanded={open} onClick={toggle} className={GHOST}>{effort}</button>}>
+              <EffortSlider value={effort} onChange={setEffort} />
+            </Popover>
+
+            <Popover id="usage" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="bottom-full right-0 mb-1.5 w-[300px]"
+              render={(open, toggle) => (
+                <button aria-haspopup="dialog" aria-expanded={open} aria-label={\`Usage: plan \${PLAN_PCT}%\`} onClick={toggle} className={GHOST_SQ}>
+                  <UsageRing pct={PLAN_PCT} />
+                </button>
+              )}>
+              <div className="flex items-center justify-between px-2.5 pt-1 pb-1.5"><span className={cn('text-[13px]', MUTED)}>Plan usage</span><ArrowRight className={cn('size-3.5', MUTED)} /></div>
+              {USAGE.map((u) => (
+                <div key={u.label} className="px-2.5 py-1.5">
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span>{u.label}</span>
+                    <span className={cn('flex items-center gap-3', MUTED)}><span>{u.meta}</span>{u.pct != null && <span>{u.pct}%</span>}</span>
+                  </div>
+                  {u.pct != null && (
+                    <div className="mt-1.5 h-1 w-full overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                      <div className="h-full rounded-full" style={{ width: \`\${u.pct}%\`, background: ACCENT }} />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </Popover>
+          </div>
         }
       />
+
       {submitted && (
-        <div className="bg-muted/50 m-2 flex items-center justify-between rounded-lg border p-3 text-sm">
+        <div className="bg-muted/50 flex items-center justify-between rounded-lg border p-3 text-sm">
           <span className="text-muted-foreground">Submitted — clear to send again.</span>
           <button onClick={reset} className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs" aria-label="Reset">
             <RotateCcw className="size-3.5" /> Reset

--- a/app/examples/claude-input.tsx
+++ b/app/examples/claude-input.tsx
@@ -1,0 +1,552 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  Plus,
+  ChevronDown,
+  ChevronRight,
+  Mic,
+  AudioLines,
+  ArrowUp,
+  X,
+  Check,
+  Info,
+  Pencil,
+  GraduationCap,
+  Code,
+  Coffee,
+  type LucideIcon,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  PromptArea,
+  isSegmentsEmpty,
+  type Segment,
+  type TriggerConfig,
+  type PromptAreaFile,
+} from 'prompt-area'
+import { useSubmittablePrompt } from './use-submittable-prompt'
+import { SubmittedPreview } from './submitted-preview'
+
+// ---------------------------------------------------------------------------
+// Option data (representative placeholders)
+// ---------------------------------------------------------------------------
+
+type ClaudeModel = {
+  id: string
+  name: string
+  desc: string
+  /** Greyed-out, non-selectable row (e.g. a model that's temporarily down). */
+  unavailable?: boolean
+}
+
+const MODELS: ClaudeModel[] = [
+  { id: 'fable-5', name: 'Fable 5', desc: 'For your toughest challenges', unavailable: true },
+  { id: 'opus-4.8', name: 'Opus 4.8', desc: 'For complex tasks' },
+  { id: 'sonnet-4.6', name: 'Sonnet 4.6', desc: 'Most efficient for everyday tasks' },
+  { id: 'haiku-4.5', name: 'Haiku 4.5', desc: 'Fastest for quick answers' },
+]
+
+const EFFORTS = ['High', 'Medium', 'Low'] as const
+type Effort = (typeof EFFORTS)[number]
+
+const CATEGORIES: { label: string; icon: LucideIcon }[] = [
+  { label: 'Write', icon: Pencil },
+  { label: 'Learn', icon: GraduationCap },
+  { label: 'Code', icon: Code },
+  { label: 'Life stuff', icon: Coffee },
+]
+
+// The blue Claude uses for the selected-model check.
+const ACCENT = '#2c7fff'
+// Claude's coral send affordance.
+const SEND = '#d97757'
+
+// Shared class fragments, following the per-example ICON_BTN / MENU_ITEM naming
+// convention used by the other style examples. Colors are pinned to Claude's
+// warm neutral palette (light + dark) rather than the docs theme so the composer
+// reads as Claude on any page.
+const ICON_BTN =
+  'flex size-8 shrink-0 items-center justify-center rounded-lg text-[#5a5851] transition-colors hover:bg-black/[0.06] dark:text-[#c2c0b8] dark:hover:bg-white/[0.08]'
+const MENU =
+  'absolute right-0 top-full z-30 mt-2 flex w-[320px] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e] dark:shadow-[0_12px_36px_rgba(0,0,0,0.55)]'
+const ROW =
+  'flex w-full items-center rounded-xl px-3 py-2 text-left transition-colors hover:bg-black/[0.05] dark:hover:bg-white/[0.06]'
+
+// The Google Drive glyph for the "From Drive" chip — its multicolor logo, so it
+// stays branded rather than inheriting the chip's text color like the others.
+function DriveGlyph() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+      <path
+        d="M1.85 12.62l.64 1.11c.13.23.32.41.55.55l2.28-3.96H.75c0 .26.07.51.2.74l.9 1.56z"
+        fill="#0066DA"
+      />
+      <path
+        d="M8 5.67L5.72 1.72c-.23.13-.42.32-.55.55L.95 9.58c-.13.22-.2.48-.2.74h4.57L8 5.67z"
+        fill="#00AC47"
+      />
+      <path
+        d="M12.97 14.28c.22-.13.41-.32.55-.55l.27-.46 1.27-2.2c.13-.23.2-.48.2-.74h-4.57l.97 1.91 1.31 2.04z"
+        fill="#EA4335"
+      />
+      <path
+        d="M8 5.67L10.28 1.72c-.22-.13-.48-.2-.74-.2H6.46c-.27 0-.52.08-.74.2L8 5.67z"
+        fill="#00832D"
+      />
+      <path
+        d="M10.68 10.32H5.32l-2.28 3.96c.22.13.48.2.74.2h8.44c.27 0 .52-.08.74-.2l-2.28-3.96z"
+        fill="#2684FC"
+      />
+      <path
+        d="M12.94 5.92l-2.11-3.65c-.13-.23-.32-.42-.55-.55L8 5.67l2.68 4.65h4.56c0-.26-.07-.51-.2-.74l-2.1-3.66z"
+        fill="#FFBA00"
+      />
+    </svg>
+  )
+}
+
+// The model selector pill + its flyout. Opens below the pill, mirroring Claude
+// in an empty chat: each row is a model name over a muted one-line description,
+// with a blue check on the active one and a greyed, non-selectable row for an
+// unavailable model. Below a divider sit a cycling "Effort" control and an inert
+// "More models" row.
+function ModelMenu({
+  open,
+  setOpen,
+  model,
+  onSelect,
+  effort,
+  cycleEffort,
+}: {
+  open: boolean
+  setOpen: (next: boolean) => void
+  model: ClaudeModel
+  onSelect: (model: ClaudeModel) => void
+  effort: Effort
+  cycleEffort: () => void
+}) {
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+        className="flex h-8 items-center gap-1 rounded-lg pr-2 pl-2.5 text-[14px] text-[#1f1e1d] transition-colors hover:bg-black/[0.05] dark:text-[#f5f4ee] dark:hover:bg-white/[0.06]">
+        <span className="max-w-40 truncate">
+          {model.name}
+          <span className="ml-1 text-[#8a887f] dark:text-[#92908a]">{effort}</span>
+        </span>
+        <ChevronDown className="size-3 opacity-70" />
+      </button>
+      {open && (
+        <div role="menu" className={MENU}>
+          {MODELS.map((m) => {
+            const active = m.id === model.id
+            return (
+              <button
+                key={m.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={active}
+                aria-disabled={m.unavailable || undefined}
+                disabled={m.unavailable}
+                className={cn(ROW, 'gap-3', m.unavailable && 'opacity-45 hover:bg-transparent')}
+                onClick={() => {
+                  if (m.unavailable) return
+                  onSelect(m)
+                  setOpen(false)
+                }}>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 text-[15px] font-medium text-[#1f1e1d] dark:text-[#f5f4ee]">
+                    {m.name}
+                    {m.unavailable && (
+                      <span className="inline-flex items-center gap-1 text-[12px] font-normal text-[#8a887f] dark:text-[#92908a]">
+                        <Info className="size-3" />
+                        Currently unavailable
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[13px] text-[#8a887f] dark:text-[#92908a]">{m.desc}</div>
+                </div>
+                {active && <Check className="size-4 shrink-0" style={{ color: ACCENT }} />}
+              </button>
+            )
+          })}
+
+          <div className="mx-2 my-1 h-px bg-black/[0.08] dark:bg-white/10" />
+
+          <button
+            type="button"
+            className={cn(ROW, 'justify-between text-[14px] text-[#1f1e1d] dark:text-[#f5f4ee]')}
+            onClick={cycleEffort}>
+            Effort
+            <span className="flex items-center gap-1 text-[#8a887f] dark:text-[#92908a]">
+              {effort}
+              <ChevronRight className="size-3.5" />
+            </span>
+          </button>
+
+          <div className="mx-2 my-1 h-px bg-black/[0.08] dark:bg-white/10" />
+
+          <button
+            type="button"
+            className={cn(ROW, 'justify-between text-[14px] text-[#1f1e1d] dark:text-[#f5f4ee]')}
+            onClick={() => setOpen(false)}>
+            More models
+            <ChevronRight className="size-3.5 text-[#8a887f] dark:text-[#92908a]" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ClaudeInputExample({
+  initialSegments = [],
+  initialFiles = [],
+  triggers,
+  markdown = false,
+}: {
+  initialSegments?: Segment[]
+  initialFiles?: PromptAreaFile[]
+  triggers?: TriggerConfig[]
+  markdown?: boolean
+} = {}) {
+  const { segments, setSegments, submitted, promptRef, submit, reset } =
+    useSubmittablePrompt<PromptAreaFile>({ initialSegments, initialFiles })
+
+  const [model, setModel] = useState<ClaudeModel>(MODELS[1])
+  const [effort, setEffort] = useState<Effort>('High')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [bannerOpen, setBannerOpen] = useState(true)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const isEmpty = isSegmentsEmpty(segments)
+  const cycleEffort = () =>
+    setEffort((prev) => EFFORTS[(EFFORTS.indexOf(prev) + 1) % EFFORTS.length])
+
+  // Close the model menu on outside click or Escape.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setMenuOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [menuOpen])
+
+  return (
+    <div className="flex flex-col gap-3" ref={rootRef}>
+      {/* Composer + the notice that peeks out above it */}
+      <div className="relative flex flex-col">
+        {/* Background notice — sticks up above the composer card, which overlaps
+            its bottom edge. Dismissible via the X. */}
+        {bannerOpen && (
+          <div className="relative z-0 mx-2 -mb-5 flex items-center justify-between gap-3 rounded-t-[20px] border border-b-0 border-black/[0.06] bg-[#f5f3ec] px-4 pt-2.5 pb-7 dark:border-white/[0.07] dark:bg-[#262624]">
+            <span className="text-sm font-bold text-[#1f1e1d] dark:text-[#f5f4ee]">
+              Claude Fable 5 is currently unavailable.
+            </span>
+            <div className="flex shrink-0 items-center gap-3">
+              <button
+                type="button"
+                className="text-sm text-[#1f1e1d] underline decoration-black/30 underline-offset-[3px] transition-colors hover:decoration-current dark:text-[#f5f4ee] dark:decoration-white/30">
+                Learn more
+              </button>
+              <button
+                type="button"
+                aria-label="Dismiss"
+                onClick={() => setBannerOpen(false)}
+                className="flex size-6 items-center justify-center rounded-md text-[#5a5851] transition-colors hover:bg-black/[0.06] dark:text-[#c2c0b8] dark:hover:bg-white/[0.08]">
+                <X className="size-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Foreground composer card */}
+        <div
+          onClick={() => promptRef.current?.focus()}
+          className={cn(
+            'relative z-10 cursor-text rounded-[20px] bg-white transition-shadow',
+            'shadow-[0_4px_20px_rgba(0,0,0,0.035),0_0_0_0.5px_rgba(0,0,0,0.08)]',
+            'hover:shadow-[0_4px_20px_rgba(0,0,0,0.05),0_0_0_0.5px_rgba(0,0,0,0.12)]',
+            'focus-within:shadow-[0_4px_20px_rgba(0,0,0,0.07),0_0_0_0.5px_rgba(0,0,0,0.15)]',
+            'dark:bg-[#30302e] dark:shadow-[0_0_0_0.5px_rgba(255,255,255,0.08)]',
+            'dark:hover:shadow-[0_0_0_0.5px_rgba(255,255,255,0.14)]',
+            'dark:focus-within:shadow-[0_0_0_0.5px_rgba(255,255,255,0.18)]',
+            '[--prompt-area-surface:#ffffff] dark:[--prompt-area-surface:#30302e]',
+            '[--prompt-area-placeholder:#8a887f] dark:[--prompt-area-placeholder:#92908a]',
+          )}>
+          <div className="flex flex-col gap-3 p-3.5">
+            <div className="text-[16px] leading-6 text-[#1f1e1d] dark:text-[#f5f4ee]">
+              <PromptArea
+                ref={promptRef}
+                value={segments}
+                onChange={setSegments}
+                triggers={triggers}
+                placeholder="Paste a doc, an email, or a question to get started"
+                onSubmit={submit}
+                markdown={markdown}
+                autoGrow
+                minHeight={48}
+                maxHeight={280}
+              />
+            </div>
+
+            {/* Controls row: add on the left, model + voice cluster on the right */}
+            <div className="flex w-full items-center gap-2">
+              <button
+                type="button"
+                className={ICON_BTN}
+                aria-label="Add files, connectors, and more">
+                <Plus className="size-5" />
+              </button>
+
+              <div className="grow" />
+
+              <ModelMenu
+                open={menuOpen}
+                setOpen={setMenuOpen}
+                model={model}
+                onSelect={setModel}
+                effort={effort}
+                cycleEffort={cycleEffort}
+              />
+
+              <button type="button" className={ICON_BTN} aria-label="Press and hold to record">
+                <Mic className="size-5" />
+              </button>
+
+              {isEmpty ? (
+                <button type="button" className={ICON_BTN} aria-label="Use voice mode">
+                  <AudioLines className="size-5" />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => submit(segments)}
+                  aria-label="Send message"
+                  className="flex size-8 shrink-0 items-center justify-center rounded-lg text-white transition-opacity hover:opacity-90"
+                  style={{ backgroundColor: SEND }}>
+                  <ArrowUp className="size-5" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Suggested prompt categories */}
+      <ul className="flex flex-wrap justify-center gap-2 pt-1" aria-label="Prompt categories">
+        {CATEGORIES.map(({ label, icon: Icon }) => (
+          <li key={label}>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-black/[0.08] bg-white px-3 py-2 text-sm text-[#1f1e1d] shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-colors hover:bg-black/[0.03] dark:border-white/[0.08] dark:bg-[#30302e] dark:text-[#f5f4ee] dark:shadow-none dark:hover:bg-white/[0.04]">
+              <Icon className="size-[18px] text-[#8a887f] dark:text-[#92908a]" />
+              {label}
+            </button>
+          </li>
+        ))}
+        <li>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-black/[0.08] bg-white px-3 py-2 text-sm text-[#1f1e1d] shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-colors hover:bg-black/[0.03] dark:border-white/[0.08] dark:bg-[#30302e] dark:text-[#f5f4ee] dark:shadow-none dark:hover:bg-white/[0.04]">
+            <DriveGlyph />
+            From Drive
+          </button>
+        </li>
+      </ul>
+
+      <SubmittedPreview text={submitted?.text} onReset={reset} />
+    </div>
+  )
+}
+
+export const claudeInputCode = `import { useEffect, useRef, useState } from 'react'
+import { Plus, ChevronDown, ChevronRight, Mic, AudioLines, ArrowUp, X, Check, Info, RotateCcw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PromptArea, isSegmentsEmpty } from '@/components/prompt-area'
+import type { Segment, PromptAreaHandle } from '@/components/types'
+
+type ClaudeModel = { id: string; name: string; desc: string; unavailable?: boolean }
+const MODELS: ClaudeModel[] = [
+  { id: 'fable-5', name: 'Fable 5', desc: 'For your toughest challenges', unavailable: true },
+  { id: 'opus-4.8', name: 'Opus 4.8', desc: 'For complex tasks' },
+  { id: 'sonnet-4.6', name: 'Sonnet 4.6', desc: 'Most efficient for everyday tasks' },
+  { id: 'haiku-4.5', name: 'Haiku 4.5', desc: 'Fastest for quick answers' },
+]
+const EFFORTS = ['High', 'Medium', 'Low'] as const
+const ACCENT = '#2c7fff' // selected-model check
+const SEND = '#d97757'   // coral send affordance
+
+const ICON_BTN = 'flex size-8 shrink-0 items-center justify-center rounded-lg text-[#5a5851] transition-colors hover:bg-black/[0.06] dark:text-[#c2c0b8] dark:hover:bg-white/[0.08]'
+const MENU = 'absolute right-0 top-full z-30 mt-2 flex w-[320px] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e]'
+const ROW = 'flex w-full items-center rounded-xl px-3 py-2 text-left transition-colors hover:bg-black/[0.05] dark:hover:bg-white/[0.06]'
+
+function ClaudeInputExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  // Snapshot of the last submission so Reset can restore it for another send.
+  const [submitted, setSubmitted] = useState<Segment[] | null>(null)
+  const [model, setModel] = useState<ClaudeModel>(MODELS[1])
+  const [effort, setEffort] = useState<(typeof EFFORTS)[number]>('High')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [bannerOpen, setBannerOpen] = useState(true)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const promptRef = useRef<PromptAreaHandle>(null)
+
+  const isEmpty = isSegmentsEmpty(segments)
+  const cycleEffort = () => setEffort((p) => EFFORTS[(EFFORTS.indexOf(p) + 1) % EFFORTS.length])
+
+  const submit = (segs: Segment[]) => {
+    if (isSegmentsEmpty(segs)) return
+    setSubmitted(segs)
+    promptRef.current?.clear()
+    setSegments([])
+  }
+  const reset = () => {
+    if (submitted) setSegments(submitted)
+    setSubmitted(null)
+    promptRef.current?.focus()
+  }
+
+  // Close the model menu on outside click.
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [menuOpen])
+
+  return (
+    <div className="flex flex-col gap-3" ref={rootRef}>
+      <div className="relative flex flex-col">
+        {/* Notice that peeks out above the composer card */}
+        {bannerOpen && (
+          <div className="relative z-0 mx-2 -mb-5 flex items-center justify-between gap-3 rounded-t-[20px] border border-b-0 border-black/[0.06] bg-[#f5f3ec] px-4 pb-7 pt-2.5 dark:border-white/[0.07] dark:bg-[#262624]">
+            <span className="text-sm font-bold text-[#1f1e1d] dark:text-[#f5f4ee]">Claude Fable 5 is currently unavailable.</span>
+            <div className="flex shrink-0 items-center gap-3">
+              <button className="text-sm underline decoration-black/30 underline-offset-[3px] hover:decoration-current">Learn more</button>
+              <button aria-label="Dismiss" onClick={() => setBannerOpen(false)} className="flex size-6 items-center justify-center rounded-md hover:bg-black/[0.06] dark:hover:bg-white/[0.08]">
+                <X className="size-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Foreground composer card */}
+        <div
+          onClick={() => promptRef.current?.focus()}
+          className={cn(
+            'relative z-10 cursor-text rounded-[20px] bg-white transition-shadow',
+            'shadow-[0_4px_20px_rgba(0,0,0,0.035),0_0_0_0.5px_rgba(0,0,0,0.08)]',
+            'focus-within:shadow-[0_4px_20px_rgba(0,0,0,0.07),0_0_0_0.5px_rgba(0,0,0,0.15)]',
+            'dark:bg-[#30302e] dark:shadow-[0_0_0_0.5px_rgba(255,255,255,0.08)]',
+            '[--prompt-area-surface:#ffffff] dark:[--prompt-area-surface:#30302e]',
+            '[--prompt-area-placeholder:#8a887f] dark:[--prompt-area-placeholder:#92908a]',
+          )}>
+          <div className="flex flex-col gap-3 p-3.5">
+            <div className="text-[16px] leading-6 text-[#1f1e1d] dark:text-[#f5f4ee]">
+              <PromptArea
+                ref={promptRef}
+                value={segments}
+                onChange={setSegments}
+                placeholder="Paste a doc, an email, or a question to get started"
+                onSubmit={submit}
+                autoGrow
+                minHeight={48}
+                maxHeight={280}
+              />
+            </div>
+
+            {/* Controls: add on the left, model + voice cluster on the right */}
+            <div className="flex w-full items-center gap-2">
+              <button className={ICON_BTN} aria-label="Add files, connectors, and more"><Plus className="size-5" /></button>
+              <div className="grow" />
+
+              {/* Model selector — opens below the pill */}
+              <div className="relative">
+                <button
+                  onClick={() => setMenuOpen((v) => !v)}
+                  className="flex h-8 items-center gap-1 rounded-lg pl-2.5 pr-2 text-[14px] transition-colors hover:bg-black/[0.05] dark:hover:bg-white/[0.06]">
+                  <span className="max-w-40 truncate">{model.name}<span className="ml-1 text-[#8a887f] dark:text-[#92908a]">{effort}</span></span>
+                  <ChevronDown className="size-3 opacity-70" />
+                </button>
+                {menuOpen && (
+                  <div role="menu" className={MENU}>
+                    {MODELS.map((m) => {
+                      const active = m.id === model.id
+                      return (
+                        <button
+                          key={m.id}
+                          disabled={m.unavailable}
+                          className={cn(ROW, 'gap-3', m.unavailable && 'opacity-45 hover:bg-transparent')}
+                          onClick={() => { if (!m.unavailable) { setModel(m); setMenuOpen(false) } }}>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-1.5 text-[15px] font-medium">
+                              {m.name}
+                              {m.unavailable && (
+                                <span className="inline-flex items-center gap-1 text-[12px] font-normal text-[#8a887f] dark:text-[#92908a]">
+                                  <Info className="size-3" /> Currently unavailable
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-[13px] text-[#8a887f] dark:text-[#92908a]">{m.desc}</div>
+                          </div>
+                          {active && <Check className="size-4 shrink-0" style={{ color: ACCENT }} />}
+                        </button>
+                      )
+                    })}
+                    <div className="mx-2 my-1 h-px bg-black/[0.08] dark:bg-white/10" />
+                    <button className={cn(ROW, 'justify-between text-[14px]')} onClick={() => setEffort((p) => EFFORTS[(EFFORTS.indexOf(p) + 1) % EFFORTS.length])}>
+                      Effort
+                      <span className="flex items-center gap-1 text-[#8a887f] dark:text-[#92908a]">{effort}<ChevronRight className="size-3.5" /></span>
+                    </button>
+                    <div className="mx-2 my-1 h-px bg-black/[0.08] dark:bg-white/10" />
+                    <button className={cn(ROW, 'justify-between text-[14px]')} onClick={() => setMenuOpen(false)}>
+                      More models <ChevronRight className="size-3.5 text-[#8a887f] dark:text-[#92908a]" />
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <button className={ICON_BTN} aria-label="Press and hold to record"><Mic className="size-5" /></button>
+
+              {isEmpty ? (
+                <button className={ICON_BTN} aria-label="Use voice mode"><AudioLines className="size-5" /></button>
+              ) : (
+                <button
+                  onClick={() => submit(segments)}
+                  aria-label="Send message"
+                  className="flex size-8 shrink-0 items-center justify-center rounded-lg text-white transition-opacity hover:opacity-90"
+                  style={{ backgroundColor: SEND }}>
+                  <ArrowUp className="size-5" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {submitted && (
+        <div className="bg-muted/50 flex items-center justify-between rounded-lg border p-3 text-sm">
+          <span className="text-muted-foreground">Submitted — clear to send again.</span>
+          <button onClick={reset} className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs" aria-label="Reset">
+            <RotateCcw className="size-3.5" /> Reset
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}`

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -23,6 +23,7 @@ export { CompactPromptAreaExample, compactPromptAreaCode } from './compact-promp
 export { ChatPromptLayoutExample, chatPromptLayoutCode } from './chat-prompt-layout'
 export { DxHelpersExample, dxHelpersCode } from './dx-helpers'
 export { RotatingPlaceholdersExample, rotatingPlaceholdersCode } from './rotating-placeholders'
+export { ClaudeInputExample, claudeInputCode } from './claude-input'
 export { ClaudeCodeInputExample, claudeCodeInputCode } from './claude-code-input'
 export { CodexInputExample, codexInputCode } from './codex-input'
 export { ChatGptInputExample, chatgptInputCode } from './chatgpt-input'

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -192,6 +192,12 @@ export default function HomeContent() {
               <ArrowRight className="size-3.5" />
             </Link>
             <Link
+              href="/styles#claude"
+              className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm font-medium transition-colors">
+              Claude style
+              <ArrowRight className="size-3.5" />
+            </Link>
+            <Link
               href="/styles#claude-code"
               className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-4 py-2 text-sm font-medium transition-colors">
               Claude Code style

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -97,8 +97,9 @@ export default function StylesPage() {
         <div className="flex flex-col gap-1.5">
           <h2 className="text-2xl font-semibold tracking-tight">Claude Code</h2>
           <p className="text-muted-foreground leading-relaxed">
-            A Claude Code–style composer: a file chip above the input, a Plan-mode toggle and model
-            selector in the action bar, and project/branch context in the status bar.
+            A Claude Code–style composer: environment and repository context above the input, an
+            inline return-to-send arrow, and a control bar with a permission-mode menu, dictation,
+            model and reasoning-effort selectors, and a plan-usage meter.
           </p>
         </div>
         <ExampleShowcase code={claudeCodeInputCode}>

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { ExampleShowcase } from '@/components/example-showcase'
+import { ClaudeInputExample, claudeInputCode } from '@/app/examples/claude-input'
 import { ClaudeCodeInputExample, claudeCodeInputCode } from '@/app/examples/claude-code-input'
 import { CodexInputExample, codexInputCode } from '@/app/examples/codex-input'
 import { ChatGptInputExample, chatgptInputCode } from '@/app/examples/chatgpt-input'
@@ -9,16 +10,16 @@ import { ChatGptInputExample, chatgptInputCode } from '@/app/examples/chatgpt-in
 const SITE_URL = 'https://prompt-area.com'
 
 export const metadata: Metadata = {
-  title: 'Styles — ChatGPT, Claude Code & Codex Agent Inputs',
+  title: 'Styles — ChatGPT, Claude, Claude Code & Codex Agent Inputs',
   description:
-    'Ready-made agent-input styles built with Prompt Area: a ChatGPT-style composer, a Claude Code–style composer, and an OpenAI Codex–style composer, assembled from Prompt Area, Action Bar, and Status Bar.',
+    'Ready-made agent-input styles built with Prompt Area: a ChatGPT-style composer, a Claude-style composer, a Claude Code–style composer, and an OpenAI Codex–style composer, assembled from Prompt Area, Action Bar, and Status Bar.',
   alternates: { canonical: `${SITE_URL}/styles` },
   openGraph: {
     type: 'website',
     url: `${SITE_URL}/styles`,
-    title: 'Styles — ChatGPT, Claude Code & Codex Agent Inputs',
+    title: 'Styles — ChatGPT, Claude, Claude Code & Codex Agent Inputs',
     description:
-      'Ready-made agent-input styles built with Prompt Area — ChatGPT, Claude Code, and OpenAI Codex composers you can drop into your app.',
+      'Ready-made agent-input styles built with Prompt Area — ChatGPT, Claude, Claude Code, and OpenAI Codex composers you can drop into your app.',
   },
 }
 
@@ -53,6 +54,32 @@ export default function StylesPage() {
         </div>
         <ExampleShowcase code={chatgptInputCode}>
           <ChatGptInputExample />
+        </ExampleShowcase>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          Composed from{' '}
+          <Link
+            href="/docs/components/prompt-area"
+            className="text-foreground font-medium underline underline-offset-4">
+            Prompt Area
+          </Link>{' '}
+          alone — the controls live inline around the input.
+        </p>
+      </section>
+
+      {/* Claude */}
+      <section id="claude" className="flex scroll-mt-20 flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <h2 className="text-2xl font-semibold tracking-tight">Claude</h2>
+          <p className="text-muted-foreground leading-relaxed">
+            A Claude-style composer: a rounded card with the input stacked over an inline control
+            row — a model selector whose menu lists each model over a one-line description with a
+            blue check on the active one, a dictation button, and a voice affordance that swaps to a
+            coral send button once there&apos;s text. A dismissible notice peeks out above the card,
+            and suggested-prompt chips sit below.
+          </p>
+        </div>
+        <ExampleShowcase code={claudeInputCode}>
+          <ClaudeInputExample />
         </ExampleShowcase>
         <p className="text-muted-foreground text-sm leading-relaxed">
           Composed from{' '}


### PR DESCRIPTION
## Summary
Added a new Claude-style input composer example to the styles showcase, complementing the existing ChatGPT and Claude Code examples.

## Key Changes
- **New Claude composer component** (`app/examples/claude-input.tsx`): A complete, production-ready example featuring:
  - Rounded card design with integrated model selector pill
  - Model menu with descriptions, unavailable state handling, and effort cycling
  - Dismissible banner notice that peeks above the composer
  - Dynamic send button that swaps between voice affordance and coral send icon based on input state
  - Suggested prompt category chips below the composer
  - Full dark mode support with Claude's warm neutral color palette
  - Integration with `PromptArea` component for rich text input with file support

- **Updated styles page** (`app/styles/page.tsx`): 
  - Added Claude section with showcase and documentation
  - Updated metadata and descriptions to include Claude style

- **Updated home page** (`app/home-content.tsx`):
  - Added link to Claude style example in the styles section

- **Updated exports** (`app/examples/index.ts`):
  - Exported new Claude example component and code snippet

## Implementation Details
- The model selector implements a proper dropdown menu with keyboard support (Escape to close, outside-click detection)
- Effort cycling is implemented as a state machine rotating through High → Medium → Low
- The component uses CSS custom properties for theming (`--prompt-area-surface`, `--prompt-area-placeholder`)
- Includes a `SubmittedPreview` component to show submission state and reset functionality
- Comprehensive code snippet included for easy copy-paste integration

https://claude.ai/code/session_01JwsEcFSn46XQ3hhmkGR7xb