### PR TITLE
Replace Reveal primitive with scroll-triggered stagger animation

### DIFF
--- a/app/sections/features-grid.tsx
+++ b/app/sections/features-grid.tsx
@@ -10,7 +10,15 @@ import {
   Keyboard,
   Puzzle,
 } from 'lucide-react'
-import { Reveal } from '@/components/reveal'
+import { motion, useReducedMotion } from 'framer-motion'
+
+// Shared motion vocabulary with the page's Reveal primitive: the same
+// "ease-out-expo" settle so cards glide in and decelerate, reading as premium.
+const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
+const DURATION = 0.7
+// How far off-screen a card starts. The clip wrapper hides this travel, so the
+// card appears to enter from the section's edge.
+const OFFSET = 220
 
 const FEATURES = [
   {
@@ -64,22 +72,58 @@ const FEATURES = [
 ]
 
 export function FeaturesGrid() {
-  // Each card reveals independently as it scrolls into view (rather than a
-  // single group stagger) so the effect holds up when the grid collapses to one
-  // tall column on mobile — otherwise the lower cards would animate off-screen.
+  const reduce = useReducedMotion()
+
+  // Cards converge from the section's edges to the center, row by row, as you
+  // scroll: the left column slides in from the left, the right column from the
+  // right. Each card triggers its own scroll reveal (rather than one group
+  // stagger), so the two cards sharing a row — which cross the trigger line at
+  // the same moment — animate together and meet in the middle. When the grid
+  // collapses to a single column on mobile, the alternating left/right origin
+  // turns into a gentle zig-zag instead of breaking.
+  const cardClass = 'flex items-start gap-3 rounded-lg border p-4'
+
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {FEATURES.map((feature) => (
-        <Reveal key={feature.title} className="flex items-start gap-3 rounded-lg border p-4">
-          <div className="bg-muted shrink-0 rounded-md p-2">
-            <feature.icon className="size-4" />
-          </div>
-          <div>
-            <div className="text-sm font-medium">{feature.title}</div>
-            <div className="text-muted-foreground text-xs">{feature.description}</div>
-          </div>
-        </Reveal>
-      ))}
+    // overflow-x-clip so a card's off-screen starting position never adds a
+    // horizontal scrollbar while it travels in.
+    <div className="overflow-x-clip">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {FEATURES.map((feature, i) => {
+          const inner = (
+            <>
+              <div className="bg-muted shrink-0 rounded-md p-2">
+                <feature.icon className="size-4" />
+              </div>
+              <div>
+                <div className="text-sm font-medium">{feature.title}</div>
+                <div className="text-muted-foreground text-xs">{feature.description}</div>
+              </div>
+            </>
+          )
+
+          if (reduce) {
+            return (
+              <div key={feature.title} className={cardClass}>
+                {inner}
+              </div>
+            )
+          }
+
+          // Even index → left column → enter from the left; odd → from the right.
+          const fromLeft = i % 2 === 0
+          return (
+            <motion.div
+              key={feature.title}
+              className={cardClass}
+              initial={{ opacity: 0, x: fromLeft ? -OFFSET : OFFSET }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true, margin: '0px 0px -15% 0px' }}
+              transition={{ duration: DURATION, ease: EASE }}>
+              {inner}
+            </motion.div>
+          )
+        })}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Replaced the generic `Reveal` component with a custom scroll-triggered animation in the features grid that creates a converging effect where cards slide in from opposite edges (left column from left, right column from right) as they enter the viewport.

## Key Changes
- Removed dependency on the `Reveal` primitive component
- Implemented custom Framer Motion animations with:
  - Configurable easing (`ease-out-expo` curve) and duration (0.7s) for premium feel
  - Per-card scroll reveal triggers instead of grouped stagger
  - Alternating entry directions based on column position (even index = left, odd = right)
  - Reduced motion support that disables animations when user prefers reduced motion
- Added `overflow-x-clip` wrapper to prevent horizontal scrollbar during off-screen animation travel
- Enhanced viewport trigger with `-15%` bottom margin for earlier animation start

## Implementation Details
- Cards use `initial={{ opacity: 0, x: ±OFFSET }}` to start off-screen and slide to `x: 0`
- Each card independently triggers when scrolling into view (`whileInView`), allowing row-by-row convergence
- On mobile (single column), the alternating left/right origin creates a gentle zig-zag effect
- Respects user's `prefers-reduced-motion` preference by rendering static cards without animation

https://claude.ai/code/session_011Jg8J37HTZSnKJ6ALjevHt