### PR TITLE
Add Vercel AI SDK integration example with streaming chat

### DIFF
--- a/app/docs/examples/page.tsx
+++ b/app/docs/examples/page.tsx
@@ -34,6 +34,11 @@ const EXAMPLES = [
     description: 'usePromptAreaState, trigger presets, and segment helpers.',
   },
   {
+    href: '/docs/examples/vercel-ai-sdk',
+    title: 'Vercel AI SDK',
+    description: 'Stream chat with useChat — onSubmit to sendMessage, status-aware send/stop.',
+  },
+  {
     href: '/styles',
     title: 'Agent Styles',
     description: 'Claude Code– and Codex-style composers on the dedicated Styles page.',

--- a/app/docs/examples/vercel-ai-sdk/page.tsx
+++ b/app/docs/examples/vercel-ai-sdk/page.tsx
@@ -56,11 +56,18 @@ export async function POST(req: Request) {
   }
   const { messages, model, command, mentions } = parsed.data
 
-  const result = streamText({
-    model: anthropic(model),
-    system: command
+  const system = [
+    command
       ? \`The user invoked the "\${command}" command. Follow its conventions.\`
       : 'You are a helpful assistant.',
+    mentions.length ? \`People referenced: \${mentions.join(', ')}.\` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const result = streamText({
+    model: anthropic(model),
+    system,
     messages: convertToModelMessages(messages),
   })
 
@@ -145,11 +152,10 @@ export default function VercelAiSdkExamplesPage() {
 
       <DocsH2 id="how-it-works">How it works</DocsH2>
       <DocsP>
-        Prompt Area is provider-agnostic — it produces structured segments, and you decide what to
-        send. To feed the AI SDK, flatten the segments to a string with{' '}
-        <code>segmentsToPlainText()</code> and pass it to <code>sendMessage</code>. Mentions,
-        commands, and tags resolve to their display text, so a model-friendly prompt falls out for
-        free.
+        On submit, flatten the segments to a string with <code>segmentsToPlainText()</code> and pass
+        it to <code>sendMessage</code>. Mentions, commands, and tags resolve to their display text,
+        so a model-friendly prompt falls out for free; <code>useChat</code> appends it to{' '}
+        <code>messages</code> and POSTs to your route.
       </DocsP>
       <DocsP>
         The AI SDK&apos;s <code>status</code> (<code>ready</code>, <code>submitted</code>,{' '}
@@ -189,8 +195,8 @@ export default function VercelAiSdkExamplesPage() {
       <DocsH2 id="attachments">Attachments</DocsH2>
       <DocsP>
         Prompt Area handles the attachment UI — pasted screenshots and picked files render as
-        thumbnails with loading and remove states. The AI SDK accepts files on the same call:
-        collect them into a <code>FileList</code> and pass{' '}
+        thumbnails with loading and remove states. The AI SDK accepts files on the same call: hand
+        the underlying <code>File</code> objects to{' '}
         <code>sendMessage(&#123; text, files &#125;)</code>. See{' '}
         <Link
           href="/docs/examples/attachments"

--- a/app/docs/examples/vercel-ai-sdk/page.tsx
+++ b/app/docs/examples/vercel-ai-sdk/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${SITE_URL}/docs/examples/vercel-ai-sdk` },
 }
 
-const INSTALL_CMD = 'npm install ai @ai-sdk/react @ai-sdk/anthropic'
+const INSTALL_CMD = 'npm install ai @ai-sdk/react @ai-sdk/anthropic zod'
 
 const STRUCTURED_CONTEXT_CODE = `import { getChipsByTrigger, segmentsToPlainText } from '@/components/segment-helpers'
 
@@ -37,12 +37,27 @@ function handleSubmit() {
   setSegments([])
 }`
 
-const SERVER_CONTEXT_CODE = `export async function POST(req: Request) {
-  // Read the extra fields you attached via \`body\` on sendMessage.
-  const { messages, mentions, command, model } = await req.json()
+const SERVER_CONTEXT_CODE = `import { anthropic } from '@ai-sdk/anthropic'
+import { convertToModelMessages, streamText, type UIMessage } from 'ai'
+import { z } from 'zod'
+
+// Allowlist everything you accept — the request body is untrusted input.
+const bodySchema = z.object({
+  messages: z.array(z.custom<UIMessage>()),
+  model: z.enum(['claude-opus-4-8', 'claude-haiku-4-5']).default('claude-opus-4-8'),
+  command: z.enum(['summarize', 'translate']).optional(),
+  mentions: z.array(z.string().max(64)).max(10).default([]),
+})
+
+export async function POST(req: Request) {
+  const parsed = bodySchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.issues }, { status: 400 })
+  }
+  const { messages, model, command, mentions } = parsed.data
 
   const result = streamText({
-    model: anthropic(model ?? 'claude-opus-4-8'),
+    model: anthropic(model),
     system: command
       ? \`The user invoked the "\${command}" command. Follow its conventions.\`
       : 'You are a helpful assistant.',
@@ -160,13 +175,15 @@ export default function VercelAiSdkExamplesPage() {
       </DocsP>
       <CodeBlock code={STRUCTURED_CONTEXT_CODE} lang="tsx" />
       <DocsP>
-        Then read the extra fields in your route handler and shape the call accordingly:
+        Then validate the body with a Zod schema in your route handler and shape the call from the
+        parsed, allowlisted values:
       </DocsP>
       <CodeBlock code={SERVER_CONTEXT_CODE} lang="tsx" />
       <Callout variant="warning">
-        Request <code>body</code> is untrusted input. Validate <code>model</code>,{' '}
-        <code>command</code>, and any chip values server-side — allowlist model IDs and commands
-        rather than passing them straight through.
+        Request <code>body</code> is untrusted input. Parse it with a Zod schema and{' '}
+        <code>safeParse</code> on the server — allowlist <code>model</code> IDs and{' '}
+        <code>command</code> values with <code>z.enum()</code> and bound array sizes rather than
+        passing anything straight through to the model.
       </Callout>
 
       <DocsH2 id="attachments">Attachments</DocsH2>

--- a/app/docs/examples/vercel-ai-sdk/page.tsx
+++ b/app/docs/examples/vercel-ai-sdk/page.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { DocsLead, DocsP, DocsH2, Callout } from '@/components/docs/docs-primitives'
+import { DocsExample } from '@/components/docs/docs-example'
+import { CodeBlock } from '@/components/code-block'
+import { VercelAiSdkExample, vercelAiSdkCode } from '@/app/examples'
+
+const SITE_URL = 'https://prompt-area.com'
+
+export const metadata: Metadata = {
+  title: 'Vercel AI SDK',
+  description:
+    'Integrate Prompt Area with the Vercel AI SDK: wire onSubmit to useChat’s sendMessage, stream responses, and drive a status-aware send/stop button — chips flatten to plain text for your model.',
+  alternates: { canonical: `${SITE_URL}/docs/examples/vercel-ai-sdk` },
+}
+
+const INSTALL_CMD = 'npm install ai @ai-sdk/react @ai-sdk/anthropic'
+
+export default function VercelAiSdkExamplesPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold tracking-tight">Vercel AI SDK</h1>
+      <DocsLead>
+        Drop Prompt Area into a{' '}
+        <a
+          href="https://ai-sdk.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground font-medium underline underline-offset-4">
+          Vercel AI SDK
+        </a>{' '}
+        chatbot. PromptArea owns the input; <code>useChat</code> owns the stream. They meet at one
+        line: <code>sendMessage(&#123; text: segmentsToPlainText(segments) &#125;)</code>.
+      </DocsLead>
+
+      <DocsH2 id="install">Install</DocsH2>
+      <DocsP>
+        Add the AI SDK alongside Prompt Area. This example streams from Claude, so it uses the
+        Anthropic provider — swap in any other provider package if you prefer.
+      </DocsP>
+      <CodeBlock code={INSTALL_CMD} lang="bash" />
+
+      <DocsH2 id="example">Example</DocsH2>
+      <DocsExample
+        id="demo"
+        title="Streaming chat with useChat"
+        description="Type a message and submit. The demo simulates the AI SDK stream so it runs without a backend; the Code tab shows the real useChat + Claude wiring. The send button becomes a stop button while a response streams."
+        code={vercelAiSdkCode}>
+        <VercelAiSdkExample />
+      </DocsExample>
+
+      <Callout>
+        The live preview swaps the real <code>useChat()</code> for a small simulated hook so it can
+        run in the browser with no API key. Everything else — the <code>onSubmit</code> wiring,{' '}
+        <code>segmentsToPlainText()</code>, the status-aware send/stop button, and rendering{' '}
+        <code>message.parts</code> — is identical to the production code in the Code tab.
+      </Callout>
+
+      <DocsH2 id="how-it-works">How it works</DocsH2>
+      <DocsP>
+        Prompt Area is provider-agnostic — it produces structured segments, and you decide what to
+        send. To feed the AI SDK, flatten the segments to a string with{' '}
+        <code>segmentsToPlainText()</code> and pass it to <code>sendMessage</code>. Mentions,
+        commands, and tags resolve to their display text, so a model-friendly prompt falls out for
+        free. Need the structured data too? Read chips with <code>getChipsByTrigger()</code> and
+        attach them via the request <code>body</code>.
+      </DocsP>
+      <DocsP>
+        The AI SDK&apos;s <code>status</code> (<code>ready</code>, <code>submitted</code>,{' '}
+        <code>streaming</code>, <code>error</code>) drives the action bar: while a response streams,
+        the send button becomes a stop button wired to <code>stop()</code>. See the{' '}
+        <Link
+          href="/docs/components/action-bar"
+          className="text-foreground font-medium underline underline-offset-4">
+          Action Bar
+        </Link>{' '}
+        and{' '}
+        <Link
+          href="/docs/api/hooks"
+          className="text-foreground font-medium underline underline-offset-4">
+          Hooks &amp; Helpers
+        </Link>{' '}
+        references for the pieces used here.
+      </DocsP>
+    </>
+  )
+}

--- a/app/docs/examples/vercel-ai-sdk/page.tsx
+++ b/app/docs/examples/vercel-ai-sdk/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { DocsLead, DocsP, DocsH2, Callout } from '@/components/docs/docs-primitives'
+import { DocsLead, DocsP, DocsH2, DocsUl, Callout } from '@/components/docs/docs-primitives'
 import { DocsExample } from '@/components/docs/docs-example'
 import { CodeBlock } from '@/components/code-block'
 import { VercelAiSdkExample, vercelAiSdkCode } from '@/app/examples'
@@ -10,11 +10,47 @@ const SITE_URL = 'https://prompt-area.com'
 export const metadata: Metadata = {
   title: 'Vercel AI SDK',
   description:
-    'Integrate Prompt Area with the Vercel AI SDK: wire onSubmit to useChat’s sendMessage, stream responses, and drive a status-aware send/stop button — chips flatten to plain text for your model.',
+    'Integrate Prompt Area with the Vercel AI SDK: wire onSubmit to useChat’s sendMessage, stream responses, drive a status-aware send/stop button, and pass typed chips as request metadata — chips flatten to plain text for your model.',
   alternates: { canonical: `${SITE_URL}/docs/examples/vercel-ai-sdk` },
 }
 
 const INSTALL_CMD = 'npm install ai @ai-sdk/react @ai-sdk/anthropic'
+
+const STRUCTURED_CONTEXT_CODE = `import { getChipsByTrigger, segmentsToPlainText } from '@/components/segment-helpers'
+
+function handleSubmit() {
+  const mentions = getChipsByTrigger(segments, '@')
+  const commands = getChipsByTrigger(segments, '/')
+
+  sendMessage(
+    { text: segmentsToPlainText(segments) },
+    {
+      // Anything in \`body\` is merged into the POST to /api/chat,
+      // so typed chips travel alongside the prompt — no string parsing.
+      body: {
+        mentions: mentions.map((c) => c.value),
+        command: commands[0]?.value,
+        model: 'claude-opus-4-8',
+      },
+    },
+  )
+  setSegments([])
+}`
+
+const SERVER_CONTEXT_CODE = `export async function POST(req: Request) {
+  // Read the extra fields you attached via \`body\` on sendMessage.
+  const { messages, mentions, command, model } = await req.json()
+
+  const result = streamText({
+    model: anthropic(model ?? 'claude-opus-4-8'),
+    system: command
+      ? \`The user invoked the "\${command}" command. Follow its conventions.\`
+      : 'You are a helpful assistant.',
+    messages: convertToModelMessages(messages),
+  })
+
+  return result.toUIMessageStreamResponse()
+}`
 
 export default function VercelAiSdkExamplesPage() {
   return (
@@ -33,12 +69,48 @@ export default function VercelAiSdkExamplesPage() {
         line: <code>sendMessage(&#123; text: segmentsToPlainText(segments) &#125;)</code>.
       </DocsLead>
 
+      <DocsP>
+        The AI SDK gives you transport, streaming, and message state for free. Prompt Area gives you
+        a rich composer — mentions, slash commands, tags, inline markdown, and attachments — that
+        most chat starters skip. Because Prompt Area is just a controlled <code>Segment[]</code>{' '}
+        value, it sits cleanly between the two: you keep the AI SDK&apos;s runtime and add a real
+        input on top.
+      </DocsP>
+
+      <DocsUl
+        items={[
+          <>
+            <strong>One integration seam.</strong> Flatten segments with{' '}
+            <code>segmentsToPlainText()</code> and hand them to <code>sendMessage</code>. No bespoke
+            serialization.
+          </>,
+          <>
+            <strong>Status-aware controls.</strong> The AI SDK&apos;s <code>status</code> drives the
+            action bar — the send button becomes a stop button while a response streams.
+          </>,
+          <>
+            <strong>Structured metadata.</strong> Read typed chips with{' '}
+            <code>getChipsByTrigger()</code> and ship them in the request <code>body</code> next to
+            the prompt.
+          </>,
+          <>
+            <strong>Provider-agnostic.</strong> Swap <code>@ai-sdk/anthropic</code> for any other
+            provider package — the component code is identical.
+          </>,
+        ]}
+      />
+
       <DocsH2 id="install">Install</DocsH2>
       <DocsP>
         Add the AI SDK alongside Prompt Area. This example streams from Claude, so it uses the
-        Anthropic provider — swap in any other provider package if you prefer.
+        Anthropic provider — swap in another provider package (<code>@ai-sdk/openai</code>,{' '}
+        <code>@ai-sdk/google</code>, …) if you prefer.
       </DocsP>
       <CodeBlock code={INSTALL_CMD} lang="bash" />
+      <DocsP>
+        The Anthropic provider reads <code>ANTHROPIC_API_KEY</code> from the environment. Set it in{' '}
+        <code>.env.local</code> before calling the route.
+      </DocsP>
 
       <DocsH2 id="example">Example</DocsH2>
       <DocsExample
@@ -62,26 +134,93 @@ export default function VercelAiSdkExamplesPage() {
         send. To feed the AI SDK, flatten the segments to a string with{' '}
         <code>segmentsToPlainText()</code> and pass it to <code>sendMessage</code>. Mentions,
         commands, and tags resolve to their display text, so a model-friendly prompt falls out for
-        free. Need the structured data too? Read chips with <code>getChipsByTrigger()</code> and
-        attach them via the request <code>body</code>.
+        free.
       </DocsP>
       <DocsP>
         The AI SDK&apos;s <code>status</code> (<code>ready</code>, <code>submitted</code>,{' '}
         <code>streaming</code>, <code>error</code>) drives the action bar: while a response streams,
-        the send button becomes a stop button wired to <code>stop()</code>. See the{' '}
-        <Link
-          href="/docs/components/action-bar"
-          className="text-foreground font-medium underline underline-offset-4">
-          Action Bar
-        </Link>{' '}
-        and{' '}
-        <Link
-          href="/docs/api/hooks"
-          className="text-foreground font-medium underline underline-offset-4">
-          Hooks &amp; Helpers
-        </Link>{' '}
-        references for the pieces used here.
+        the send button becomes a stop button wired to <code>stop()</code>. Guard{' '}
+        <code>handleSubmit</code> on both <code>isSegmentsEmpty(segments)</code> and the streaming
+        state so a press during generation is a no-op rather than a second request.
       </DocsP>
+      <DocsP>
+        On the server, <code>convertToModelMessages()</code> turns the UI message history into the
+        provider format, <code>streamText()</code> calls the model, and{' '}
+        <code>toUIMessageStreamResponse()</code> streams it back in the shape <code>useChat</code>{' '}
+        expects. Render each assistant reply by mapping over <code>message.parts</code> and picking
+        the <code>text</code> parts.
+      </DocsP>
+
+      <DocsH2 id="structured-context">Send structured context</DocsH2>
+      <DocsP>
+        Flattening to text is enough for a plain chatbot, but the whole point of chips is keeping
+        structure. Read them back with <code>getChipsByTrigger()</code> and attach them to the
+        request <code>body</code> — the AI SDK merges <code>body</code> into the POST, so your route
+        receives them next to <code>messages</code>.
+      </DocsP>
+      <CodeBlock code={STRUCTURED_CONTEXT_CODE} lang="tsx" />
+      <DocsP>
+        Then read the extra fields in your route handler and shape the call accordingly:
+      </DocsP>
+      <CodeBlock code={SERVER_CONTEXT_CODE} lang="tsx" />
+      <Callout variant="warning">
+        Request <code>body</code> is untrusted input. Validate <code>model</code>,{' '}
+        <code>command</code>, and any chip values server-side — allowlist model IDs and commands
+        rather than passing them straight through.
+      </Callout>
+
+      <DocsH2 id="attachments">Attachments</DocsH2>
+      <DocsP>
+        Prompt Area handles the attachment UI — pasted screenshots and picked files render as
+        thumbnails with loading and remove states. The AI SDK accepts files on the same call:
+        collect them into a <code>FileList</code> and pass{' '}
+        <code>sendMessage(&#123; text, files &#125;)</code>. See{' '}
+        <Link
+          href="/docs/examples/attachments"
+          className="text-foreground font-medium underline underline-offset-4">
+          Attachments
+        </Link>{' '}
+        for the image and file props.
+      </DocsP>
+
+      <DocsH2 id="next-steps">Next steps</DocsH2>
+      <DocsUl
+        items={[
+          <>
+            <Link
+              href="/docs/components/action-bar"
+              className="text-foreground font-medium underline underline-offset-4">
+              Action Bar
+            </Link>{' '}
+            — the toolbar that hosts the send/stop button and any extra controls.
+          </>,
+          <>
+            <Link
+              href="/docs/examples/dx-helpers"
+              className="text-foreground font-medium underline underline-offset-4">
+              DX Helpers
+            </Link>{' '}
+            — <code>usePromptAreaState()</code>, trigger presets, and{' '}
+            <code>getChipsByTrigger()</code>.
+          </>,
+          <>
+            <Link
+              href="/docs/components/chat-prompt-layout"
+              className="text-foreground font-medium underline underline-offset-4">
+              Chat Prompt Layout
+            </Link>{' '}
+            — a scrollable message list with a pinned composer to wrap this example.
+          </>,
+          <>
+            <Link
+              href="/docs/api/hooks"
+              className="text-foreground font-medium underline underline-offset-4">
+              Hooks &amp; Helpers
+            </Link>{' '}
+            — full signatures for the helpers used here.
+          </>,
+        ]}
+      />
     </>
   )
 }

--- a/app/examples/index.ts
+++ b/app/examples/index.ts
@@ -28,3 +28,4 @@ export { ClaudeCodeInputExample, claudeCodeInputCode } from './claude-code-input
 export { CodexInputExample, codexInputCode } from './codex-input'
 export { ChatGptInputExample, chatgptInputCode } from './chatgpt-input'
 export { PerplexityInputExample, perplexityInputCode } from './perplexity-input'
+export { VercelAiSdkExample, vercelAiSdkCode } from './vercel-ai-sdk'

--- a/app/examples/vercel-ai-sdk.tsx
+++ b/app/examples/vercel-ai-sdk.tsx
@@ -1,0 +1,267 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ArrowUp, Square } from 'lucide-react'
+import {
+  PromptArea,
+  ActionBar,
+  segmentsToPlainText,
+  isSegmentsEmpty,
+  type Segment,
+  type PromptAreaHandle,
+} from 'prompt-area'
+
+// --- Simulated AI SDK chat ------------------------------------------------
+// The docs run in the browser with no backend or API key, so this example
+// ships a tiny stand-in for the AI SDK's `useChat`. It mirrors the real hook's
+// surface — `messages` (with `parts`), `status`, `sendMessage`, and `stop` — so
+// the wiring shown in the live demo matches the production code below verbatim.
+// In your app you swap `useSimulatedChat()` for `useChat()` from `@ai-sdk/react`
+// and delete everything in this section.
+
+type UIPart = { type: 'text'; text: string }
+type UIMessage = { id: string; role: 'user' | 'assistant'; parts: UIPart[] }
+type ChatStatus = 'ready' | 'submitted' | 'streaming' | 'error'
+
+const CANNED_REPLY =
+  'PromptArea hands the AI SDK plain text via segmentsToPlainText(), and the AI SDK streams the response back token by token. Try @mentions, /commands, or **markdown** — chips resolve to text before they reach your model.'
+
+function useSimulatedChat() {
+  const [messages, setMessages] = useState<UIMessage[]>([])
+  const [status, setStatus] = useState<ChatStatus>('ready')
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([])
+
+  const clearTimers = useCallback(() => {
+    timers.current.forEach(clearTimeout)
+    timers.current = []
+  }, [])
+
+  useEffect(() => clearTimers, [clearTimers])
+
+  const stop = useCallback(() => {
+    clearTimers()
+    setStatus('ready')
+  }, [clearTimers])
+
+  const sendMessage = useCallback(({ text }: { text: string }) => {
+    const userMessage: UIMessage = {
+      id: `u-${Date.now()}`,
+      role: 'user',
+      parts: [{ type: 'text', text }],
+    }
+    const assistantId = `a-${Date.now()}`
+    setMessages((prev) => [
+      ...prev,
+      userMessage,
+      { id: assistantId, role: 'assistant', parts: [{ type: 'text', text: '' }] },
+    ])
+    setStatus('submitted')
+
+    const words = CANNED_REPLY.split(' ')
+    timers.current.push(
+      setTimeout(() => {
+        setStatus('streaming')
+        words.forEach((word, i) => {
+          timers.current.push(
+            setTimeout(() => {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, parts: [{ type: 'text', text: words.slice(0, i + 1).join(' ') }] }
+                    : m,
+                ),
+              )
+              if (i === words.length - 1) setStatus('ready')
+            }, i * 45),
+          )
+        })
+      }, 400),
+    )
+  }, [])
+
+  return { messages, status, sendMessage, stop }
+}
+
+// --- Example --------------------------------------------------------------
+
+const SEND_BUTTON_CLASS =
+  'rounded-lg bg-primary p-1.5 text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50'
+const STOP_BUTTON_CLASS = 'rounded-lg border p-1.5 transition-colors hover:bg-muted'
+
+export function VercelAiSdkExample() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const promptRef = useRef<PromptAreaHandle>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const { messages, status, sendMessage, stop } = useSimulatedChat()
+
+  const isStreaming = status === 'submitted' || status === 'streaming'
+  const isEmpty = isSegmentsEmpty(segments)
+
+  const handleSubmit = useCallback(() => {
+    if (isSegmentsEmpty(segments) || isStreaming) return
+    sendMessage({ text: segmentsToPlainText(segments) })
+    promptRef.current?.clear()
+    setSegments([])
+  }, [segments, isStreaming, sendMessage])
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
+  }, [messages])
+
+  return (
+    <div className="flex h-[460px] flex-col rounded-lg border">
+      <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto p-4">
+        {messages.length === 0 ? (
+          <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+            Send a message to start streaming a response.
+          </div>
+        ) : (
+          messages.map((message) => (
+            <div
+              key={message.id}
+              className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm ${
+                  message.role === 'user'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-foreground'
+                }`}>
+                {message.parts.map((part, i) =>
+                  part.type === 'text' ? <span key={i}>{part.text}</span> : null,
+                )}
+                {message.role === 'assistant' &&
+                  isStreaming &&
+                  message.id === messages[messages.length - 1]?.id && (
+                    <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse bg-current align-middle" />
+                  )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="border-t p-3">
+        <PromptArea
+          ref={promptRef}
+          value={segments}
+          onChange={setSegments}
+          placeholder="Send a message..."
+          onSubmit={handleSubmit}
+          autoGrow
+          minHeight={44}
+          maxHeight={160}
+        />
+        <ActionBar
+          right={
+            isStreaming ? (
+              <button
+                type="button"
+                className={STOP_BUTTON_CLASS}
+                aria-label="Stop generating"
+                onClick={stop}>
+                <Square className="size-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={SEND_BUTTON_CLASS}
+                aria-label="Send message"
+                disabled={isEmpty}
+                onClick={handleSubmit}>
+                <ArrowUp className="size-4" />
+              </button>
+            )
+          }
+        />
+      </div>
+    </div>
+  )
+}
+
+export const vercelAiSdkCode = `// app/api/chat/route.ts — stream completions from Claude via the AI SDK
+import { anthropic } from '@ai-sdk/anthropic'
+import { convertToModelMessages, streamText, type UIMessage } from 'ai'
+
+export const maxDuration = 30
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json()
+
+  const result = streamText({
+    model: anthropic('claude-opus-4-8'),
+    system: 'You are a helpful assistant.',
+    messages: convertToModelMessages(messages),
+  })
+
+  return result.toUIMessageStreamResponse()
+}
+
+// chat.tsx — PromptArea wired to useChat
+'use client'
+
+import { useState } from 'react'
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import { ArrowUp, Square } from 'lucide-react'
+import { PromptArea } from '@/components/prompt-area'
+import { ActionBar } from '@/components/action-bar'
+import { segmentsToPlainText, isSegmentsEmpty } from '@/components/segment-helpers'
+import type { Segment } from '@/components/types'
+
+export function Chat() {
+  const [segments, setSegments] = useState<Segment[]>([])
+  const { messages, status, sendMessage, stop } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat' }),
+  })
+
+  const isStreaming = status === 'submitted' || status === 'streaming'
+
+  const handleSubmit = () => {
+    if (isSegmentsEmpty(segments) || isStreaming) return
+    // Chips (mentions, commands, tags) flatten to plain text for the model.
+    sendMessage({ text: segmentsToPlainText(segments) })
+    setSegments([])
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="space-y-4">
+        {messages.map((message) => (
+          <div key={message.id} className={message.role === 'user' ? 'text-right' : 'text-left'}>
+            {message.parts.map((part, i) =>
+              part.type === 'text' ? <span key={i}>{part.text}</span> : null,
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-lg border p-3">
+        <PromptArea
+          value={segments}
+          onChange={setSegments}
+          placeholder="Send a message..."
+          onSubmit={handleSubmit}
+          autoGrow
+          minHeight={44}
+        />
+        <ActionBar
+          right={
+            isStreaming ? (
+              <button type="button" onClick={stop} aria-label="Stop generating">
+                <Square className="size-4" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isSegmentsEmpty(segments)}
+                aria-label="Send message">
+                <ArrowUp className="size-4" />
+              </button>
+            )
+          }
+        />
+      </div>
+    </div>
+  )
+}`

--- a/app/examples/vercel-ai-sdk.tsx
+++ b/app/examples/vercel-ai-sdk.tsx
@@ -181,16 +181,25 @@ export function VercelAiSdkExample() {
 export const vercelAiSdkCode = `// app/api/chat/route.ts — stream completions from Claude via the AI SDK
 import { anthropic } from '@ai-sdk/anthropic'
 import { convertToModelMessages, streamText, type UIMessage } from 'ai'
+import { z } from 'zod'
 
 export const maxDuration = 30
 
+// Validate the request body — never trust what the client POSTs.
+const bodySchema = z.object({
+  messages: z.array(z.custom<UIMessage>()),
+})
+
 export async function POST(req: Request) {
-  const { messages }: { messages: UIMessage[] } = await req.json()
+  const parsed = bodySchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.issues }, { status: 400 })
+  }
 
   const result = streamText({
     model: anthropic('claude-opus-4-8'),
     system: 'You are a helpful assistant.',
-    messages: convertToModelMessages(messages),
+    messages: convertToModelMessages(parsed.data.messages),
   })
 
   return result.toUIMessageStreamResponse()

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -8,7 +8,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   return (
     <>
       <SiteHeader />
-      <main role="main" className="min-h-screen overflow-x-hidden">
+      <main role="main" className="min-h-screen overflow-x-clip">
         {children}
       </main>
     </>

--- a/components/docs/docs-primitives.tsx
+++ b/components/docs/docs-primitives.tsx
@@ -14,7 +14,7 @@ export function DocsP({ children }: { children: ReactNode }) {
 
 export function DocsH2({ id, children }: { id: string; children: ReactNode }) {
   return (
-    <h2 id={id} className="group/h scroll-mt-24 pt-4 text-xl font-semibold tracking-tight">
+    <h2 id={id} className="group/h scroll-mt-28 pt-4 text-xl font-semibold tracking-tight">
       <a href={`#${id}`} className="hover:underline">
         {children}
       </a>
@@ -24,7 +24,7 @@ export function DocsH2({ id, children }: { id: string; children: ReactNode }) {
 
 export function DocsH3({ id, children }: { id: string; children: ReactNode }) {
   return (
-    <h3 id={id} className="scroll-mt-24 pt-2 text-base font-semibold">
+    <h3 id={id} className="scroll-mt-28 pt-2 text-base font-semibold">
       <a href={`#${id}`} className="hover:underline">
         {children}
       </a>

--- a/lib/docs-navigation.ts
+++ b/lib/docs-navigation.ts
@@ -41,6 +41,7 @@ export const docsNavigation: NavSection[] = [
       { title: 'Formatting', href: '/docs/examples/formatting' },
       { title: 'Attachments', href: '/docs/examples/attachments' },
       { title: 'DX Helpers', href: '/docs/examples/dx-helpers' },
+      { title: 'Vercel AI SDK', href: '/docs/examples/vercel-ai-sdk' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
Adds a comprehensive example demonstrating how to integrate Prompt Area with the Vercel AI SDK's `useChat` hook for building streaming chat interfaces.

## Changes
- **New example component** (`app/examples/vercel-ai-sdk.tsx`): 
  - Implements `VercelAiSdkExample` component showcasing a chat interface with streaming responses
  - Includes a simulated `useSimulatedChat()` hook that mirrors the real AI SDK's `useChat` API surface (`messages`, `status`, `sendMessage`, `stop`)
  - Demonstrates the key integration pattern: `sendMessage({ text: segmentsToPlainText(segments) })`
  - Shows status-aware UI: send button becomes stop button while streaming
  - Includes production code example in `vercelAiSdkCode` string showing real Claude integration via Anthropic provider

- **New documentation page** (`app/docs/examples/vercel-ai-sdk/page.tsx`):
  - Explains installation of AI SDK packages
  - Documents the integration pattern and how chips flatten to plain text
  - Clarifies the difference between the simulated demo and production code
  - Links to related documentation (Action Bar, Hooks & Helpers)

- **Updated navigation**:
  - Added "Vercel AI SDK" example to the examples index
  - Updated docs navigation to include the new example page

## Implementation Details
- The simulated chat hook uses `setTimeout` to stream words token-by-token, matching the real AI SDK's streaming behavior
- Segments are converted to plain text via `segmentsToPlainText()` before being sent to the model, allowing mentions, commands, and tags to resolve naturally
- The example demonstrates proper state management: clearing segments after submission, handling streaming status, and auto-scrolling the message list
- Production code shows the minimal wiring needed: swap `useSimulatedChat()` for `useChat()` from `@ai-sdk/react` and point to your API route

https://claude.ai/code/session_01KMrb153GGLiWFkAjrgo4hP