### PR TITLE
Add /launch page to sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,6 +20,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     { url: `${SITE_URL}/compare`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
     { url: `${SITE_URL}/blog`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${SITE_URL}/launch`, lastModified: now, changeFrequency: 'monthly', priority: 0.6 },
     { url: `${SITE_URL}/about`, lastModified: now, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/contact`, lastModified: now, changeFrequency: 'monthly', priority: 0.5 },
     { url: `${SITE_URL}/partners`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },


### PR DESCRIPTION
## Summary
Added the `/launch` page to the sitemap to ensure it is discoverable by search engines.

## Changes
- Added `/launch` route entry to the sitemap with:
  - Monthly change frequency
  - 0.6 priority (between blog and about pages)
  - Current timestamp as last modified date

This makes the launch page visible to search engine crawlers and helps with SEO discoverability.

https://claude.ai/code/session_013cLgk1WebQLpobJTL6XRq9