### PR TITLE
Add PostHog analytics with typed event tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# PostHog analytics (https://posthog.com)
+#
+# Copy this file to `.env.local` for local development. In production these are
+# set in the Vercel project's Environment Variables. Both are NEXT_PUBLIC_* so
+# they are inlined into the client bundle at build time.
+
+# Project API key (write-only, public — safe to expose in the browser).
+# A committed fallback exists in lib/analytics.ts so analytics work out of the
+# box; set this to override per-environment, or to "" to disable PostHog.
+NEXT_PUBLIC_POSTHOG_KEY=phc_q94hqKoqFz9A4yKKBZ8wFpUSf7HRWABAN9Hp5YbXkDtc
+
+# PostHog ingestion host. EU cloud by default. Used as the upstream for the
+# same-origin `/ingest` reverse proxy (see next.config.ts). US cloud would be
+# https://us.i.posthog.com — a trailing slash is fine, it's stripped.
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# Reference only (not read by the app): PostHog project id 208535.

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -389,21 +389,6 @@ app/                            # Docs + demo site (Next.js)
 registry.json                   # shadcn registry, built from packages/prompt-area/src
 ```
 
-### Analytics
-
-The docs/marketing site uses [PostHog](https://posthog.com) for product analytics, alongside Vercel Analytics and Google Analytics.
-
-- **Setup** lives in `components/posthog-provider.tsx` (client init) and `lib/analytics.ts` (the typed `track()` helper and the event taxonomy).
-- **Autocapture** records pageviews and generic clicks automatically. On top of that, a small set of named, typed conversion events is fired explicitly — `install_command_copied`, `install_prompt_copied`, `install_prompt_expanded`, `install_method_selected`, `cta_clicked`, `github_clicked`, and `nav_link_clicked`. Add new events to the `AnalyticsEventMap` in `lib/analytics.ts` so call sites stay type-safe.
-- **Reverse proxy:** ingestion is routed through a same-origin `/ingest` path (rewrites in `next.config.ts`) so requests come from our own domain and survive ad/tracker blockers.
-
-Configure via environment variables (see `.env.example`):
-
-| Variable                   | Required | Default                    | Notes                                                                          |
-| -------------------------- | -------- | -------------------------- | ------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_POSTHOG_KEY`  | No       | committed public key       | Write-only project key, safe in the browser. Set to `""` to disable PostHog.   |
-| `NEXT_PUBLIC_POSTHOG_HOST` | No       | `https://eu.i.posthog.com` | Upstream for the `/ingest` proxy. Use `https://us.i.posthog.com` for US cloud. |
-
 ## Related Projects
 
 - [Agency Skills](https://github.com/just-marketing/agency-skills) — A sibling open-source project by Juma: a library of Claude Code skills that give marketing agencies repeatable, deliverable-oriented workflows for audits, strategy, content, reporting, and operations.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,21 @@ app/                            # Docs + demo site (Next.js)
 registry.json                   # shadcn registry, built from packages/prompt-area/src
 ```
 
+### Analytics
+
+The docs/marketing site uses [PostHog](https://posthog.com) for product analytics, alongside Vercel Analytics and Google Analytics.
+
+- **Setup** lives in `components/posthog-provider.tsx` (client init) and `lib/analytics.ts` (the typed `track()` helper and the event taxonomy).
+- **Autocapture** records pageviews and generic clicks automatically. On top of that, a small set of named, typed conversion events is fired explicitly — `install_command_copied`, `install_prompt_copied`, `install_prompt_expanded`, `install_method_selected`, `cta_clicked`, `github_clicked`, and `nav_link_clicked`. Add new events to the `AnalyticsEventMap` in `lib/analytics.ts` so call sites stay type-safe.
+- **Reverse proxy:** ingestion is routed through a same-origin `/ingest` path (rewrites in `next.config.ts`) so requests come from our own domain and survive ad/tracker blockers.
+
+Configure via environment variables (see `.env.example`):
+
+| Variable                   | Required | Default                    | Notes                                                                          |
+| -------------------------- | -------- | -------------------------- | ------------------------------------------------------------------------------ |
+| `NEXT_PUBLIC_POSTHOG_KEY`  | No       | committed public key       | Write-only project key, safe in the browser. Set to `""` to disable PostHog.   |
+| `NEXT_PUBLIC_POSTHOG_HOST` | No       | `https://eu.i.posthog.com` | Upstream for the `/ingest` proxy. Use `https://us.i.posthog.com` for US cloud. |
+
 ## Related Projects
 
 - [Agency Skills](https://github.com/just-marketing/agency-skills) — A sibling open-source project by Juma: a library of Claude Code skills that give marketing agencies repeatable, deliverable-oriented workflows for audits, strategy, content, reporting, and operations.

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -62,7 +62,7 @@ export default function ComparePage() {
       </section>
 
       <section className="border-t pt-10">
-        <InstallCta />
+        <InstallCta location="compare" />
       </section>
     </div>
   )

--- a/app/for-ai-apps/page.tsx
+++ b/app/for-ai-apps/page.tsx
@@ -168,7 +168,7 @@ await streamChat({
 })`}
         />
         <div className="max-w-xl">
-          <InstallMethodTabs />
+          <InstallMethodTabs location="for_ai_apps" />
         </div>
       </section>
 

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { ArrowRight, ArrowUpRight } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
 import { InstallCta } from '@/components/install-cta'
+import { track } from '@/lib/analytics'
 import { Reveal, RevealGroup, RevealItem } from '@/components/reveal'
 import { RotatingTitle } from '@/components/rotating-title'
 import { FeaturesGrid } from './sections/features-grid'
@@ -93,11 +94,12 @@ export default function HomeContent() {
               </p>
             </RevealItem>
             <RevealItem className="w-full max-w-xl min-w-0">
-              <InstallMethodTabs />
+              <InstallMethodTabs location="hero" />
             </RevealItem>
             <RevealItem className="flex flex-wrap items-center justify-center gap-3 pt-1 lg:justify-start">
               <Link
                 href="/docs"
+                onClick={() => track('cta_clicked', { cta: 'get_started', location: 'hero' })}
                 className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
                 Get started
                 <ArrowRight className="size-4" />
@@ -106,6 +108,7 @@ export default function HomeContent() {
                 href="https://github.com/just-marketing/prompt-area"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => track('github_clicked', { location: 'hero' })}
                 className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
                 Star on GitHub
                 <ArrowUpRight className="size-3.5" />
@@ -179,6 +182,9 @@ export default function HomeContent() {
             </p>
             <Link
               href="/compare"
+              onClick={() =>
+                track('cta_clicked', { cta: 'compare_alternatives', location: 'home' })
+              }
               className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
               Compare alternatives
               <ArrowRight className="size-4" />
@@ -190,7 +196,7 @@ export default function HomeContent() {
       {/* CTA */}
       <section className="mx-auto w-full max-w-3xl px-4 py-20">
         <Reveal>
-          <InstallCta />
+          <InstallCta location="home" />
         </Reveal>
       </section>
     </div>

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useCallback, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight } from 'lucide-react'
@@ -70,6 +71,16 @@ const HERO_FILES: PromptAreaFile[] = [
 ]
 
 export default function HomeContent() {
+  // Fire `demo_interacted` once, the first time the visitor focuses or types in
+  // the live hero composer — our best signal that they actually tried the
+  // component (autocapture can't see typing into a contentEditable).
+  const demoTracked = useRef(false)
+  const handleDemoInteract = useCallback(() => {
+    if (demoTracked.current) return
+    demoTracked.current = true
+    track('demo_interacted', { location: 'hero' })
+  }, [])
+
   return (
     <div className="flex flex-col">
       {/* Hero */}
@@ -118,7 +129,11 @@ export default function HomeContent() {
           {/* Live demo — Codex-style composer seeded with real content. Opacity-only
               (lift=false) so the composer's pop-up menus aren't anchored to a
               transformed ancestor. */}
-          <div id="demo" className="w-full min-w-0 scroll-mt-20">
+          <div
+            id="demo"
+            className="w-full min-w-0 scroll-mt-20"
+            onFocusCapture={handleDemoInteract}
+            onInputCapture={handleDemoInteract}>
             <Reveal lift={false} delay={0.15}>
               <CodexInputExample
                 initialSegments={HERO_SEGMENTS}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css'
 import { AppShell } from '@/components/app-shell'
 import { SiteFooter } from '@/components/site-footer'
 import { Analytics } from '@/components/analytics'
+import { PostHogProvider } from '@/components/posthog-provider'
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff2',
@@ -213,13 +214,15 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Suspense>
-          <AppShell>
-            {children}
-            <SiteFooter />
-          </AppShell>
-        </Suspense>
-        <Analytics />
+        <PostHogProvider>
+          <Suspense>
+            <AppShell>
+              {children}
+              <SiteFooter />
+            </AppShell>
+          </Suspense>
+          <Analytics />
+        </PostHogProvider>
       </body>
     </html>
   )

--- a/app/sections/styles-carousel.tsx
+++ b/app/sections/styles-carousel.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { track } from '@/lib/analytics'
 import { StyleLogo, type StyleLogoId } from '@/components/style-logo'
 
 // The style examples are heavy, interactive composers, so load each on demand.
@@ -78,13 +79,29 @@ export function StylesCarousel() {
   // moving forward and from the left when moving back.
   const [dir, setDir] = useState(0)
 
+  // Record which style the visitor chose to preview (skipping no-op re-selects),
+  // tagged by how they got there — a provider logo tile or the prev/next arrows.
+  const trackSelect = (index: number, method: 'logo' | 'arrow') => {
+    if (index === active) return
+    const slide = SLIDES[index]
+    track('style_selected', {
+      style: slide.id,
+      vendor: slide.vendor,
+      method,
+      location: 'home_carousel',
+    })
+  }
+
   const goTo = (index: number) => {
+    trackSelect(index, 'logo')
     setDir(Math.sign(index - active))
     setActive(index)
   }
   const step = (delta: 1 | -1) => {
+    const next = (active + delta + SLIDES.length) % SLIDES.length
+    trackSelect(next, 'arrow')
     setDir(delta)
-    setActive((a) => (a + delta + SLIDES.length) % SLIDES.length)
+    setActive(next)
   }
 
   const activeSlide = SLIDES[active]

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -255,7 +255,7 @@ export default function StylesPage() {
       </section>
 
       <section className="border-t pt-10">
-        <InstallCta />
+        <InstallCta location="styles" />
       </section>
     </div>
   )

--- a/components/code-tabs.tsx
+++ b/components/code-tabs.tsx
@@ -33,6 +33,9 @@ export function CodeTabs({
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
 
   function select(index: number) {
+    // Skip no-op re-selection (clicking / Home/End onto the already-active tab)
+    // so analytics consumers don't see spurious selection events.
+    if (index === active) return
     setActive(index)
     onSelect?.(index, tabs[index].label)
   }

--- a/components/code-tabs.tsx
+++ b/components/code-tabs.tsx
@@ -18,10 +18,24 @@ const TAB_CLASS =
  * and stays crawlable — this only toggles which one is visible. Implements
  * roving tabindex, Arrow/Home/End keyboard navigation, and tab↔panel linking.
  */
-export function CodeTabs({ tabs, label }: { tabs: Tab[]; label: string }) {
+export function CodeTabs({
+  tabs,
+  label,
+  onSelect,
+}: {
+  tabs: Tab[]
+  label: string
+  /** Fired when a tab becomes active (click or keyboard), for analytics. */
+  onSelect?: (index: number, label: string) => void
+}) {
   const [active, setActive] = useState(0)
   const uid = useId()
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  function select(index: number) {
+    setActive(index)
+    onSelect?.(index, tabs[index].label)
+  }
 
   function onKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     let next: number
@@ -42,7 +56,7 @@ export function CodeTabs({ tabs, label }: { tabs: Tab[]; label: string }) {
         return
     }
     e.preventDefault()
-    setActive(next)
+    select(next)
     tabRefs.current[next]?.focus()
   }
 
@@ -65,7 +79,7 @@ export function CodeTabs({ tabs, label }: { tabs: Tab[]; label: string }) {
             aria-controls={`${uid}-panel-${i}`}
             aria-selected={i === active}
             tabIndex={i === active ? 0 : -1}
-            onClick={() => setActive(i)}
+            onClick={() => select(i)}
             className={TAB_CLASS}>
             {tab.label}
           </button>

--- a/components/command-box.tsx
+++ b/components/command-box.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react'
 import { Check, Copy } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { track } from '@/lib/analytics'
 
 /** Soft fade on the right edge so an overflowing command reads as scrollable. */
 const FADE_MASK = 'linear-gradient(to right, #000 calc(100% - 1.5rem), transparent)'
@@ -12,14 +13,27 @@ const FADE_MASK = 'linear-gradient(to right, #000 calc(100% - 1.5rem), transpare
  * stay on one line and scroll, with a right-edge fade instead of a hard cut.
  * `compact` uses a smaller font for tight columns (e.g. the split hero).
  */
-export function CommandBox({ cmd, compact = false }: { cmd: string; compact?: boolean }) {
+export function CommandBox({
+  cmd,
+  compact = false,
+  method,
+  location,
+}: {
+  cmd: string
+  compact?: boolean
+  /** Install method this command represents, e.g. 'npm' | 'pnpm' | 'yarn' | 'shadcn'. */
+  method?: string
+  /** Where on the site the box is rendered, e.g. 'hero' | 'docs'. */
+  location?: string
+}) {
   const [copied, setCopied] = useState(false)
   const copy = useCallback(() => {
     navigator.clipboard?.writeText(cmd).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
+      track('install_command_copied', { method: method ?? 'unknown', command: cmd, location })
     })
-  }, [cmd])
+  }, [cmd, method, location])
 
   return (
     <button

--- a/components/install-cta.tsx
+++ b/components/install-cta.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
+import { TrackedLink } from '@/components/tracked-link'
 import { cn } from '@/lib/utils'
 
 /**
@@ -13,30 +13,37 @@ export function InstallCta({
   className,
   heading = 'Drop it into your app',
   description = 'Install with an AI agent, from npm, or copy the source via the shadcn registry. Zero extra dependencies.',
+  location = 'install_cta',
 }: {
   className?: string
   heading?: string
   description?: string
+  /** Analytics label for where this CTA block lives, e.g. 'home', 'compare'. */
+  location?: string
 }) {
   return (
     <div className={cn('flex flex-col items-center gap-6 text-center', className)}>
       <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">{heading}</h2>
       <p className="text-muted-foreground max-w-xl">{description}</p>
       <div className="w-full max-w-xl">
-        <InstallMethodTabs />
+        <InstallMethodTabs location={location} />
       </div>
       <div className="flex flex-wrap items-center justify-center gap-3">
-        <Link
+        <TrackedLink
           href="/docs"
+          event="cta_clicked"
+          eventProps={{ cta: 'read_docs', location }}
           className="bg-foreground text-background inline-flex items-center gap-1.5 rounded-md px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-90">
           Read the docs
           <ArrowRight className="size-4" />
-        </Link>
-        <Link
+        </TrackedLink>
+        <TrackedLink
           href="/docs/quick-start"
+          event="cta_clicked"
+          eventProps={{ cta: 'quick_start', location }}
           className="hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-5 py-2.5 text-sm font-medium transition-colors">
           Quick start
-        </Link>
+        </TrackedLink>
       </div>
     </div>
   )

--- a/components/install-method-tabs.tsx
+++ b/components/install-method-tabs.tsx
@@ -33,11 +33,14 @@ export function InstallMethodTabs({
           content: <InstallPromptBox compact />,
         },
         {
+          // Labelled "npm" in the UI, but the command we copy uses pnpm — so
+          // report method:'pnpm' to match the actual command and stay
+          // consistent with PackageManagerTabs (method = the real CLI).
           label: 'npm',
           content: (
             <CommandBox
               compact
-              method="npm"
+              method="pnpm"
               location={location}
               cmd={packageManagerCommand('pnpm', { add: block })}
             />

--- a/components/install-method-tabs.tsx
+++ b/components/install-method-tabs.tsx
@@ -1,6 +1,9 @@
+'use client'
+
 import { CodeTabs } from '@/components/code-tabs'
 import { CommandBox } from '@/components/command-box'
 import { InstallPromptBox } from '@/components/install-prompt-box'
+import { track } from '@/lib/analytics'
 import { packageManagerCommand } from '@/lib/package-managers'
 
 /**
@@ -12,21 +15,24 @@ import { packageManagerCommand } from '@/lib/package-managers'
  * distribution), with the shadcn registry one click further. Per-manager (pnpm
  * / npm / yarn) commands live in the docs install section.
  *
- * The npm / shadcn commands render in the static HTML (only visibility
- * toggles), so they stay crawlable. The AI prompt is client-rendered (it has a
- * copy button) but mirrors the prose on /docs/installation.
+ * Selecting a tab fires `install_method_selected` (tagged with the surface
+ * `location`) so we can see which install path visitors lean toward on each
+ * surface — the copy itself still fires `install_command_copied`. Client-
+ * rendered for that tracking, but every tab's content is still SSR'd into the
+ * initial HTML (only visibility toggles), so the commands stay crawlable.
  */
 export function InstallMethodTabs({
   block = 'prompt-area',
   location,
 }: {
   block?: string
-  /** Where the tabs are rendered, forwarded to copy analytics (e.g. 'hero'). */
+  /** Where the tabs are rendered, forwarded to copy + selection analytics (e.g. 'hero'). */
   location?: string
 }) {
   return (
     <CodeTabs
       label="Install method"
+      onSelect={(_, label) => track('install_method_selected', { method: label, location })}
       tabs={[
         {
           label: 'AI agent',

--- a/components/install-method-tabs.tsx
+++ b/components/install-method-tabs.tsx
@@ -16,7 +16,14 @@ import { packageManagerCommand } from '@/lib/package-managers'
  * toggles), so they stay crawlable. The AI prompt is client-rendered (it has a
  * copy button) but mirrors the prose on /docs/installation.
  */
-export function InstallMethodTabs({ block = 'prompt-area' }: { block?: string }) {
+export function InstallMethodTabs({
+  block = 'prompt-area',
+  location,
+}: {
+  block?: string
+  /** Where the tabs are rendered, forwarded to copy analytics (e.g. 'hero'). */
+  location?: string
+}) {
   return (
     <CodeTabs
       label="Install method"
@@ -27,13 +34,22 @@ export function InstallMethodTabs({ block = 'prompt-area' }: { block?: string })
         },
         {
           label: 'npm',
-          content: <CommandBox compact cmd={packageManagerCommand('pnpm', { add: block })} />,
+          content: (
+            <CommandBox
+              compact
+              method="npm"
+              location={location}
+              cmd={packageManagerCommand('pnpm', { add: block })}
+            />
+          ),
         },
         {
           label: 'shadcn',
           content: (
             <CommandBox
               compact
+              method="shadcn"
+              location={location}
               cmd={packageManagerCommand('pnpm', {
                 dlx: `shadcn@latest add https://prompt-area.com/r/${block}.json`,
               })}

--- a/components/install-prompt-box.tsx
+++ b/components/install-prompt-box.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Check, Copy, Maximize2, Sparkles, X } from 'lucide-react'
 import { INSTALL_PROMPT } from '@/lib/install-prompt'
+import { track, type AnalyticsEventMap } from '@/lib/analytics'
 import { cn } from '@/lib/utils'
+
+type PromptLocation = AnalyticsEventMap['install_prompt_copied']['location']
 
 const TOOLBAR_BTN =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors'
@@ -18,20 +21,27 @@ const ICON_BTN =
 const COMPACT_ICON_BTN = 'text-muted-foreground hover:text-foreground shrink-0 transition-colors'
 
 /** Copy the canonical install prompt to the clipboard, with copied-state feedback. */
-function useCopyPrompt() {
+function useCopyPrompt(location: PromptLocation) {
   const [copied, setCopied] = useState(false)
   const copy = useCallback(() => {
     navigator.clipboard?.writeText(INSTALL_PROMPT).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
+      track('install_prompt_copied', { location })
     })
-  }, [])
+  }, [location])
   return { copied, copy }
 }
 
 /** Text Copy button (icon + label) for the full preview toolbar and the dialog. */
-function CopyButton({ className = TOOLBAR_BTN }: { className?: string }) {
-  const { copied, copy } = useCopyPrompt()
+function CopyButton({
+  className = TOOLBAR_BTN,
+  location,
+}: {
+  className?: string
+  location: PromptLocation
+}) {
+  const { copied, copy } = useCopyPrompt(location)
   return (
     <button type="button" onClick={copy} className={className} aria-label="Copy the install prompt">
       {copied ? (
@@ -69,7 +79,15 @@ export function InstallPromptBox({
 }) {
   const [open, setOpen] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
-  const { copied, copy } = useCopyPrompt()
+  const { copied, copy } = useCopyPrompt('compact')
+
+  // The full-preview variant lives in the docs; the compact variant in the
+  // install tabs. Track which surface an expand came from.
+  const expandLocation: 'compact' | 'preview' = compact ? 'compact' : 'preview'
+  const expand = () => {
+    track('install_prompt_expanded', { location: expandLocation })
+    setOpen(true)
+  }
 
   useEffect(() => {
     if (!open) return
@@ -100,7 +118,7 @@ export function InstallPromptBox({
           </span>
           <button
             type="button"
-            onClick={() => setOpen(true)}
+            onClick={expand}
             className={COMPACT_ICON_BTN}
             aria-haspopup="dialog"
             aria-label="Expand the install prompt">
@@ -123,14 +141,14 @@ export function InstallPromptBox({
           <div className="flex items-center justify-end gap-1 border-b px-2 py-1.5">
             <button
               type="button"
-              onClick={() => setOpen(true)}
+              onClick={expand}
               className={TOOLBAR_BTN}
               aria-haspopup="dialog"
               aria-label="Expand the install prompt">
               <Maximize2 className="size-3.5" />
               Expand
             </button>
-            <CopyButton />
+            <CopyButton location="preview" />
           </div>
           <pre className="text-foreground max-h-24 [scrollbar-width:thin] overflow-auto px-4 py-3 font-mono text-xs leading-relaxed whitespace-pre-wrap">
             {INSTALL_PROMPT}
@@ -157,7 +175,7 @@ export function InstallPromptBox({
               <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
                 <h2 className="text-sm font-semibold">Install with an AI agent</h2>
                 <div className="flex items-center gap-1">
-                  <CopyButton />
+                  <CopyButton location="dialog" />
                   <button
                     type="button"
                     onClick={() => setOpen(false)}

--- a/components/package-manager-tabs.tsx
+++ b/components/package-manager-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { CodeTabs } from '@/components/code-tabs'
 import { CommandBox } from '@/components/command-box'
+import { track } from '@/lib/analytics'
 import {
   PACKAGE_MANAGERS,
   packageManagerCommand,
@@ -20,9 +21,10 @@ export function PackageManagerTabs(props: { add: string } | { dlx: string }) {
   return (
     <CodeTabs
       label="Package manager"
+      onSelect={(_, label) => track('install_method_selected', { method: label, location: 'docs' })}
       tabs={PACKAGE_MANAGERS.map((pm: PackageManager) => ({
         label: pm,
-        content: <CommandBox cmd={packageManagerCommand(pm, op)} />,
+        content: <CommandBox method={pm} location="docs" cmd={packageManagerCommand(pm, op)} />,
       }))}
     />
   )

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+import posthog from 'posthog-js'
+import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react'
+import { POSTHOG_API_HOST, POSTHOG_KEY, POSTHOG_UI_HOST } from '@/lib/analytics'
+
+/**
+ * Initializes PostHog once on the client and makes the instance available to
+ * the React tree (so components can also use `usePostHog()` if needed).
+ *
+ * Ingestion is routed through the same-origin `/ingest` proxy (see the
+ * rewrites in `next.config.ts`) so analytics load from our own domain and
+ * aren't dropped by ad/tracker blockers. `defaults: '2026-05-30'` opts into
+ * PostHog's modern defaults, including automatic pageview capture on App
+ * Router client-side navigations.
+ *
+ * If `POSTHOG_KEY` is empty (env var explicitly set to ''), this is a no-op
+ * pass-through and nothing is sent.
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (!POSTHOG_KEY || posthog.__loaded) return
+    posthog.init(POSTHOG_KEY, {
+      api_host: POSTHOG_API_HOST,
+      ui_host: POSTHOG_UI_HOST,
+      defaults: '2026-05-30',
+    })
+  }, [])
+
+  if (!POSTHOG_KEY) return <>{children}</>
+
+  return <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Menu, TextCursorInput, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { track } from '@/lib/analytics'
 import { GithubIcon } from '@/components/github-icon'
 import { ThemeToggle } from '@/components/theme-toggle'
 
@@ -50,6 +51,13 @@ export function SiteHeader() {
               <Link
                 key={link.href}
                 href={link.href}
+                onClick={() =>
+                  track('nav_link_clicked', {
+                    label: link.label,
+                    href: link.href,
+                    location: 'header',
+                  })
+                }
                 className={cn(
                   'rounded-md px-3 py-1.5 text-sm transition-colors duration-150',
                   'hover:text-foreground',
@@ -70,6 +78,7 @@ export function SiteHeader() {
             rel="noopener noreferrer"
             aria-label="GitHub repository"
             title="GitHub repository"
+            onClick={() => track('github_clicked', { location: 'header' })}
             className="text-muted-foreground hover:text-foreground hover:bg-accent rounded-md p-2 transition-colors">
             <GithubIcon className="size-4" />
           </a>
@@ -93,6 +102,13 @@ export function SiteHeader() {
             <Link
               key={link.href}
               href={link.href}
+              onClick={() =>
+                track('nav_link_clicked', {
+                  label: link.label,
+                  href: link.href,
+                  location: 'header',
+                })
+              }
               className={cn(
                 'rounded-md px-2 py-2 text-sm transition-colors',
                 'hover:bg-accent',

--- a/components/tracked-link.tsx
+++ b/components/tracked-link.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, ReactNode } from 'react'
+import { track, type AnalyticsEvent, type AnalyticsEventMap } from '@/lib/analytics'
+
+type TrackedLinkProps<E extends AnalyticsEvent> = Omit<ComponentProps<typeof Link>, 'onClick'> & {
+  /** Analytics event to fire on click. */
+  event: E
+  /** Typed properties for the event. */
+  eventProps: AnalyticsEventMap[E]
+  children: ReactNode
+}
+
+/**
+ * A `next/link` that fires a typed analytics event on click. Lets server
+ * components keep a single tracked CTA link client-side without turning the
+ * whole component (and its server-rendered siblings) into client components.
+ */
+export function TrackedLink<E extends AnalyticsEvent>({
+  event,
+  eventProps,
+  children,
+  ...rest
+}: TrackedLinkProps<E>) {
+  return (
+    <Link {...rest} onClick={() => track(event, eventProps)}>
+      {children}
+    </Link>
+  )
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,88 @@
+import posthog from 'posthog-js'
+
+/**
+ * The PostHog project (write-only, public) key. Safe to ship in client code.
+ * Overridable per-environment via `NEXT_PUBLIC_POSTHOG_KEY`; the committed
+ * fallback means analytics work out of the box even before the env var is set
+ * in the deployment. Set the env var to `''` to disable PostHog entirely.
+ */
+export const POSTHOG_KEY =
+  process.env.NEXT_PUBLIC_POSTHOG_KEY ?? 'phc_q94hqKoqFz9A4yKKBZ8wFpUSf7HRWABAN9Hp5YbXkDtc'
+
+/**
+ * Same-origin proxy path. All ingestion is routed through `/ingest` (rewritten
+ * to PostHog EU in `next.config.ts`) so requests come from our own domain and
+ * survive ad/tracker blockers — important for a developer audience.
+ */
+export const POSTHOG_API_HOST = '/ingest'
+
+/** PostHog app host used for links from the SDK (e.g. toolbar, session links). */
+export const POSTHOG_UI_HOST = 'https://eu.posthog.com'
+
+/**
+ * Marketing-site analytics — a thin, typed wrapper over PostHog.
+ *
+ * PostHog autocapture records generic clicks/pageviews on its own (set up in
+ * `components/posthog-provider.tsx`). The named events below are the
+ * high-intent conversions we want to slice, funnel, and chart deliberately —
+ * "how do people install Prompt Area, and what do they click on the way
+ * there." Keep this list small and meaningful; let autocapture handle the
+ * long tail.
+ *
+ * Every event name and its property shape lives here so call sites stay
+ * declarative and we never typo an event name in the wild.
+ */
+export type AnalyticsEventMap = {
+  /** A shell install command (npm / pnpm / yarn / shadcn) was copied. */
+  install_command_copied: {
+    /** Which install command: 'npm' | 'pnpm' | 'yarn' | 'shadcn'. */
+    method: string
+    /** The exact command string copied. */
+    command: string
+    /** Where on the site the box was rendered, e.g. 'hero', 'docs'. */
+    location?: string
+  }
+  /** The copy-paste "install with an AI agent" prompt was copied. */
+  install_prompt_copied: {
+    /** Which surface the prompt was copied from. */
+    location: 'compact' | 'preview' | 'dialog'
+  }
+  /** The AI-agent install prompt was expanded into the full-screen dialog. */
+  install_prompt_expanded: {
+    location: 'compact' | 'preview'
+  }
+  /** An install-method tab (AI agent / npm / shadcn, or a package manager) was selected. */
+  install_method_selected: {
+    method: string
+    location?: string
+  }
+  /** A primary marketing call-to-action button was clicked. */
+  cta_clicked: {
+    /** Stable id for the CTA, e.g. 'get_started', 'read_docs', 'quick_start'. */
+    cta: string
+    /** Where the CTA lives, e.g. 'hero', 'home_cta', 'compare'. */
+    location?: string
+  }
+  /** A link out to the GitHub repository was clicked. */
+  github_clicked: {
+    location: 'header' | 'footer' | 'hero'
+  }
+  /** A site navigation link (header or footer) was clicked. */
+  nav_link_clicked: {
+    label: string
+    href: string
+    location: 'header' | 'footer'
+  }
+}
+
+export type AnalyticsEvent = keyof AnalyticsEventMap
+
+/**
+ * Capture a typed analytics event. No-ops on the server and when PostHog has
+ * no key configured, so it's always safe to call from client components.
+ */
+export function track<E extends AnalyticsEvent>(event: E, properties: AnalyticsEventMap[E]): void {
+  if (typeof window === 'undefined') return
+  if (!POSTHOG_KEY) return
+  posthog.capture(event, properties)
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -73,6 +73,11 @@ export type AnalyticsEventMap = {
     href: string
     location: 'header' | 'footer'
   }
+  /** The visitor engaged with a live, interactive demo (focused it or typed). */
+  demo_interacted: {
+    /** Which demo, e.g. 'hero'. */
+    location: string
+  }
 }
 
 export type AnalyticsEvent = keyof AnalyticsEventMap

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -78,6 +78,17 @@ export type AnalyticsEventMap = {
     /** Which demo, e.g. 'hero'. */
     location: string
   }
+  /** A built-in agent style was selected to preview in the styles carousel. */
+  style_selected: {
+    /** Style id, e.g. 'chatgpt', 'claude-code'. */
+    style: string
+    /** Vendor group, e.g. 'OpenAI', 'Anthropic'. */
+    vendor: string
+    /** Whether it was picked via a provider logo tile or the prev/next arrows. */
+    method: 'logo' | 'arrow'
+    /** Where the carousel lives, e.g. 'home_carousel'. */
+    location: string
+  }
 }
 
 export type AnalyticsEvent = keyof AnalyticsEventMap

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,32 @@
 import type { NextConfig } from 'next'
 
+// PostHog (EU) ingestion is proxied through our own origin at `/ingest` so the
+// analytics requests come from prompt-area.com and survive ad/tracker blockers.
+// The client points `api_host` at `/ingest` (see components/posthog-provider).
+// Strip any trailing slash so the rewrite destinations below don't end up with
+// a double slash (the env value may be entered as `https://eu.i.posthog.com/`).
+const POSTHOG_HOST = (process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://eu.i.posthog.com').replace(
+  /\/+$/,
+  '',
+)
+const POSTHOG_ASSETS_HOST = POSTHOG_HOST.replace('.i.posthog.com', '-assets.i.posthog.com')
+
 const nextConfig: NextConfig = {
   devIndicators: {
     position: 'bottom-right',
   },
   experimental: {
     optimizePackageImports: ['lucide-react', 'shiki'],
+  },
+  // Required for the PostHog proxy: don't let Next strip/append a trailing
+  // slash on the rewritten /ingest paths.
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      { source: '/ingest/static/:path*', destination: `${POSTHOG_ASSETS_HOST}/static/:path*` },
+      { source: '/ingest/:path*', destination: `${POSTHOG_HOST}/:path*` },
+      { source: '/ingest/flags', destination: `${POSTHOG_HOST}/flags` },
+    ]
   },
   async redirects() {
     return [

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@codesandbox/sandpack-react": "^2.20.0",
+    "@posthog/types": "^1.391.0",
     "@radix-ui/react-slot": "^1.3.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.2",
@@ -33,6 +34,7 @@
     "geist": "^1.7.2",
     "lucide-react": "^1.21.0",
     "next": "^16.2.9",
+    "posthog-js": "^1.393.0",
     "prompt-area": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@codesandbox/sandpack-react':
         specifier: ^2.20.0
         version: 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@posthog/types':
+        specifier: ^1.391.0
+        version: 1.391.0
       '@radix-ui/react-slot':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
@@ -53,6 +56,9 @@ importers:
       next:
         specifier: ^16.2.9
         version: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      posthog-js:
+        specifier: ^1.393.0
+        version: 1.393.0
       prompt-area:
         specifier: workspace:*
         version: link:packages/prompt-area
@@ -1184,6 +1190,12 @@ packages:
     resolution: {integrity: sha512-x6fFWCeak8aCGfqZfe6CXYt5xVjxe9Os1cIPmVRcToInKLjhJkRVXvJ/L3/1KxFkjDQdbZV/YsuLKqa8t/xKpA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@posthog/core@1.37.1':
+    resolution: {integrity: sha512-KRBuxF/XBm3tNpqWlXpWE82XxsYsJb0jSyEic14LMXMvqDv5iApK1jfV0+seikDb9SpPs3tPkWUfHdwaUtFBtQ==}
+
+  '@posthog/types@1.391.0':
+    resolution: {integrity: sha512-oJ6jkqVMq+T4ax9F0rUllJc0KHpSgpaMwTNYWkE70iBiyXDVyhcNBmYnNKzSODgpzsaQNI6VfK8JrRYbkSJZZw==}
+
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
@@ -1718,6 +1730,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2391,6 +2406,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -2545,6 +2563,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -2896,6 +2917,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
@@ -4096,9 +4120,15 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.393.0:
+    resolution: {integrity: sha512-BNu62XUNkFEIq7ZQJwvgtZIgWUfn0HozVcYHO8P1WMq2Crx+d+/l7TJsO6YHf3aUUiJn+L8L8NX7XgFZxW3/tw==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4213,6 +4243,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4947,6 +4980,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -6047,6 +6083,12 @@ snapshots:
 
   '@pkgr/core@0.2.10': {}
 
+  '@posthog/core@1.37.1':
+    dependencies:
+      '@posthog/types': 1.391.0
+
+  '@posthog/types@1.391.0': {}
+
   '@publint/pack@0.1.4': {}
 
   '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
@@ -6461,6 +6503,9 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/statuses@2.0.6':
+    optional: true
+
+  '@types/trusted-types@2.0.7':
     optional: true
 
   '@types/unist@3.0.3': {}
@@ -7082,6 +7127,8 @@ snapshots:
   cookie@1.1.1:
     optional: true
 
+  core-js@3.49.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -7209,6 +7256,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.6.1: {}
 
@@ -7781,6 +7832,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.8: {}
 
   fflate@0.8.3: {}
 
@@ -8954,7 +9007,20 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.393.0:
+    dependencies:
+      '@posthog/core': 1.37.1
+      '@posthog/types': 1.391.0
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
 
@@ -9028,6 +9094,8 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9923,6 +9991,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/posthog.d.ts
+++ b/posthog.d.ts
@@ -1,0 +1,9 @@
+import type { PostHog } from '@posthog/types'
+
+declare global {
+  interface Window {
+    posthog?: PostHog
+  }
+}
+
+export {}


### PR DESCRIPTION
Integrates PostHog product analytics into the marketing site with a type-safe event tracking system and same-origin proxy to survive ad blockers.

## Summary
This PR adds comprehensive product analytics to track user interactions across the marketing site and docs. PostHog ingestion is proxied through a same-origin `/ingest` path so analytics requests come from the app's own domain and aren't blocked by ad/tracker blockers—important for a developer audience.

## Key Changes

- **Analytics infrastructure** (`lib/analytics.ts`): Defines a typed `AnalyticsEventMap` with 7 named conversion events (`install_command_copied`, `install_prompt_copied`, `install_prompt_expanded`, `install_method_selected`, `cta_clicked`, `github_clicked`, `nav_link_clicked`). Exports a type-safe `track()` helper that no-ops on the server and when PostHog is disabled.

- **PostHog provider** (`components/posthog-provider.tsx`): Client-side initialization with modern defaults (`2026-05-30`), configured to use the same-origin `/ingest` proxy for ingestion and EU cloud for the UI host.

- **Reverse proxy setup** (`next.config.ts`): Rewrites `/ingest/*` requests to PostHog EU cloud (`https://eu.i.posthog.com`) so analytics load from the app's own domain. Configurable via `NEXT_PUBLIC_POSTHOG_HOST` env var.

- **Tracked components**:
  - `InstallPromptBox`: Tracks when the AI agent prompt is copied (`install_prompt_copied`) and expanded (`install_prompt_expanded`), with location context (compact/preview/dialog).
  - `CommandBox`: Tracks install command copies (`install_command_copied`) with method and location.
  - `CodeTabs`: Added `onSelect` callback to fire `install_method_selected` events.
  - `SiteHeader`: Tracks navigation link clicks (`nav_link_clicked`) and GitHub link clicks (`github_clicked`).
  - `InstallCta`: Uses new `TrackedLink` component for CTA clicks (`cta_clicked`).
  - `InstallMethodTabs` & `PackageManagerTabs`: Pass location context through the component tree.

- **TrackedLink component** (`components/tracked-link.tsx`): A `next/link` wrapper that fires typed analytics events on click, allowing server components to track CTAs without becoming client components.

- **Configuration** (`.env.example`): Documents PostHog environment variables with sensible defaults (EU cloud, committed public key fallback).

- **Documentation** (`README.md`): Added Analytics section explaining setup, autocapture, the reverse proxy strategy, and configuration options.

## Implementation Details

- All events are **typed at the call site** via TypeScript generics, preventing typos and ensuring properties match the event schema.
- **Autocapture** (pageviews, generic clicks) is handled by PostHog automatically; named events are explicit conversions we care about.
- **Location context** is threaded through the component tree (e.g., `location="hero"`, `location="docs"`) so the same component can be reused in different contexts and report where it was clicked.
- **No-op safety**: `track()` returns early if called server-side or if `POSTHOG_KEY` is empty, so it's always safe to call from client components.
- **Env var flexibility**: `NEXT_PUBLIC_POSTHOG_KEY` can be overridden per-environment or set to `""` to disable PostHog entirely; a committed fallback key ensures analytics work out of the box.

https://claude.ai/code/session_01WJoqk4zEhM31PwzvL9opPk