### PR TITLE
feat(prompt-area): commandTrigger fires anywhere by default

### DIFF
--- a/app/docs/api/hooks/page.tsx
+++ b/app/docs/api/hooks/page.tsx
@@ -76,7 +76,8 @@ export default function HooksApiPage() {
           {
             name: 'commandTrigger(opts?)',
             type: '(opts) => TriggerConfig',
-            description: '/ dropdown with start-of-line detection.',
+            description:
+              '/ dropdown anywhere in the input. Pass position: "start" to limit it to the start of a line.',
           },
           {
             name: 'hashtagTrigger(opts?)',

--- a/app/docs/components/prompt-area/page.tsx
+++ b/app/docs/components/prompt-area/page.tsx
@@ -76,7 +76,7 @@ const { bind } = usePromptAreaState()
       <DocsUl
         items={[
           'mentionTrigger() — @ dropdown for users, agents, or documents',
-          'commandTrigger() — / dropdown with start-of-line detection',
+          'commandTrigger() — / dropdown anywhere (opt into start-of-line only with position: "start")',
           'hashtagTrigger() — # tags that auto-resolve on space',
           'callbackTrigger() — fire a callback (e.g. open a file picker) instead of a dropdown',
         ]}

--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -7,6 +7,14 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`commandTrigger()` now fires anywhere in the input by default, and exposes a
+  `position` option.** Previously the preset hardcoded `position: 'start'` and
+  did not let you override it, so `/commands` only worked at the very start of a
+  line — an artificial limitation. The default is now `position: 'any'` (a `/`
+  after any whitespace opens the menu), and you can opt back into the classic
+  line-start behavior with `commandTrigger({ position: 'start' })`. Consumers
+  using the raw `TriggerConfig` are unaffected — they already set `position`
+  explicitly.
 - **BREAKING: `clsx` and `tailwind-merge` are now peer dependencies** instead of
   bundled runtime dependencies. The package no longer ships its own copies of
   the two `cn` helpers; they dedupe with the copies any shadcn/Tailwind project

--- a/packages/prompt-area/src/prompt-area/__tests__/trigger-presets.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/trigger-presets.test.ts
@@ -33,10 +33,19 @@ describe('trigger-presets', () => {
     it('returns sensible defaults', () => {
       const config = commandTrigger()
       expect(config.char).toBe('/')
-      expect(config.position).toBe('start')
+      expect(config.position).toBe('any')
       expect(config.mode).toBe('dropdown')
       expect(config.chipStyle).toBe('inline')
       expect(config.accessibilityLabel).toBe('command')
+    })
+
+    it('defaults to working everywhere in the input', () => {
+      expect(commandTrigger().position).toBe('any')
+    })
+
+    it('allows restricting to the start of a line', () => {
+      const config = commandTrigger({ position: 'start' })
+      expect(config.position).toBe('start')
     })
 
     it('allows overriding emptyMessage', () => {

--- a/packages/prompt-area/src/prompt-area/trigger-presets.ts
+++ b/packages/prompt-area/src/prompt-area/trigger-presets.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-import type { TriggerConfig } from './types'
+import type { TriggerConfig, TriggerPosition } from './types'
 
 // ---------------------------------------------------------------------------
 // Shared option type — everything in TriggerConfig except the keys each
@@ -53,25 +53,35 @@ export function mentionTrigger(opts: MentionTriggerOptions = {}): TriggerConfig 
 }
 
 // ---------------------------------------------------------------------------
-// /command — dropdown only at line start
+// /command — dropdown anywhere (opt into line-start-only with `position`)
 // ---------------------------------------------------------------------------
 
 export type CommandTriggerOptions = TriggerPresetOptions & {
   /** Override the trigger character. Defaults to `'/'`. */
   char?: string
+  /**
+   * Where the command trigger is valid. Defaults to `'any'`, so commands fire
+   * anywhere a `/` follows whitespace — not just at the start of a line.
+   * Set to `'start'` to restrict the dropdown to the very start of the input
+   * or immediately after a newline (the classic slash-command behavior).
+   */
+  position?: TriggerPosition
 }
 
 /**
  * Creates a **command** trigger (`/`).
  *
- * Defaults: `position: 'start'`, `mode: 'dropdown'`, `chipStyle: 'inline'`,
+ * Defaults: `position: 'any'`, `mode: 'dropdown'`, `chipStyle: 'inline'`,
  * accessible label `"command"`.
+ *
+ * By default commands work everywhere in the input. Pass `position: 'start'`
+ * to limit them to the start of a line.
  */
 export function commandTrigger(opts: CommandTriggerOptions = {}): TriggerConfig {
-  const { char = '/', ...rest } = opts
+  const { char = '/', position = 'any', ...rest } = opts
   return {
     char,
-    position: 'start',
+    position,
     mode: 'dropdown',
     chipStyle: 'inline',
     accessibilityLabel: 'command',


### PR DESCRIPTION
Slash commands were locked to the start of a line: the commandTrigger
preset hardcoded position: 'start' and TriggerPresetOptions omitted
'position', so consumers could not override it at all — an artificial
limitation.

commandTrigger now defaults to position: 'any' (a / after any whitespace
opens the menu) and exposes position as an option, so the classic
line-start behavior is still available via commandTrigger({ position:
'start' }). Raw TriggerConfig consumers are unaffected since they already
set position explicitly.

Updates tests, API/component docs, and the changelog.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Do89mYmNceH8NrGKxCu1JL