### PR TITLE
Improve mobile responsiveness of styles examples

### DIFF
--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -398,7 +398,7 @@ export function ClaudeCodeInputExample({
 
       {/* Control bar: permission + dictation on the left, model + effort + usage on the right */}
       <ActionBar
-        className="px-1 pt-0"
+        className="flex-wrap gap-y-1 px-1 pt-0"
         left={
           <div className="flex items-center gap-0.5">
             <Popover
@@ -777,7 +777,7 @@ function ClaudeCodeInputExample() {
       </div>
 
       {/* Control bar */}
-      <ActionBar className="px-1 pt-0"
+      <ActionBar className="flex-wrap gap-y-1 px-1 pt-0"
         left={
           <div className="flex items-center gap-0.5">
             <Popover id="permission" openMenu={openMenu} setOpenMenu={setOpenMenu} panelClass="bottom-full left-0 mb-1.5 w-[208px]"

--- a/app/examples/claude-input.tsx
+++ b/app/examples/claude-input.tsx
@@ -69,7 +69,7 @@ const SEND = '#d97757'
 const ICON_BTN =
   'flex size-8 shrink-0 items-center justify-center rounded-lg text-[#5a5851] transition-colors hover:bg-black/[0.06] dark:text-[#c2c0b8] dark:hover:bg-white/[0.08]'
 const MENU =
-  'absolute right-0 top-full z-30 mt-2 flex w-[320px] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e] dark:shadow-[0_12px_36px_rgba(0,0,0,0.55)]'
+  'absolute right-0 top-full z-30 mt-2 flex w-[320px] max-w-[calc(100vw-2rem)] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e] dark:shadow-[0_12px_36px_rgba(0,0,0,0.55)]'
 const ROW =
   'flex w-full items-center rounded-xl px-3 py-2 text-left transition-colors hover:bg-black/[0.05] dark:hover:bg-white/[0.06]'
 
@@ -390,7 +390,7 @@ const ACCENT = '#2c7fff' // selected-model check
 const SEND = '#d97757'   // coral send affordance
 
 const ICON_BTN = 'flex size-8 shrink-0 items-center justify-center rounded-lg text-[#5a5851] transition-colors hover:bg-black/[0.06] dark:text-[#c2c0b8] dark:hover:bg-white/[0.08]'
-const MENU = 'absolute right-0 top-full z-30 mt-2 flex w-[320px] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e]'
+const MENU = 'absolute right-0 top-full z-30 mt-2 flex w-[320px] max-w-[calc(100vw-2rem)] flex-col rounded-2xl border border-black/[0.08] bg-white p-1.5 shadow-[0_12px_36px_rgba(0,0,0,0.16)] dark:border-white/10 dark:bg-[#30302e]'
 const ROW = 'flex w-full items-center rounded-xl px-3 py-2 text-left transition-colors hover:bg-black/[0.05] dark:hover:bg-white/[0.06]'
 
 function ClaudeInputExample() {

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -216,7 +216,7 @@ export function CodexInputExample({
               onFileRemove={(f) => setFiles((prev) => prev.filter((x) => x.id !== f.id))}
             />
             <ActionBar
-              className="pt-2"
+              className="flex-wrap gap-y-2 pt-2"
               left={
                 <div className="flex items-center gap-0.5">
                   <button type="button" className={ICON_BTN} aria-label="Add attachment">
@@ -399,7 +399,7 @@ function CodexInputExample() {
             maxHeight={280}
           />
           <ActionBar
-            className="pt-2"
+            className="flex-wrap gap-y-2 pt-2"
             left={
               <div className="flex items-center gap-0.5">
                 <button className={ICON_BTN} aria-label="Add"><Plus className="size-4" /></button>

--- a/app/examples/perplexity-input.tsx
+++ b/app/examples/perplexity-input.tsx
@@ -236,7 +236,15 @@ function AddMenu({
               <ChevronRight className="size-4 shrink-0 text-[#9a9a94] dark:text-[#76786f]" />
             </button>
             {subOpen && (
-              <div role="menu" className={cn(MENU, 'top-0 left-full ml-1.5 w-[268px]')}>
+              <div
+                role="menu"
+                className={cn(
+                  MENU,
+                  // Mobile: stack below the row (a side flyout would run off-screen).
+                  'top-full left-0 mt-1.5 w-full',
+                  // ≥sm: the desktop side flyout, with room to the right.
+                  'sm:top-0 sm:left-full sm:mt-0 sm:ml-1.5 sm:w-[268px]',
+                )}>
                 <button
                   type="button"
                   onClick={() => setOpen(false)}
@@ -385,7 +393,7 @@ export function PerplexityInputExample({
           </div>
 
           {/* Controls: add + mode toggle on the left, model + voice cluster right */}
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <div className="flex items-center gap-2">
               <AddMenu
                 open={openMenu === 'add'}
@@ -426,7 +434,7 @@ export function PerplexityInputExample({
               </div>
             </div>
 
-            <div className="flex items-center gap-1">
+            <div className="ml-auto flex items-center gap-1">
               <ModelMenu
                 open={openMenu === 'model'}
                 setOpen={(next) => setOpenMenu(next ? 'model' : null)}
@@ -615,7 +623,7 @@ function PerplexityInputExample() {
           </div>
 
           {/* Controls */}
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <div className="flex items-center gap-2">
               {/* "+" add menu with a Connectors fly-out */}
               <div className="relative">
@@ -633,7 +641,7 @@ function PerplexityInputExample() {
                         <ChevronRight className="size-4 text-[#9a9a94] dark:text-[#76786f]" />
                       </button>
                       {subOpen && (
-                        <div role="menu" className={cn(MENU, 'top-0 left-full ml-1.5 w-[268px]')}>
+                        <div role="menu" className={cn(MENU, 'top-full left-0 mt-1.5 w-full sm:top-0 sm:left-full sm:mt-0 sm:ml-1.5 sm:w-[268px]')}>
                           <button className={UPSELL} onClick={() => setOpenMenu(null)}>
                             Upgrade to connect more sources
                             <ArrowRight className="size-4" style={{ color: SUPER }} />
@@ -684,7 +692,7 @@ function PerplexityInputExample() {
               </div>
             </div>
 
-            <div className="flex items-center gap-1">
+            <div className="ml-auto flex items-center gap-1">
               {/* Model / Orchestrator picker — gated list, switches with the mode */}
               <div className="relative -mr-1">
                 <button onClick={() => setOpenMenu(openMenu === 'model' ? null : 'model')} className={PILL}>


### PR DESCRIPTION
The five style composers crowded or clipped their controls at phone
widths. Make the control rows and menus adapt:

- Codex / Claude Code: let the ActionBar wrap so the right-hand cluster
  (model, effort, send) drops to a second line instead of overflowing
  the card and clipping the send button.
- Perplexity: wrap the control row the same way, and stack the
  Connectors fly-out below its row on small screens (it ran off the
  right edge as a side flyout); keep the side flyout from sm up.
- Claude: cap the model menu width to the viewport so it no longer
  clips on narrow screens.

Mirrored each change in the copy-paste code string shown in the Code tab.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qp3jAfhprGW83wP7CwVueE