### PR TITLE
Add scroll-reveal motion to the homepage

### DIFF
--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -169,9 +169,11 @@ export default function HomeContent() {
             Compose the input with companions to build full chat experiences.
           </p>
         </Reveal>
-        <RevealGroup className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {/* Per-card reveals (not a group stagger) so the cascade still lands when
+            the grid stacks into one tall column on mobile. */}
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {COMPONENTS.map((c) => (
-            <RevealItem key={c.href}>
+            <Reveal key={c.href} className="h-full">
               <Link
                 href={c.href}
                 className="group hover:bg-accent/40 flex h-full items-start justify-between gap-3 rounded-lg border p-5 transition-colors">
@@ -181,9 +183,9 @@ export default function HomeContent() {
                 </span>
                 <ArrowRight className="text-muted-foreground mt-0.5 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
               </Link>
-            </RevealItem>
+            </Reveal>
           ))}
-        </RevealGroup>
+        </div>
       </section>
 
       {/* Built-in styles */}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
+import { Reveal, RevealGroup, RevealItem } from '@/components/reveal'
 import { RotatingTitle } from '@/components/rotating-title'
 import { FeaturesGrid } from './sections/features-grid'
 import { StylesCarousel } from './sections/styles-carousel'
@@ -92,20 +93,28 @@ export default function HomeContent() {
       {/* Hero */}
       <section className="mx-auto w-full max-w-6xl px-4 pt-16 pb-16 sm:pt-24">
         <div className="grid grid-cols-1 items-center gap-10 lg:grid-cols-[1fr_1.2fr] lg:gap-12">
-          {/* Copy + install */}
-          <div className="flex min-w-0 flex-col items-center gap-6 text-center lg:items-start lg:text-left">
-            <span className="border-border text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs">
-              npm + shadcn · zero dependencies
-            </span>
-            <RotatingTitle className="max-w-3xl text-4xl font-bold tracking-tight text-balance sm:text-5xl md:text-6xl" />
-            <p className="text-muted-foreground max-w-2xl text-lg text-balance">
-              A production-grade textarea for AI chat interfaces — @mentions, /commands, #tags,
-              inline markdown, and file attachments in one contentEditable component.
-            </p>
-            <div className="w-full max-w-xl min-w-0">
+          {/* Copy + install — staggered into place on load */}
+          <RevealGroup
+            trigger="mount"
+            className="flex min-w-0 flex-col items-center gap-6 text-center lg:items-start lg:text-left">
+            <RevealItem>
+              <span className="border-border text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs">
+                npm + shadcn · zero dependencies
+              </span>
+            </RevealItem>
+            <RevealItem>
+              <RotatingTitle className="max-w-3xl text-4xl font-bold tracking-tight text-balance sm:text-5xl md:text-6xl" />
+            </RevealItem>
+            <RevealItem>
+              <p className="text-muted-foreground max-w-2xl text-lg text-balance">
+                A production-grade textarea for AI chat interfaces — @mentions, /commands, #tags,
+                inline markdown, and file attachments in one contentEditable component.
+              </p>
+            </RevealItem>
+            <RevealItem className="w-full max-w-xl min-w-0">
               <InstallMethodTabs />
-            </div>
-            <div className="flex flex-wrap items-center justify-center gap-3 pt-1 lg:justify-start">
+            </RevealItem>
+            <RevealItem className="flex flex-wrap items-center justify-center gap-3 pt-1 lg:justify-start">
               <Link
                 href="/docs"
                 className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
@@ -120,17 +129,21 @@ export default function HomeContent() {
                 Star on GitHub
                 <ArrowUpRight className="size-3.5" />
               </a>
-            </div>
-          </div>
-          {/* Live demo — Codex-style composer seeded with real content */}
+            </RevealItem>
+          </RevealGroup>
+          {/* Live demo — Codex-style composer seeded with real content. Opacity-only
+              (lift=false) so the composer's pop-up menus aren't anchored to a
+              transformed ancestor. */}
           <div id="demo" className="w-full min-w-0 scroll-mt-20">
-            <CodexInputExample
-              initialSegments={HERO_SEGMENTS}
-              triggers={HERO_TRIGGERS}
-              initialFiles={HERO_FILES}
-              markdown
-              minHeight={76}
-            />
+            <Reveal lift={false} delay={0.15}>
+              <CodexInputExample
+                initialSegments={HERO_SEGMENTS}
+                triggers={HERO_TRIGGERS}
+                initialFiles={HERO_FILES}
+                markdown
+                minHeight={76}
+              />
+            </Reveal>
           </div>
         </div>
       </section>
@@ -138,92 +151,99 @@ export default function HomeContent() {
       {/* Features */}
       <section className="bg-muted/20 border-y">
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-16">
-          <div className="flex flex-col gap-2 text-center">
+          <Reveal className="flex flex-col gap-2 text-center">
             <h2 className="text-2xl font-semibold tracking-tight">Everything in one input</h2>
             <p className="text-muted-foreground">
               One component replaces five libraries — no ProseMirror, Slate, or Lexical.
             </p>
-          </div>
+          </Reveal>
           <FeaturesGrid />
         </div>
       </section>
 
       {/* Components */}
       <section className="mx-auto w-full max-w-5xl px-4 py-16">
-        <div className="mb-8 flex flex-col gap-2 text-center">
+        <Reveal className="mb-8 flex flex-col gap-2 text-center">
           <h2 className="text-2xl font-semibold tracking-tight">Components &amp; layouts</h2>
           <p className="text-muted-foreground">
             Compose the input with companions to build full chat experiences.
           </p>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        </Reveal>
+        <RevealGroup className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {COMPONENTS.map((c) => (
-            <Link
-              key={c.href}
-              href={c.href}
-              className="group hover:bg-accent/40 flex items-start justify-between gap-3 rounded-lg border p-5 transition-colors">
-              <span className="flex flex-col gap-1">
-                <span className="text-sm font-semibold">{c.title}</span>
-                <span className="text-muted-foreground text-sm leading-relaxed">{c.desc}</span>
-              </span>
-              <ArrowRight className="text-muted-foreground mt-0.5 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
-            </Link>
+            <RevealItem key={c.href}>
+              <Link
+                href={c.href}
+                className="group hover:bg-accent/40 flex h-full items-start justify-between gap-3 rounded-lg border p-5 transition-colors">
+                <span className="flex flex-col gap-1">
+                  <span className="text-sm font-semibold">{c.title}</span>
+                  <span className="text-muted-foreground text-sm leading-relaxed">{c.desc}</span>
+                </span>
+                <ArrowRight className="text-muted-foreground mt-0.5 size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </RevealItem>
           ))}
-        </div>
+        </RevealGroup>
       </section>
 
       {/* Built-in styles */}
       <section className="bg-muted/20 border-y">
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-16">
-          <div className="flex flex-col gap-2 text-center">
+          <Reveal className="flex flex-col gap-2 text-center">
             <h2 className="text-2xl font-semibold tracking-tight">Built-in agent styles</h2>
             <p className="text-muted-foreground">
               Real, copy-paste compositions modeled on the agent UIs you already know.
             </p>
-          </div>
-          <StylesCarousel />
+          </Reveal>
+          <Reveal lift={false} delay={0.05}>
+            <StylesCarousel />
+          </Reveal>
         </div>
       </section>
 
       {/* Comparison teaser */}
       <section className="border-y">
-        <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-4 px-4 py-16 text-center">
-          <h2 className="text-2xl font-semibold tracking-tight">A modern alternative</h2>
-          <p className="text-muted-foreground max-w-2xl">
-            Lighter than Tiptap, Lexical, or Plate for chat inputs — and a drop-in upgrade from
-            react-mentions. See the honest, side-by-side breakdowns.
-          </p>
-          <Link
-            href="/compare"
-            className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
-            Compare alternatives
-            <ArrowRight className="size-4" />
-          </Link>
+        <div className="mx-auto w-full max-w-3xl px-4 py-16">
+          <Reveal className="flex flex-col items-center gap-4 text-center">
+            <h2 className="text-2xl font-semibold tracking-tight">A modern alternative</h2>
+            <p className="text-muted-foreground max-w-2xl">
+              Lighter than Tiptap, Lexical, or Plate for chat inputs — and a drop-in upgrade from
+              react-mentions. See the honest, side-by-side breakdowns.
+            </p>
+            <Link
+              href="/compare"
+              className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
+              Compare alternatives
+              <ArrowRight className="size-4" />
+            </Link>
+          </Reveal>
         </div>
       </section>
 
       {/* CTA */}
-      <section className="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 px-4 py-20 text-center">
-        <h2 className="text-3xl font-bold tracking-tight">Drop it into your app</h2>
-        <p className="text-muted-foreground max-w-xl">
-          Install from npm, or copy the source via the shadcn registry. Zero extra dependencies.
-        </p>
-        <div className="w-full max-w-xl">
-          <InstallMethodTabs />
-        </div>
-        <div className="flex flex-wrap items-center justify-center gap-3">
-          <Link
-            href="/docs"
-            className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
-            Read the docs
-            <ArrowRight className="size-4" />
-          </Link>
-          <Link
-            href="/docs/quick-start"
-            className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
-            Quick start
-          </Link>
-        </div>
+      <section className="mx-auto w-full max-w-3xl px-4 py-20">
+        <Reveal className="flex flex-col items-center gap-6 text-center">
+          <h2 className="text-3xl font-bold tracking-tight">Drop it into your app</h2>
+          <p className="text-muted-foreground max-w-xl">
+            Install from npm, or copy the source via the shadcn registry. Zero extra dependencies.
+          </p>
+          <div className="w-full max-w-xl">
+            <InstallMethodTabs />
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/docs"
+              className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
+              Read the docs
+              <ArrowRight className="size-4" />
+            </Link>
+            <Link
+              href="/docs/quick-start"
+              className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
+              Quick start
+            </Link>
+          </div>
+        </Reveal>
       </section>
     </div>
   )

--- a/app/sections/features-grid.tsx
+++ b/app/sections/features-grid.tsx
@@ -10,7 +10,7 @@ import {
   Keyboard,
   Puzzle,
 } from 'lucide-react'
-import { RevealGroup, RevealItem } from '@/components/reveal'
+import { Reveal } from '@/components/reveal'
 
 const FEATURES = [
   {
@@ -64,10 +64,13 @@ const FEATURES = [
 ]
 
 export function FeaturesGrid() {
+  // Each card reveals independently as it scrolls into view (rather than a
+  // single group stagger) so the effect holds up when the grid collapses to one
+  // tall column on mobile — otherwise the lower cards would animate off-screen.
   return (
-    <RevealGroup className="grid gap-3 sm:grid-cols-2">
+    <div className="grid gap-3 sm:grid-cols-2">
       {FEATURES.map((feature) => (
-        <RevealItem key={feature.title} className="flex items-start gap-3 rounded-lg border p-4">
+        <Reveal key={feature.title} className="flex items-start gap-3 rounded-lg border p-4">
           <div className="bg-muted shrink-0 rounded-md p-2">
             <feature.icon className="size-4" />
           </div>
@@ -75,8 +78,8 @@ export function FeaturesGrid() {
             <div className="text-sm font-medium">{feature.title}</div>
             <div className="text-muted-foreground text-xs">{feature.description}</div>
           </div>
-        </RevealItem>
+        </Reveal>
       ))}
-    </RevealGroup>
+    </div>
   )
 }

--- a/app/sections/features-grid.tsx
+++ b/app/sections/features-grid.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   AtSign,
   Type,
@@ -8,6 +10,7 @@ import {
   Keyboard,
   Puzzle,
 } from 'lucide-react'
+import { RevealGroup, RevealItem } from '@/components/reveal'
 
 const FEATURES = [
   {
@@ -62,9 +65,9 @@ const FEATURES = [
 
 export function FeaturesGrid() {
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
+    <RevealGroup className="grid gap-3 sm:grid-cols-2">
       {FEATURES.map((feature) => (
-        <div key={feature.title} className="flex items-start gap-3 rounded-lg border p-4">
+        <RevealItem key={feature.title} className="flex items-start gap-3 rounded-lg border p-4">
           <div className="bg-muted shrink-0 rounded-md p-2">
             <feature.icon className="size-4" />
           </div>
@@ -72,8 +75,8 @@ export function FeaturesGrid() {
             <div className="text-sm font-medium">{feature.title}</div>
             <div className="text-muted-foreground text-xs">{feature.description}</div>
           </div>
-        </div>
+        </RevealItem>
       ))}
-    </div>
+    </RevealGroup>
   )
 }

--- a/components/reveal.tsx
+++ b/components/reveal.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { motion, useReducedMotion, type Variants } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+/**
+ * Scroll-reveal primitives — the motion vocabulary for the marketing pages.
+ *
+ * Content fades and gently lifts into place the first time it enters the
+ * viewport (or on mount, above the fold), all sharing one easing curve so the
+ * page moves with a single, calm voice rather than a grab-bag of effects.
+ *
+ * Every export degrades to a plain `<div>` under `prefers-reduced-motion`, so
+ * the reduced-motion render is byte-for-byte identical in layout — only the
+ * entrance is dropped. Pass `lift={false}` (opacity only) around interactive
+ * widgets whose floating menus shouldn't sit inside a transformed ancestor.
+ */
+
+// "ease-out-expo"-ish: decelerates as it settles, reading as premium not springy.
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
+const DURATION = 0.6
+const DISTANCE = 24
+
+// Fire once, starting a little before the element is fully on-screen so the
+// motion resolves around the time it reaches a comfortable reading position.
+const VIEWPORT = { once: true, margin: '0px 0px -15% 0px' } as const
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: DISTANCE },
+  show: { opacity: 1, y: 0, transition: { duration: DURATION, ease: EASE } },
+}
+
+/**
+ * Fades + lifts its children into place the first time they scroll into view.
+ * Above-the-fold usage animates on mount (the element is already in view).
+ */
+export function Reveal({
+  children,
+  delay = 0,
+  className,
+  lift = true,
+}: {
+  children: ReactNode
+  delay?: number
+  className?: string
+  /** Disable the vertical translate (opacity-only) — avoids a lingering
+   *  `transform` ancestor that would re-anchor a child's fixed-position menus. */
+  lift?: boolean
+}) {
+  const reduce = useReducedMotion()
+  if (reduce) return <div className={className}>{children}</div>
+  return (
+    <motion.div
+      className={className}
+      initial={lift ? { opacity: 0, y: DISTANCE } : { opacity: 0 }}
+      whileInView={lift ? { opacity: 1, y: 0 } : { opacity: 1 }}
+      viewport={VIEWPORT}
+      transition={{ duration: DURATION, ease: EASE, delay }}>
+      {children}
+    </motion.div>
+  )
+}
+
+/**
+ * Staggers its {@link RevealItem} children so they cascade in one after another.
+ * `trigger="scroll"` (default) starts when the group scrolls into view;
+ * `trigger="mount"` starts immediately — use it above the fold (e.g. the hero).
+ */
+export function RevealGroup({
+  children,
+  className,
+  trigger = 'scroll',
+  stagger = 0.08,
+  delayChildren = 0.04,
+}: {
+  children: ReactNode
+  className?: string
+  trigger?: 'scroll' | 'mount'
+  stagger?: number
+  delayChildren?: number
+}) {
+  const reduce = useReducedMotion()
+  if (reduce) return <div className={className}>{children}</div>
+
+  const variants: Variants = {
+    hidden: {},
+    show: { transition: { staggerChildren: stagger, delayChildren } },
+  }
+  const activate =
+    trigger === 'mount'
+      ? { animate: 'show' as const }
+      : { whileInView: 'show' as const, viewport: VIEWPORT }
+
+  return (
+    <motion.div className={className} variants={variants} initial="hidden" {...activate}>
+      {children}
+    </motion.div>
+  )
+}
+
+/** A single staggered child. Must be rendered inside a {@link RevealGroup}. */
+export function RevealItem({ children, className }: { children: ReactNode; className?: string }) {
+  const reduce = useReducedMotion()
+  if (reduce) return <div className={className}>{children}</div>
+  return (
+    <motion.div className={className} variants={itemVariants}>
+      {children}
+    </motion.div>
+  )
+}


### PR DESCRIPTION
Introduce a small framer-motion primitive (Reveal / RevealGroup /
RevealItem) and apply it across the marketing homepage so content fades
and gently lifts into place as it scrolls into view — and the hero copy
staggers in on load. This gives the site the smooth, scroll-driven feel
of modern product landing pages.

- components/reveal.tsx: shared reveal primitives with one easing curve.
  Degrade to a plain wrapper under prefers-reduced-motion (layout
  identical), and a `lift` flag for opacity-only reveals around
  interactive composers whose pop-up menus must not sit inside a
  transformed ancestor.
- home-content.tsx: hero stagger on mount; scroll reveals on the
  features, components, styles, comparison, and CTA sections; staggered
  components grid.
- features-grid.tsx: cards cascade in via a staggered group.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AnAGiiKRzuFK8ijtb5b5He