### PR TITLE
Add AI agent install prompt with copyable component

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,22 @@ npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 ### Install with AI coding agents
 
-Copy this prompt and give it to your AI coding agent (Claude Code, Codex, Cursor, etc.):
+Copy this prompt and give it to your AI coding agent (Claude Code, Codex, Cursor, etc.). It reads the [machine-readable docs](https://prompt-area.com/llms-full.txt), installs Prompt Area (npm by default, or the shadcn registry if you ask for it), and wires it into your app — replacing any existing chat input or scaffolding a new one:
 
-> Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation.
+```text
+Install Prompt Area — a production-grade React chat/prompt input (@mentions, /commands, #tags, inline markdown, file attachments) — into this project. Do the full integration yourself; don't just print instructions.
+
+1. Read the docs first. Fetch https://prompt-area.com/llms-full.txt and read it in full. It is the source of truth for the API, props, triggers, helpers, and required CSS — use it, don't guess.
+
+2. Choose how to install, and default to the npm package:
+   - npm (default): install prompt-area with the project's package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
+   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run npx shadcn@latest add https://prompt-area.com/r/prompt-area.json, then add the .prompt-area-* component classes from the docs to globals.css.
+   If it is ambiguous, ask me once which I want; otherwise use npm.
+
+3. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+
+4. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.
+```
 
 <details>
 <summary>Add the required CSS classes to your <code>globals.css</code> after <code>@layer base</code></summary>

--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ Install Prompt Area — a production-grade React chat/prompt input (@mentions, /
 
 1. Read the docs first. Fetch https://prompt-area.com/llms-full.txt and read it in full. It is the source of truth for the API, props, triggers, helpers, and required CSS — use it, don't guess.
 
-2. Choose how to install, and default to the npm package:
-   - npm (default): install prompt-area with the project's package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
-   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run npx shadcn@latest add https://prompt-area.com/r/prompt-area.json, then add the .prompt-area-* component classes from the docs to globals.css.
-   If it is ambiguous, ask me once which I want; otherwise use npm.
+2. Detect the project's package manager from its lockfile (npm, yarn, pnpm, or bun) and use it for every install and CLI command below.
 
-3. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+3. Choose how to install, and default to the npm package:
+   - npm package (default): add prompt-area with the detected package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
+   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run shadcn@latest add https://prompt-area.com/r/prompt-area.json with the detected package manager's runner (npx, pnpm dlx, yarn dlx, or bunx), then add the .prompt-area-* component classes from the docs to globals.css.
+   If it is ambiguous, ask me once which I want; otherwise use the npm package.
 
-4. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.
+4. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+
+5. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.
 ```
 
 <details>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { COMPARISONS, SITE_URL } from '../vs/comparisons'
 import { ComparisonSection } from '../sections/comparison-section'
+import { InstallCta } from '@/components/install-cta'
 
 export const metadata: Metadata = {
   title: 'Compare Prompt Area vs Tiptap, Lexical, Plate.js & react-mentions',
@@ -58,6 +59,10 @@ export default function ComparePage() {
           chat or prompt input.
         </p>
         <ComparisonSection />
+      </section>
+
+      <section className="border-t pt-10">
+        <InstallCta />
       </section>
     </div>
   )

--- a/app/docs/installation/page.tsx
+++ b/app/docs/installation/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { CodeBlock } from '@/components/code-block'
 import { PackageManagerTabs } from '@/components/package-manager-tabs'
+import { InstallPromptBox } from '@/components/install-prompt-box'
 import { DocsLead, DocsP, DocsH2, Callout } from '@/components/docs/docs-primitives'
 
 const SITE_URL = 'https://prompt-area.com'
@@ -133,16 +134,11 @@ npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json`}
           className="text-foreground font-medium underline underline-offset-4">
           /llms-full.txt
         </a>
-        . Give your coding agent (Claude Code, Cursor, Codex) this prompt:
+        . Copy this prompt into your coding agent (Claude Code, Cursor, Codex, …) — it reads the
+        docs, installs Prompt Area (npm by default, or the shadcn registry if you ask for it), and
+        wires it into your app, replacing any existing chat input or scaffolding a new one:
       </DocsP>
-      <CodeBlock
-        lang="bash"
-        code={`Fetch https://prompt-area.com/llms-full.txt and read the full
-documentation. Install the prompt-area component by running:
-npx shadcn@latest add https://prompt-area.com/r/prompt-area.json
-then add the required CSS classes to globals.css and help me
-build a prompt input.`}
-      />
+      <InstallPromptBox />
 
       <Callout>
         Next:{' '}

--- a/app/for-ai-apps/page.tsx
+++ b/app/for-ai-apps/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowLeft, ArrowUpRight, Bot, Boxes, Code2, Plug, ShieldCheck, Zap } from 'lucide-react'
 import { CodeBlock } from '@/components/code-block'
+import { InstallMethodTabs } from '@/components/install-method-tabs'
 
 const SITE_URL = 'https://prompt-area.com'
-const INSTALL_CMD = 'npx shadcn@latest add https://prompt-area.com/r/prompt-area.json'
 
 export const metadata: Metadata = {
   title: 'React Input for AI Chatbots & LLM Apps — Prompt Area',
@@ -167,9 +167,9 @@ await streamChat({
   command,
 })`}
         />
-        <code className="bg-background text-foreground overflow-x-auto rounded-md border px-3 py-2 font-mono text-xs">
-          {INSTALL_CMD}
-        </code>
+        <div className="max-w-xl">
+          <InstallMethodTabs />
+        </div>
       </section>
 
       <section className="flex flex-col gap-4">

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
+import { InstallCta } from '@/components/install-cta'
 import { Reveal, RevealGroup, RevealItem } from '@/components/reveal'
 import { RotatingTitle } from '@/components/rotating-title'
 import { FeaturesGrid } from './sections/features-grid'
@@ -224,27 +225,8 @@ export default function HomeContent() {
 
       {/* CTA */}
       <section className="mx-auto w-full max-w-3xl px-4 py-20">
-        <Reveal className="flex flex-col items-center gap-6 text-center">
-          <h2 className="text-3xl font-bold tracking-tight">Drop it into your app</h2>
-          <p className="text-muted-foreground max-w-xl">
-            Install from npm, or copy the source via the shadcn registry. Zero extra dependencies.
-          </p>
-          <div className="w-full max-w-xl">
-            <InstallMethodTabs />
-          </div>
-          <div className="flex flex-wrap items-center justify-center gap-3">
-            <Link
-              href="/docs"
-              className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
-              Read the docs
-              <ArrowRight className="size-4" />
-            </Link>
-            <Link
-              href="/docs/quick-start"
-              className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
-              Quick start
-            </Link>
-          </div>
+        <Reveal>
+          <InstallCta />
         </Reveal>
       </section>
     </div>

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { ExampleShowcase } from '@/components/example-showcase'
+import { InstallCta } from '@/components/install-cta'
 import { StyleLogo } from '@/components/style-logo'
 import { ClaudeInputExample, claudeInputCode } from '@/app/examples/claude-input'
 import { ClaudeCodeInputExample, claudeCodeInputCode } from '@/app/examples/claude-code-input'
@@ -251,6 +252,10 @@ export default function StylesPage() {
             Components
           </Link>
         </div>
+      </section>
+
+      <section className="border-t pt-10">
+        <InstallCta />
       </section>
     </div>
   )

--- a/components/install-cta.tsx
+++ b/components/install-cta.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import { InstallMethodTabs } from '@/components/install-method-tabs'
+import { cn } from '@/lib/utils'
+
+/**
+ * Reusable "Drop it into your app" install call-to-action: a heading, blurb,
+ * the AI agent / npm / shadcn install tabs, and links into the docs. Shared by
+ * the homepage CTA and the marketing pages so every page offers the same
+ * one-stop install — including the copy-paste AI agent prompt.
+ */
+export function InstallCta({
+  className,
+  heading = 'Drop it into your app',
+  description = 'Install with an AI agent, from npm, or copy the source via the shadcn registry. Zero extra dependencies.',
+}: {
+  className?: string
+  heading?: string
+  description?: string
+}) {
+  return (
+    <div className={cn('flex flex-col items-center gap-6 text-center', className)}>
+      <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">{heading}</h2>
+      <p className="text-muted-foreground max-w-xl">{description}</p>
+      <div className="w-full max-w-xl">
+        <InstallMethodTabs />
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href="/docs"
+          className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
+          Read the docs
+          <ArrowRight className="size-4" />
+        </Link>
+        <Link
+          href="/docs/quick-start"
+          className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
+          Quick start
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/components/install-method-tabs.tsx
+++ b/components/install-method-tabs.tsx
@@ -23,7 +23,7 @@ export function InstallMethodTabs({ block = 'prompt-area' }: { block?: string })
       tabs={[
         {
           label: 'AI agent',
-          content: <InstallPromptBox />,
+          content: <InstallPromptBox compact />,
         },
         {
           label: 'npm',

--- a/components/install-method-tabs.tsx
+++ b/components/install-method-tabs.tsx
@@ -1,23 +1,34 @@
 import { CodeTabs } from '@/components/code-tabs'
 import { CommandBox } from '@/components/command-box'
+import { InstallPromptBox } from '@/components/install-prompt-box'
 import { packageManagerCommand } from '@/lib/package-managers'
 
 /**
- * Homepage install switcher: one row of tabs to pick the shadcn registry or
- * the npm package, each showing a single pnpm-default command. shadcn leads to
- * match the "shadcn chat input" framing, with the npm package one click away —
- * so the install stays consistent with the "npm + shadcn" badge instead of
- * only ever showing npm. Per-manager (pnpm / npm / yarn) commands live in the
- * docs install section.
+ * Homepage install switcher: one row of tabs to install with an AI agent, the
+ * npm package, or the shadcn registry.
  *
- * Both commands render in the static HTML (only visibility toggles), so they
- * stay crawlable.
+ * The "AI agent" tab leads with the copy-paste prompt — the lowest-effort path,
+ * and the one that does the whole integration for you. npm is next (the default
+ * distribution), with the shadcn registry one click further. Per-manager (pnpm
+ * / npm / yarn) commands live in the docs install section.
+ *
+ * The npm / shadcn commands render in the static HTML (only visibility
+ * toggles), so they stay crawlable. The AI prompt is client-rendered (it has a
+ * copy button) but mirrors the prose on /docs/installation.
  */
 export function InstallMethodTabs({ block = 'prompt-area' }: { block?: string }) {
   return (
     <CodeTabs
       label="Install method"
       tabs={[
+        {
+          label: 'AI agent',
+          content: <InstallPromptBox />,
+        },
+        {
+          label: 'npm',
+          content: <CommandBox compact cmd={packageManagerCommand('pnpm', { add: block })} />,
+        },
         {
           label: 'shadcn',
           content: (
@@ -28,10 +39,6 @@ export function InstallMethodTabs({ block = 'prompt-area' }: { block?: string })
               })}
             />
           ),
-        },
-        {
-          label: 'npm package',
-          content: <CommandBox compact cmd={packageManagerCommand('pnpm', { add: block })} />,
         },
       ]}
     />

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { INSTALL_PROMPT } from '@/lib/install-prompt'
+
+/**
+ * Copyable, multi-line "install with an AI agent" prompt. Renders the canonical
+ * INSTALL_PROMPT in a scrollable box with a copy button so users can drop it
+ * straight into Claude Code, Cursor, Codex, etc. Used by the homepage install
+ * tabs and the docs Installation page.
+ */
+export function InstallPromptBox({ className }: { className?: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = useCallback(() => {
+    navigator.clipboard?.writeText(INSTALL_PROMPT).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }, [])
+
+  return (
+    <div className={`bg-muted/50 relative rounded-lg border ${className ?? ''}`}>
+      <button
+        onClick={copy}
+        className="bg-background/80 text-muted-foreground hover:text-foreground hover:bg-background absolute top-2.5 right-2.5 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium backdrop-blur transition-colors"
+        aria-label="Copy the install prompt">
+        {copied ? (
+          <>
+            <Check className="size-3.5 text-green-600 dark:text-green-400" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Copy className="size-3.5" />
+            Copy
+          </>
+        )}
+      </button>
+      <pre className="text-foreground max-h-72 [scrollbar-width:thin] overflow-auto px-4 py-3 pr-20 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+        {INSTALL_PROMPT}
+      </pre>
+    </div>
+  )
+}

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -12,6 +12,11 @@ const TOOLBAR_BTN =
 const ICON_BTN =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors'
 
+// Bare icon button for the compact row — no padding box, so the row height is
+// governed by its 20px text line and matches the npm / shadcn command boxes
+// (no layout shift when switching tabs).
+const COMPACT_ICON_BTN = 'text-muted-foreground hover:text-foreground shrink-0 transition-colors'
+
 /** Copy the canonical install prompt to the clipboard, with copied-state feedback. */
 function useCopyPrompt() {
   const [copied, setCopied] = useState(false)
@@ -86,17 +91,17 @@ export function InstallPromptBox({
       {compact ? (
         <div
           className={cn(
-            'bg-muted/50 flex items-center gap-2.5 rounded-lg border px-4 py-3',
+            'bg-muted/50 flex items-center gap-3 rounded-lg border px-4 py-3',
             className,
           )}>
           <Sparkles className="text-muted-foreground size-4 shrink-0" />
-          <span className="text-foreground min-w-0 flex-1 truncate text-xs sm:text-sm">
+          <span className="text-foreground min-w-0 flex-1 truncate text-xs leading-5">
             Prompt for Claude Code, Cursor &amp; Codex
           </span>
           <button
             type="button"
             onClick={() => setOpen(true)}
-            className={ICON_BTN}
+            className={COMPACT_ICON_BTN}
             aria-haspopup="dialog"
             aria-label="Expand the install prompt">
             <Maximize2 className="size-4" />
@@ -104,7 +109,7 @@ export function InstallPromptBox({
           <button
             type="button"
             onClick={copy}
-            className={ICON_BTN}
+            className={COMPACT_ICON_BTN}
             aria-label="Copy the install prompt">
             {copied ? (
               <Check className="size-4 text-green-600 dark:text-green-400" />

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -1,23 +1,16 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { Check, ChevronDown, ChevronUp, Copy } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Check, Copy, Maximize2, X } from 'lucide-react'
 import { INSTALL_PROMPT } from '@/lib/install-prompt'
 
 const TOOLBAR_BTN =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors'
 
-/**
- * Copyable, multi-line "install with an AI agent" prompt. Renders the canonical
- * INSTALL_PROMPT in a box with a small toolbar (Expand / Copy) so users can
- * read the whole prompt before dropping it into Claude Code, Cursor, Codex,
- * etc. Collapsed by default to a few lines; Expand lifts the height cap. Used
- * by the homepage install tabs and the docs Installation page.
- */
-export function InstallPromptBox({ className }: { className?: string }) {
+/** Copy-to-clipboard button with copied-state feedback, reused by the box and the dialog. */
+function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
   const [copied, setCopied] = useState(false)
-  const [expanded, setExpanded] = useState(false)
-
   const copy = useCallback(() => {
     navigator.clipboard?.writeText(INSTALL_PROMPT).then(() => {
       setCopied(true)
@@ -26,50 +19,105 @@ export function InstallPromptBox({ className }: { className?: string }) {
   }, [])
 
   return (
-    <div className={`bg-muted/50 overflow-hidden rounded-lg border ${className ?? ''}`}>
-      <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className={TOOLBAR_BTN}
-          aria-expanded={expanded}
-          aria-label={expanded ? 'Collapse the install prompt' : 'Expand the install prompt'}>
-          {expanded ? (
-            <>
-              <ChevronUp className="size-3.5" />
-              Collapse
-            </>
-          ) : (
-            <>
-              <ChevronDown className="size-3.5" />
-              Expand
-            </>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={copy}
-          className={TOOLBAR_BTN}
-          aria-label="Copy the install prompt">
-          {copied ? (
-            <>
-              <Check className="size-3.5 text-green-600 dark:text-green-400" />
-              Copied
-            </>
-          ) : (
-            <>
-              <Copy className="size-3.5" />
-              Copy
-            </>
-          )}
-        </button>
+    <button type="button" onClick={copy} className={className} aria-label="Copy the install prompt">
+      {copied ? (
+        <>
+          <Check className="size-3.5 text-green-600 dark:text-green-400" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="size-3.5" />
+          Copy
+        </>
+      )}
+    </button>
+  )
+}
+
+/**
+ * Copyable "install with an AI agent" prompt. Shows a compact, scrollable
+ * preview with Expand and Copy actions; Expand opens the full canonical
+ * INSTALL_PROMPT in a centered modal (rendered through a portal so it isn't
+ * clipped by the box or anchored to a transformed ancestor, and the page
+ * layout stays put). Closes on Escape, backdrop click, or the close button.
+ * Used by the homepage install tabs and the docs Installation page.
+ */
+export function InstallPromptBox({ className }: { className?: string }) {
+  const [open, setOpen] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    dialogRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [open])
+
+  return (
+    <>
+      <div className={`bg-muted/50 overflow-hidden rounded-lg border ${className ?? ''}`}>
+        <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className={TOOLBAR_BTN}
+            aria-haspopup="dialog"
+            aria-label="Expand the install prompt">
+            <Maximize2 className="size-3.5" />
+            Expand
+          </button>
+          <CopyButton />
+        </div>
+        <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+          {INSTALL_PROMPT}
+        </pre>
       </div>
-      <pre
-        className={`text-foreground [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap ${
-          expanded ? '' : 'max-h-24'
-        }`}>
-        {INSTALL_PROMPT}
-      </pre>
-    </div>
+
+      {open &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="presentation"
+            onClick={() => setOpen(false)}>
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true" />
+            <div
+              ref={dialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Install Prompt Area with an AI agent"
+              tabIndex={-1}
+              onClick={(e) => e.stopPropagation()}
+              className="bg-background relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border shadow-2xl outline-none">
+              <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+                <h2 className="text-sm font-semibold">Install with an AI agent</h2>
+                <div className="flex items-center gap-1">
+                  <CopyButton />
+                  <button
+                    type="button"
+                    onClick={() => setOpen(false)}
+                    className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 items-center justify-center rounded-md transition-colors"
+                    aria-label="Close">
+                    <X className="size-4" />
+                  </button>
+                </div>
+              </div>
+              <pre className="text-foreground flex-1 [scrollbar-width:thin] overflow-auto px-5 py-4 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+                {INSTALL_PROMPT}
+              </pre>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
   )
 }

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -2,15 +2,18 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Check, Copy, Maximize2, X } from 'lucide-react'
+import { Check, Copy, Maximize2, Sparkles, X } from 'lucide-react'
 import { INSTALL_PROMPT } from '@/lib/install-prompt'
 import { cn } from '@/lib/utils'
 
 const TOOLBAR_BTN =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors'
 
-/** Copy-to-clipboard button with copied-state feedback, reused by the box and the dialog. */
-function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
+const ICON_BTN =
+  'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 shrink-0 items-center justify-center rounded-md transition-colors'
+
+/** Copy the canonical install prompt to the clipboard, with copied-state feedback. */
+function useCopyPrompt() {
   const [copied, setCopied] = useState(false)
   const copy = useCallback(() => {
     navigator.clipboard?.writeText(INSTALL_PROMPT).then(() => {
@@ -18,7 +21,12 @@ function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
       setTimeout(() => setCopied(false), 1500)
     })
   }, [])
+  return { copied, copy }
+}
 
+/** Text Copy button (icon + label) for the full preview toolbar and the dialog. */
+function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
+  const { copied, copy } = useCopyPrompt()
   return (
     <button type="button" onClick={copy} className={className} aria-label="Copy the install prompt">
       {copied ? (
@@ -37,16 +45,26 @@ function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
 }
 
 /**
- * Copyable "install with an AI agent" prompt. Shows a compact, scrollable
- * preview with Expand and Copy actions; Expand opens the full canonical
+ * Copyable "install with an AI agent" prompt. Expand opens the full canonical
  * INSTALL_PROMPT in a centered modal (rendered through a portal so it isn't
- * clipped by the box or anchored to a transformed ancestor, and the page
- * layout stays put). Closes on Escape, backdrop click, or the close button.
- * Used by the homepage install tabs and the docs Installation page.
+ * clipped by the box or anchored to a transformed ancestor, and the page layout
+ * stays put). Closes on Escape, backdrop click, or the close button.
+ *
+ * `compact` renders a single row sized to match the npm / shadcn command boxes,
+ * so the three install tabs line up; the default renders a scrollable preview
+ * (used on the docs Installation page, where there's room). Used by the install
+ * tabs and the docs Installation page.
  */
-export function InstallPromptBox({ className }: { className?: string }) {
+export function InstallPromptBox({
+  className,
+  compact = false,
+}: {
+  className?: string
+  compact?: boolean
+}) {
   const [open, setOpen] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
+  const { copied, copy } = useCopyPrompt()
 
   useEffect(() => {
     if (!open) return
@@ -65,23 +83,55 @@ export function InstallPromptBox({ className }: { className?: string }) {
 
   return (
     <>
-      <div className={cn('bg-muted/50 overflow-hidden rounded-lg border', className)}>
-        <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
+      {compact ? (
+        <div
+          className={cn(
+            'bg-muted/50 flex items-center gap-2.5 rounded-lg border px-4 py-3',
+            className,
+          )}>
+          <Sparkles className="text-muted-foreground size-4 shrink-0" />
+          <span className="text-foreground min-w-0 flex-1 truncate text-xs sm:text-sm">
+            Prompt for Claude Code, Cursor &amp; Codex
+          </span>
           <button
             type="button"
             onClick={() => setOpen(true)}
-            className={TOOLBAR_BTN}
+            className={ICON_BTN}
             aria-haspopup="dialog"
             aria-label="Expand the install prompt">
-            <Maximize2 className="size-3.5" />
-            Expand
+            <Maximize2 className="size-4" />
           </button>
-          <CopyButton />
+          <button
+            type="button"
+            onClick={copy}
+            className={ICON_BTN}
+            aria-label="Copy the install prompt">
+            {copied ? (
+              <Check className="size-4 text-green-600 dark:text-green-400" />
+            ) : (
+              <Copy className="size-4" />
+            )}
+          </button>
         </div>
-        <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
-          {INSTALL_PROMPT}
-        </pre>
-      </div>
+      ) : (
+        <div className={cn('bg-muted/50 overflow-hidden rounded-lg border', className)}>
+          <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              className={TOOLBAR_BTN}
+              aria-haspopup="dialog"
+              aria-label="Expand the install prompt">
+              <Maximize2 className="size-3.5" />
+              Expand
+            </button>
+            <CopyButton />
+          </div>
+          <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+            {INSTALL_PROMPT}
+          </pre>
+        </div>
+      )}
 
       {open &&
         typeof document !== 'undefined' &&
@@ -106,7 +156,7 @@ export function InstallPromptBox({ className }: { className?: string }) {
                   <button
                     type="button"
                     onClick={() => setOpen(false)}
-                    className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-7 items-center justify-center rounded-md transition-colors"
+                    className={ICON_BTN}
                     aria-label="Close">
                     <X className="size-4" />
                   </button>

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Check, Copy, Maximize2, X } from 'lucide-react'
 import { INSTALL_PROMPT } from '@/lib/install-prompt'
+import { cn } from '@/lib/utils'
 
 const TOOLBAR_BTN =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors'
@@ -64,7 +65,7 @@ export function InstallPromptBox({ className }: { className?: string }) {
 
   return (
     <>
-      <div className={`bg-muted/50 overflow-hidden rounded-lg border ${className ?? ''}`}>
+      <div className={cn('bg-muted/50 overflow-hidden rounded-lg border', className)}>
         <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
           <button
             type="button"

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -37,7 +37,7 @@ export function InstallPromptBox({ className }: { className?: string }) {
           </>
         )}
       </button>
-      <pre className="text-foreground max-h-72 [scrollbar-width:thin] overflow-auto px-4 py-3 pr-20 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+      <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 pr-20 font-mono text-xs leading-relaxed whitespace-pre-wrap">
         {INSTALL_PROMPT}
       </pre>
     </div>

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -1,17 +1,23 @@
 'use client'
 
 import { useCallback, useState } from 'react'
-import { Check, Copy } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, Copy } from 'lucide-react'
 import { INSTALL_PROMPT } from '@/lib/install-prompt'
+
+const TOOLBAR_BTN =
+  'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors'
 
 /**
  * Copyable, multi-line "install with an AI agent" prompt. Renders the canonical
- * INSTALL_PROMPT in a scrollable box with a copy button so users can drop it
- * straight into Claude Code, Cursor, Codex, etc. Used by the homepage install
- * tabs and the docs Installation page.
+ * INSTALL_PROMPT in a box with a small toolbar (Expand / Copy) so users can
+ * read the whole prompt before dropping it into Claude Code, Cursor, Codex,
+ * etc. Collapsed by default to a few lines; Expand lifts the height cap. Used
+ * by the homepage install tabs and the docs Installation page.
  */
 export function InstallPromptBox({ className }: { className?: string }) {
   const [copied, setCopied] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
   const copy = useCallback(() => {
     navigator.clipboard?.writeText(INSTALL_PROMPT).then(() => {
       setCopied(true)
@@ -20,24 +26,48 @@ export function InstallPromptBox({ className }: { className?: string }) {
   }, [])
 
   return (
-    <div className={`bg-muted/50 relative rounded-lg border ${className ?? ''}`}>
-      <button
-        onClick={copy}
-        className="bg-background/80 text-muted-foreground hover:text-foreground hover:bg-background absolute top-2.5 right-2.5 inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium backdrop-blur transition-colors"
-        aria-label="Copy the install prompt">
-        {copied ? (
-          <>
-            <Check className="size-3.5 text-green-600 dark:text-green-400" />
-            Copied
-          </>
-        ) : (
-          <>
-            <Copy className="size-3.5" />
-            Copy
-          </>
-        )}
-      </button>
-      <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 pr-20 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+    <div className={`bg-muted/50 overflow-hidden rounded-lg border ${className ?? ''}`}>
+      <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className={TOOLBAR_BTN}
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Collapse the install prompt' : 'Expand the install prompt'}>
+          {expanded ? (
+            <>
+              <ChevronUp className="size-3.5" />
+              Collapse
+            </>
+          ) : (
+            <>
+              <ChevronDown className="size-3.5" />
+              Expand
+            </>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={copy}
+          className={TOOLBAR_BTN}
+          aria-label="Copy the install prompt">
+          {copied ? (
+            <>
+              <Check className="size-3.5 text-green-600 dark:text-green-400" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="size-3.5" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+      <pre
+        className={`text-foreground [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap ${
+          expanded ? '' : 'max-h-24'
+        }`}>
         {INSTALL_PROMPT}
       </pre>
     </div>

--- a/lib/install-prompt.ts
+++ b/lib/install-prompt.ts
@@ -14,11 +14,13 @@ export const INSTALL_PROMPT = `Install Prompt Area — a production-grade React 
 
 1. Read the docs first. Fetch https://prompt-area.com/llms-full.txt and read it in full. It is the source of truth for the API, props, triggers, helpers, and required CSS — use it, don't guess.
 
-2. Choose how to install, and default to the npm package:
-   - npm (default): install prompt-area with the project's package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
-   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run npx shadcn@latest add https://prompt-area.com/r/prompt-area.json, then add the .prompt-area-* component classes from the docs to globals.css.
-   If it is ambiguous, ask me once which I want; otherwise use npm.
+2. Detect the project's package manager from its lockfile (npm, yarn, pnpm, or bun) and use it for every install and CLI command below.
 
-3. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+3. Choose how to install, and default to the npm package:
+   - npm package (default): add prompt-area with the detected package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
+   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run shadcn@latest add https://prompt-area.com/r/prompt-area.json with the detected package manager's runner (npx, pnpm dlx, yarn dlx, or bunx), then add the .prompt-area-* component classes from the docs to globals.css.
+   If it is ambiguous, ask me once which I want; otherwise use the npm package.
 
-4. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.`
+4. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+
+5. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.`

--- a/lib/install-prompt.ts
+++ b/lib/install-prompt.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical "install with an AI coding agent" prompt.
+ *
+ * Users copy this into Claude Code, Cursor, Codex, etc. and the agent does the
+ * full Prompt Area integration for them: it reads the machine-readable docs at
+ * /llms-full.txt, installs the component (npm by default, or the shadcn
+ * registry when the project uses shadcn and the user asks for it), and wires it
+ * into the app — replacing any existing chat input or scaffolding a new one.
+ *
+ * This is the single source of truth so the homepage install tabs and the docs
+ * Installation page stay in sync. The README mirrors this text by hand.
+ */
+export const INSTALL_PROMPT = `Install Prompt Area — a production-grade React chat/prompt input (@mentions, /commands, #tags, inline markdown, file attachments) — into this project. Do the full integration yourself; don't just print instructions.
+
+1. Read the docs first. Fetch https://prompt-area.com/llms-full.txt and read it in full. It is the source of truth for the API, props, triggers, helpers, and required CSS — use it, don't guess.
+
+2. Choose how to install, and default to the npm package:
+   - npm (default): install prompt-area with the project's package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
+   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run npx shadcn@latest add https://prompt-area.com/r/prompt-area.json, then add the .prompt-area-* component classes from the docs to globals.css.
+   If it is ambiguous, ask me once which I want; otherwise use npm.
+
+3. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+
+4. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.`

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -75,6 +75,7 @@ react-textarea-autosize provides a plain textarea that auto-resizes. Prompt Area
 - [Homepage](https://prompt-area.com): Live interactive demo, feature highlights, and links into the docs, styles, and comparison pages
 - [Docs](https://prompt-area.com/docs): Full documentation — installation, quick start, components, examples, and API reference
 - [Styles](https://prompt-area.com/styles): Ready-made agent-input styles — Claude Code and OpenAI Codex composers built with Prompt Area
+- [For AI Apps](https://prompt-area.com/for-ai-apps): Why Prompt Area fits LLM and AI chat apps — structured output, provider-agnostic integration, and FAQs
 - [About](https://prompt-area.com/about): Project information, team, and open source details
 - [Contact](https://prompt-area.com/contact): Bug reporting, feature requests, and business inquiries
 - [Press](https://prompt-area.com/press): Media resources, project overview, and press contact
@@ -506,6 +507,21 @@ function ChatInput() {
 | `focus()`   | `() => void`                                | Focus the editor                                          |
 | `blur()`    | `() => void`                                | Blur the editor                                           |
 | `insertChip`| `(chip: Omit<ChipSegment, 'type'>) => void` | Insert a chip at the current cursor position              |
+
+### Lower-level hook: usePromptArea
+
+For advanced cases, a lower-level `usePromptArea(options)` hook is also exported. It drives the editor's internal segment state and ref wiring directly. Most apps should prefer `usePromptAreaState` (above) or the controlled `value` / `onChange` props; reach for `usePromptArea` only when you need fine-grained control over the editor internals.
+
+## Server Components (prompt-area/helpers)
+
+All framework-agnostic helpers — segment factories, predicates, serialization, trigger presets, and the engine functions — are also exported from a dedicated `prompt-area/helpers` entry point, built without a `'use client'` boundary so it can run on the server. Import from there when you need them in a React Server Component or other server context (e.g. converting stored segments to text in a route handler, or parsing markdown on the server):
+
+```tsx
+// Server Component or route handler — no 'use client' required
+import { segmentsToPlainText, getChipsByTrigger, parseInlineMarkdown } from 'prompt-area/helpers'
+```
+
+`prompt-area/helpers` re-exports the same segment helpers, engine functions, trigger presets, and types as the main entry — just without any client component code. For the components and hooks (which are client-side), keep importing from `prompt-area`.
 
 ## Chip Customization
 
@@ -1136,6 +1152,19 @@ When you install `prompt-area`, the following modules are available:
 - **Dark mode**: Full light/dark theme via CSS variables
 - **Accessible**: ARIA labels, keyboard navigation, screen reader announcements
 - **Zero extra dependencies**: Only React + your existing shadcn/tailwind setup
+
+## Live Examples
+
+Interactive, copy-paste examples on the docs site:
+
+- Triggers — mentions, commands, tags, callback mode, async search: https://prompt-area.com/docs/examples/triggers
+- Formatting — inline markdown, list auto-formatting, rotating placeholders: https://prompt-area.com/docs/examples/formatting
+- Attachments — image and file attachments, chip-preserving copy/paste: https://prompt-area.com/docs/examples/attachments
+- DX Helpers — usePromptAreaState, trigger presets, segment helpers: https://prompt-area.com/docs/examples/dx-helpers
+- Vercel AI SDK — stream chat completions with PromptArea as the composer: https://prompt-area.com/docs/examples/vercel-ai-sdk
+- Collaborative — real-time multi-user editing with shared segment state over WebSockets: https://prompt-area.com/docs/examples/collaborative
+
+API reference: https://prompt-area.com/docs/api/prompt-area (props) and https://prompt-area.com/docs/api/hooks (hooks & helpers).
 
 ## Links
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -105,13 +105,28 @@ pnpm dlx shadcn@latest add https://prompt-area.com/r/prompt-area.json
 
 ### Install with AI Coding Agents
 
-Give your AI coding agent (Claude Code, Codex, Cursor, etc.) this prompt:
+Copy this prompt into your AI coding agent (Claude Code, Codex, Cursor, etc.). It reads these docs, installs Prompt Area (the npm package by default, or the shadcn registry if you ask), and wires it into your app — replacing any existing chat input or scaffolding a new one:
 
-"Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation."
+```text
+Install Prompt Area — a production-grade React chat/prompt input (@mentions, /commands, #tags, inline markdown, file attachments) — into this project. Do the full integration yourself; don't just print instructions.
 
-### Required CSS
+1. Read the docs first. Fetch https://prompt-area.com/llms-full.txt and read it in full. It is the source of truth for the API, props, triggers, helpers, and required CSS — use it, don't guess.
 
-Add the following CSS classes to your `globals.css` after `@layer base`:
+2. Detect the project's package manager from its lockfile (npm, yarn, pnpm, or bun) and use it for every install and CLI command below.
+
+3. Choose how to install, and default to the npm package:
+   - npm package (default): add prompt-area with the detected package manager, then import { PromptArea } from 'prompt-area' and import 'prompt-area/styles.css' once at the app root. No Tailwind required.
+   - shadcn: only if this project already uses shadcn/ui (a components.json exists) AND I explicitly ask for it — run shadcn@latest add https://prompt-area.com/r/prompt-area.json with the detected package manager's runner (npx, pnpm dlx, yarn dlx, or bunx), then add the .prompt-area-* component classes from the docs to globals.css.
+   If it is ambiguous, ask me once which I want; otherwise use the npm package.
+
+4. Wire it into the app. If a chat/prompt composer (or a <textarea> used as one) already exists, replace it with PromptArea, keeping the existing submit, placeholder, and send/attach controls, and connect @mentions, /commands, or #tags to real project data when it is obvious (otherwise leave a clearly marked stub). If there is no composer yet, scaffold a minimal working one from the Quick Start — controlled state via usePromptAreaState and an onSubmit that sends the plain text.
+
+5. Verify your work. Make sure the project typechecks and builds, fix any import or CSS wiring, then show me the final component and how to run it.
+```
+
+### Required CSS (shadcn registry route only)
+
+The npm package ships these styles in `prompt-area/styles.css`, so if you installed via npm you can skip this step. When installing via the shadcn registry, add the following CSS classes to your `globals.css` after `@layer base`:
 
 ```css
 @layer components {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -106,7 +106,7 @@ A: Yes. Prompt Area is designed for Next.js and React projects and is a drop-in 
 - [Install status-bar](https://prompt-area.com/docs/components/status-bar): Run `npx shadcn@latest add https://prompt-area.com/r/status-bar.json` to add the contextual info bar companion
 - [Install compact-prompt-area](https://prompt-area.com/docs/components/compact-prompt-area): Run `npx shadcn@latest add https://prompt-area.com/r/compact-prompt-area.json` to add the pill-shaped collapsible variant
 - [Install chat-prompt-layout](https://prompt-area.com/docs/components/chat-prompt-layout): Run `npx shadcn@latest add https://prompt-area.com/r/chat-prompt-layout.json` to add the full-height chat layout with scroll navigation
-- [Install with AI agents](https://prompt-area.com/docs/installation): Give your AI coding agent this prompt: "Fetch https://prompt-area.com/llms-full.txt and read the full documentation. Install the prompt-area component by running: npx shadcn@latest add https://prompt-area.com/r/prompt-area.json — then add the required CSS classes from the documentation to globals.css and help me build a prompt input. If there are any existing chat or prompt textarea inputs in the project, replace them with PromptArea using the context from the documentation."
+- [Install with AI agents](https://prompt-area.com/docs/installation): Copy the ready-made prompt into your AI coding agent (Claude Code, Codex, Cursor) — it reads https://prompt-area.com/llms-full.txt, detects the project's package manager, installs Prompt Area (the npm package by default, or the shadcn registry if you ask), and wires it into your app, replacing any existing chat or prompt input.
 
 ## Core Features
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -90,6 +90,8 @@ A: Yes. Prompt Area is designed for Next.js and React projects and is a drop-in 
 - [Homepage](https://prompt-area.com): Live interactive demo, feature highlights, built-in agent styles, and links into the docs, examples, and comparison pages
 - [Docs](https://prompt-area.com/docs): Full documentation — installation, quick start, components, examples, and API reference
 - [Styles](https://prompt-area.com/styles): Ready-made agent-input styles — Claude Code and OpenAI Codex composers built with Prompt Area
+- [For AI Apps](https://prompt-area.com/for-ai-apps): Why Prompt Area fits LLM and AI chat apps — structured output, provider-agnostic integration, and FAQs
+- [Blog](https://prompt-area.com/blog): Guides and articles on building AI chat inputs in React with Prompt Area
 - [About](https://prompt-area.com/about): Project information, team, and open source details
 - [Contact](https://prompt-area.com/contact): Bug reporting, feature requests, and business inquiries
 - [Press](https://prompt-area.com/press): Media resources, project overview, and press contact
@@ -142,6 +144,8 @@ A: Yes. Prompt Area is designed for Next.js and React projects and is a drop-in 
 - [Copy & Paste](https://prompt-area.com/docs/examples/attachments): Chip data preservation and trigger auto-resolution
 - [Image Attachments](https://prompt-area.com/docs/examples/attachments): Paste screenshots with loading states, removal, and configurable placement
 - [File Attachments](https://prompt-area.com/docs/examples/attachments): Attach files with type icons, metadata, and a collapsible "+N more" strip
+- [Vercel AI SDK](https://prompt-area.com/docs/examples/vercel-ai-sdk): Stream chat completions with the Vercel AI SDK — PromptArea is the composer; read plain text and structured chips and send them to your model
+- [Collaborative Editing](https://prompt-area.com/docs/examples/collaborative): Real-time multi-user editing with shared PromptArea segment state synced over WebSockets
 - [Claude Code–Style Input](https://prompt-area.com/styles#claude-code): Full composition of PromptArea, ActionBar, and StatusBar replicating a Claude Code–style chat input with plan mode and model selector
 - [Codex–Style Input](https://prompt-area.com/styles#codex): Stacked Codex-style composer with a permissions pill, reasoning-effort model selector, and a peeking repository/environment/branch context tray
 
@@ -155,6 +159,16 @@ A: Yes. Prompt Area is designed for Next.js and React projects and is a drop-in 
 ## Comparison
 
 - [Feature Matrix](https://prompt-area.com/compare): Side-by-side comparison of prompt-area against react-mentions, Tiptap, Lexical, Plate.js, BlockNote, BlockSuite, and react-textarea-autosize across 14 feature dimensions
+- [Prompt Area vs react-mentions](https://prompt-area.com/vs/react-mentions): The modern react-mentions alternative — commands, tags, markdown, and attachments beyond mentions
+- [Prompt Area vs Tiptap](https://prompt-area.com/vs/tiptap): Lightweight chat input vs the ProseMirror-based Tiptap editor framework
+- [Prompt Area vs Lexical](https://prompt-area.com/vs/lexical): Built-in mentions and commands vs Lexical's plugin-assembly editor framework
+- [Prompt Area vs Plate.js](https://prompt-area.com/vs/plate): Zero-dependency prompt input vs the Slate-based Plate.js editor
+- [Prompt Area vs assistant-ui](https://prompt-area.com/vs/assistant-ui): Prompt Area as the composer/input layer compared with assistant-ui
+
+## API Reference
+
+- [PromptArea Props](https://prompt-area.com/docs/api/prompt-area): Complete prop reference for the PromptArea component — every prop, its type, and default
+- [Hooks & Helpers](https://prompt-area.com/docs/api/hooks): Reference for usePromptAreaState, trigger presets, segment helpers, and the server-safe prompt-area/helpers entry point
 
 ## Full Documentation
 


### PR DESCRIPTION
## Summary
Introduces a new AI agent installation method as the primary option on the homepage and docs, with a reusable copyable prompt component. This allows users to paste a detailed prompt into Claude Code, Cursor, or other AI coding agents, which then automatically installs and integrates Prompt Area into their project.

## Key Changes
- **New `InstallPromptBox` component** (`components/install-prompt-box.tsx`): A client-side component that displays the canonical install prompt in a scrollable box with a one-click copy button. Shows a success state (green checkmark) after copying.

- **Canonical install prompt** (`lib/install-prompt.ts`): Extracted the AI agent prompt into a single source of truth that is used across the homepage, docs, and README. The prompt instructs agents to read the machine-readable docs, choose between npm (default) or shadcn installation, and perform the full integration automatically.

- **Reordered install methods** (`components/install-method-tabs.tsx`): Changed the homepage install tabs to prioritize "AI agent" first, followed by "npm", then "shadcn" — reflecting the lowest-effort path for users. Updated documentation to explain the new tab order and that the AI prompt is client-rendered with a copy button.

- **Updated installation docs** (`app/docs/installation/page.tsx`): Replaced the old static code block with the new `InstallPromptBox` component, keeping the installation page in sync with the homepage.

- **Updated README** (`README.md`): Replaced the brief AI agent prompt with the full, detailed version from the canonical source, ensuring consistency across all documentation surfaces.

## Implementation Details
- The prompt is a single source of truth (`INSTALL_PROMPT`) that eliminates sync issues between the homepage, docs, and README
- The copy button uses the Clipboard API with a 1.5-second success state indicator
- The component is marked as `'use client'` since it requires interactivity (copy button)
- The prompt instructs AI agents to read `/llms-full.txt` for authoritative API and integration details, ensuring agents have complete context

https://claude.ai/code/session_01SSu3ryZnR1HPpYrGdok3y3