### PR TITLE
Add descriptions to tag definitions across examples and mock data

### DIFF
--- a/app/examples/tags.tsx
+++ b/app/examples/tags.tsx
@@ -4,11 +4,11 @@ import { useState } from 'react'
 import { PromptArea, type Segment } from 'prompt-area'
 
 const TAGS = [
-  { value: 'campaign', label: 'campaign' },
-  { value: 'lead-gen', label: 'lead-gen' },
-  { value: 'conversion', label: 'conversion' },
-  { value: 'branding', label: 'branding' },
-  { value: 'outbound', label: 'outbound' },
+  { value: 'campaign', label: 'campaign', description: 'Marketing initiatives' },
+  { value: 'lead-gen', label: 'lead-gen', description: 'Top-of-funnel capture' },
+  { value: 'conversion', label: 'conversion', description: 'Funnel optimization' },
+  { value: 'branding', label: 'branding', description: 'Brand & identity' },
+  { value: 'outbound', label: 'outbound', description: 'Cold outreach' },
 ]
 
 export function TagsExample() {
@@ -40,10 +40,10 @@ import { PromptArea } from '@/components/prompt-area'
 import type { Segment } from '@/components/types'
 
 const TAGS = [
-  { value: 'campaign', label: 'campaign' },
-  { value: 'lead-gen', label: 'lead-gen' },
-  { value: 'conversion', label: 'conversion' },
-  { value: 'branding', label: 'branding' },
+  { value: 'campaign', label: 'campaign', description: 'Marketing initiatives' },
+  { value: 'lead-gen', label: 'lead-gen', description: 'Top-of-funnel capture' },
+  { value: 'conversion', label: 'conversion', description: 'Funnel optimization' },
+  { value: 'branding', label: 'branding', description: 'Brand & identity' },
 ]
 
 function TagsExample() {

--- a/app/sections/mock-data.ts
+++ b/app/sections/mock-data.ts
@@ -31,9 +31,9 @@ export const COMMANDS = [
 ]
 
 export const TAGS = [
-  { value: 'campaign', label: 'campaign' },
-  { value: 'lead-gen', label: 'lead-gen' },
-  { value: 'conversion', label: 'conversion' },
-  { value: 'branding', label: 'branding' },
-  { value: 'outbound', label: 'outbound' },
+  { value: 'campaign', label: 'campaign', description: 'Marketing initiatives' },
+  { value: 'lead-gen', label: 'lead-gen', description: 'Top-of-funnel capture' },
+  { value: 'conversion', label: 'conversion', description: 'Funnel optimization' },
+  { value: 'branding', label: 'branding', description: 'Brand & identity' },
+  { value: 'outbound', label: 'outbound', description: 'Cold outreach' },
 ]


### PR DESCRIPTION
## Summary
Added descriptive text to all tag definitions to provide better context and improve user experience when selecting tags in the prompt area component.

## Changes
- Added `description` field to each tag object in the TAGS array with contextual information:
  - `campaign`: "Marketing initiatives"
  - `lead-gen`: "Top-of-funnel capture"
  - `conversion`: "Funnel optimization"
  - `branding`: "Brand & identity"
  - `outbound`: "Cold outreach"

## Files Modified
- `app/examples/tags.tsx` - Updated both the example component and code snippet documentation
- `app/sections/mock-data.ts` - Updated the shared TAGS mock data export

These descriptions can now be displayed in the UI to help users understand the purpose of each tag option.

https://claude.ai/code/session_01XpdWyiz2W55YnKcHDUp9gq