### PR TITLE
Replace Framer Motion with CSS-driven reveal animations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -238,4 +238,68 @@
       transition: none !important;
     }
   }
+
+  /* ── Reveal (components/reveal.tsx) ──────────────────────────────────────
+     CSS engine for the marketing pages' fade/lift entrances. Two modes:
+
+     - data-reveal="mount": animates at first paint via a plain CSS animation,
+       so above-the-fold content (the hero) is visible in the server-rendered
+       frame and never waits on JavaScript — this is what keeps mobile LCP low.
+     - data-reveal="scroll": starts hidden and transitions in when the shared
+       IntersectionObserver in reveal.tsx stamps data-revealed. Only used below
+       the fold, so it can't delay LCP; a <noscript> override in the root
+       layout keeps content visible when JS is off.
+
+     Offsets are driven by --reveal-x / --reveal-y so callers can slide from
+     any direction; --reveal-delay staggers. Everything sits inside a single
+     no-preference media query, so reduced-motion users get static content
+     with zero JS involvement. */
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes reveal-in {
+      from {
+        opacity: 0;
+        transform: translate(var(--reveal-x, 0px), var(--reveal-y, 24px));
+      }
+      to {
+        opacity: 1;
+        transform: translate(0, 0);
+      }
+    }
+
+    [data-reveal='mount'] {
+      animation: reveal-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: var(--reveal-delay, 0s);
+    }
+
+    [data-reveal='scroll'] {
+      opacity: 0;
+      transform: translate(var(--reveal-x, 0px), var(--reveal-y, 24px));
+      transition:
+        opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0s),
+        transform 0.6s cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0s);
+    }
+    [data-reveal='scroll'][data-revealed] {
+      opacity: 1;
+      transform: translate(0, 0);
+    }
+
+    /* Gentle per-column drift for the homepage components cascade — the
+       CSS scroll-driven successor to the old framer-motion parallax. Pure
+       progressive enhancement: browsers without scroll timelines just show
+       the static (already offset) shelf. */
+    @supports (animation-timeline: view()) {
+      @keyframes cascade-drift {
+        from {
+          transform: translateY(var(--drift, 22px));
+        }
+        to {
+          transform: translateY(calc(-1 * var(--drift, 22px)));
+        }
+      }
+      .cascade-drift {
+        animation: cascade-drift linear both;
+        animation-timeline: view();
+      }
+    }
+  }
 }

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef } from 'react'
+import { Suspense, useCallback, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ArrowUpRight } from 'lucide-react'
@@ -134,14 +134,28 @@ export default function HomeContent() {
             className="w-full min-w-0 scroll-mt-20"
             onFocusCapture={handleDemoInteract}
             onInputCapture={handleDemoInteract}>
-            <Reveal lift={false} delay={0.15}>
-              <CodexInputExample
-                initialSegments={HERO_SEGMENTS}
-                triggers={HERO_TRIGGERS}
-                initialFiles={HERO_FILES}
-                markdown
-                minHeight={76}
-              />
+            <Reveal lift={false} delay={0.15} trigger="mount">
+              {/* Local Suspense boundary: the lazy composer suspends during
+                  SSR, and without this it bubbles to the layout-level boundary
+                  — React then wraps the ENTIRE page body in a hidden deferred
+                  segment, so nothing paints until the full HTML has parsed.
+                  Scoped here, only the demo pops in late; the fallback
+                  reserves its footprint so the swap causes no layout shift. */}
+              <Suspense
+                fallback={
+                  <div
+                    aria-hidden
+                    className="bg-card min-h-[13rem] rounded-[24px] border border-[#ececec] shadow-sm dark:border-0 dark:bg-[#2d2d2d]"
+                  />
+                }>
+                <CodexInputExample
+                  initialSegments={HERO_SEGMENTS}
+                  triggers={HERO_TRIGGERS}
+                  initialFiles={HERO_FILES}
+                  markdown
+                  minHeight={76}
+                />
+              </Suspense>
             </Reveal>
           </div>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata, Viewport } from 'next'
-import { Suspense } from 'react'
 import localFont from 'next/font/local'
 import './globals.css'
 import { AppShell } from '@/components/app-shell'
@@ -111,6 +110,12 @@ export default function RootLayout({
             __html: `(function(){try{var t=localStorage.getItem('theme');var d=t==='dark'||(t!=='light'&&matchMedia('(prefers-color-scheme:dark)').matches);if(d)document.documentElement.classList.add('dark')}catch(e){}})()`,
           }}
         />
+        {/* Scroll reveals (components/reveal.tsx) hide content until an
+            IntersectionObserver marks it visible — without JS that never
+            happens, so force everything visible. */}
+        <noscript>
+          <style>{`[data-reveal='scroll']{opacity:1 !important;transform:none !important}`}</style>
+        </noscript>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
@@ -215,12 +220,15 @@ export default function RootLayout({
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <PostHogProvider>
-          <Suspense>
-            <AppShell>
-              {children}
-              <SiteFooter />
-            </AppShell>
-          </Suspense>
+          {/* No Suspense around the shell: a root-level boundary turns the
+              whole page body into a hidden deferred streaming segment whenever
+              anything inside suspends, which blocks first paint until the full
+              HTML has parsed. Anything that suspends must bring its own local
+              boundary (e.g. the homepage hero demo). */}
+          <AppShell>
+            {children}
+            <SiteFooter />
+          </AppShell>
           <Analytics />
         </PostHogProvider>
       </body>

--- a/app/sections/components-cascade.tsx
+++ b/app/sections/components-cascade.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useRef } from 'react'
+import type { CSSProperties } from 'react'
 import Link from 'next/link'
-import { motion, useReducedMotion, useScroll, useTransform, type MotionValue } from 'framer-motion'
 import {
   ArrowRight,
   ArrowUp,
@@ -216,50 +215,37 @@ function CardFace({ c }: { c: ComponentCard }) {
   )
 }
 
-// One desktop column: an entrance fade plus a gentle, per-column scroll parallax
-// so the row drifts as you scroll rather than sitting flat like a static deck.
-function CascadeColumn({
-  c,
-  index,
-  progress,
-}: {
-  c: ComponentCard
-  index: number
-  progress: MotionValue<number>
-}) {
-  const reduce = useReducedMotion()
+// One desktop column: an entrance fade plus a gentle, per-column scroll drift
+// so the row moves as you scroll rather than sitting flat like a static deck.
+// The drift is a CSS scroll-driven animation (`.cascade-drift` in globals.css)
+// — free of any scroll-listener JS, and a no-op in browsers without scroll
+// timelines or with reduced motion, which just show the static offset shelf.
+function CascadeColumn({ c, index }: { c: ComponentCard; index: number }) {
   // Alternate drift direction and vary the range a touch so columns separate
   // in depth instead of moving as one block.
   const dir = index % 2 === 0 ? 1 : -1
   const range = 22 + (index % 3) * 8
-  const y = useTransform(progress, [0, 1], [dir * range, -dir * range])
 
   return (
-    <motion.div
+    <Reveal
+      lift={false}
+      delay={index * 0.05}
       className="min-w-0 flex-1"
-      style={{ marginTop: OFFSETS[index] ?? 0, ...(reduce ? {} : { y }) }}
-      initial={{ opacity: 0 }}
-      whileInView={{ opacity: 1 }}
-      viewport={{ once: true, margin: '0px 0px -10% 0px' }}
-      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1], delay: index * 0.05 }}>
-      <CardFace c={c} />
-    </motion.div>
+      style={{ marginTop: OFFSETS[index] ?? 0 }}>
+      <div className="cascade-drift" style={{ '--drift': `${dir * range}px` } as CSSProperties}>
+        <CardFace c={c} />
+      </div>
+    </Reveal>
   )
 }
 
 export function ComponentsCascade() {
-  const ref = useRef<HTMLDivElement>(null)
-  const { scrollYProgress } = useScroll({
-    target: ref,
-    offset: ['start end', 'end start'],
-  })
-
   return (
     <>
-      {/* Desktop — staggered, parallaxing shelf of preview cards. */}
-      <div ref={ref} className="hidden items-start gap-4 lg:flex">
+      {/* Desktop — staggered, drifting shelf of preview cards. */}
+      <div className="hidden items-start gap-4 lg:flex">
         {COMPONENTS.map((c, i) => (
-          <CascadeColumn key={c.id} c={c} index={i} progress={scrollYProgress} />
+          <CascadeColumn key={c.id} c={c} index={i} />
         ))}
       </div>
 

--- a/app/sections/features-grid.tsx
+++ b/app/sections/features-grid.tsx
@@ -10,12 +10,8 @@ import {
   Keyboard,
   Puzzle,
 } from 'lucide-react'
-import { motion, useReducedMotion } from 'framer-motion'
+import { Reveal } from '@/components/reveal'
 
-// Shared motion vocabulary with the page's Reveal primitive: the same
-// "ease-out-expo" settle so cards glide in and decelerate, reading as premium.
-const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
-const DURATION = 0.7
 // How far off-screen a card starts. The clip wrapper hides this travel, so the
 // card appears to enter from the section's edge.
 const OFFSET = 220
@@ -72,8 +68,6 @@ const FEATURES = [
 ]
 
 export function FeaturesGrid() {
-  const reduce = useReducedMotion()
-
   // Cards converge from the section's edges to the center, row by row, as you
   // scroll: the left column slides in from the left, the right column from the
   // right. Each card triggers its own scroll reveal (rather than one group
@@ -81,48 +75,27 @@ export function FeaturesGrid() {
   // the same moment — animate together and meet in the middle. When the grid
   // collapses to a single column on mobile, the alternating left/right origin
   // turns into a gentle zig-zag instead of breaking.
-  const cardClass = 'flex items-start gap-3 rounded-lg border p-4'
-
   return (
     // overflow-x-clip so a card's off-screen starting position never adds a
     // horizontal scrollbar while it travels in.
     <div className="overflow-x-clip">
       <div className="grid gap-3 sm:grid-cols-2">
-        {FEATURES.map((feature, i) => {
-          const inner = (
-            <>
-              <div className="bg-muted shrink-0 rounded-md p-2">
-                <feature.icon className="size-4" />
-              </div>
-              <div>
-                <div className="text-sm font-medium">{feature.title}</div>
-                <div className="text-muted-foreground text-xs">{feature.description}</div>
-              </div>
-            </>
-          )
-
-          if (reduce) {
-            return (
-              <div key={feature.title} className={cardClass}>
-                {inner}
-              </div>
-            )
-          }
-
+        {FEATURES.map((feature, i) => (
           // Even index → left column → enter from the left; odd → from the right.
-          const fromLeft = i % 2 === 0
-          return (
-            <motion.div
-              key={feature.title}
-              className={cardClass}
-              initial={{ opacity: 0, x: fromLeft ? -OFFSET : OFFSET }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true, margin: '0px 0px -15% 0px' }}
-              transition={{ duration: DURATION, ease: EASE }}>
-              {inner}
-            </motion.div>
-          )
-        })}
+          <Reveal
+            key={feature.title}
+            lift={false}
+            x={i % 2 === 0 ? -OFFSET : OFFSET}
+            className="flex items-start gap-3 rounded-lg border p-4">
+            <div className="bg-muted shrink-0 rounded-md p-2">
+              <feature.icon className="size-4" />
+            </div>
+            <div>
+              <div className="text-sm font-medium">{feature.title}</div>
+              <div className="text-muted-foreground text-xs">{feature.description}</div>
+            </div>
+          </Reveal>
+        ))}
       </div>
     </div>
   )

--- a/app/sections/styles-carousel.tsx
+++ b/app/sections/styles-carousel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
@@ -82,6 +82,33 @@ export function StylesCarousel() {
   // moving forward and from the left when moving back.
   const [dir, setDir] = useState(0)
 
+  // The six composers are heavy (each pulls in the full prompt-area component),
+  // so don't mount — or even fetch — any of them until the visitor scrolls
+  // near the section. Keeps their chunks off the critical path and their
+  // markup out of the initial HTML, which matters a lot on mobile.
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    const el = viewportRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setReady(true)
+      return
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setReady(true)
+          io.disconnect()
+        }
+      },
+      // Start loading well before the section is on screen so the active
+      // composer is usually interactive by the time it's visible.
+      { rootMargin: '600px 0px' },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
+
   // Record which style the visitor chose to preview (skipping no-op re-selects),
   // tagged by how they got there — a provider logo tile or the prev/next arrows.
   const trackSelect = (index: number, method: 'logo' | 'arrow') => {
@@ -132,23 +159,24 @@ export function StylesCarousel() {
             remounting these heavy composers on each step reset the page scroll,
             so instead the inactive ones are hidden (display:none keeps their
             menus from being clipped) and the active one animates in. */}
-        <div className="mx-auto flex min-h-[19rem] w-full max-w-2xl items-center">
-          {SLIDES.map((slide, i) => (
-            <div
-              key={slide.id}
-              aria-hidden={i !== active || undefined}
-              className={
-                i === active
-                  ? cn(
-                      'animate-in fade-in w-full duration-300 ease-out',
-                      dir > 0 && 'slide-in-from-right-6',
-                      dir < 0 && 'slide-in-from-left-6',
-                    )
-                  : 'hidden'
-              }>
-              {slide.render()}
-            </div>
-          ))}
+        <div ref={viewportRef} className="mx-auto flex min-h-[19rem] w-full max-w-2xl items-center">
+          {ready &&
+            SLIDES.map((slide, i) => (
+              <div
+                key={slide.id}
+                aria-hidden={i !== active || undefined}
+                className={
+                  i === active
+                    ? cn(
+                        'animate-in fade-in w-full duration-300 ease-out',
+                        dir > 0 && 'slide-in-from-right-6',
+                        dir < 0 && 'slide-in-from-left-6',
+                      )
+                    : 'hidden'
+                }>
+                {slide.render()}
+              </div>
+            ))}
         </div>
 
         <button

--- a/components/analytics.tsx
+++ b/components/analytics.tsx
@@ -8,11 +8,13 @@ export function Analytics() {
   return (
     <>
       <VercelAnalytics />
+      {/* lazyOnload (not afterInteractive): keep gtag.js from competing with
+          hydration and LCP-critical requests on slow mobile connections. */}
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-        strategy="afterInteractive"
+        strategy="lazyOnload"
       />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script id="google-analytics" strategy="lazyOnload">
         {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}window.gtag=gtag;gtag('js',new Date());gtag('config','${GA_MEASUREMENT_ID}');`}
       </Script>
       <GaRouteTracker />

--- a/components/posthog-provider.tsx
+++ b/components/posthog-provider.tsx
@@ -1,34 +1,57 @@
 'use client'
 
 import { useEffect } from 'react'
-import posthog from 'posthog-js'
-import { PostHogProvider as PostHogReactProvider } from 'posthog-js/react'
-import { POSTHOG_API_HOST, POSTHOG_KEY, POSTHOG_UI_HOST } from '@/lib/analytics'
+import { loadPostHog, POSTHOG_KEY } from '@/lib/analytics'
+
+// Signals that a visitor is engaging — any of these pulls the SDK in early so
+// autocapture doesn't miss the interaction that follows.
+const INTERACTION_EVENTS = ['pointerdown', 'keydown', 'touchstart'] as const
 
 /**
- * Initializes PostHog once on the client and makes the instance available to
- * the React tree (so components can also use `usePostHog()` if needed).
+ * Schedules the PostHog SDK load off the critical path.
  *
- * Ingestion is routed through the same-origin `/ingest` proxy (see the
- * rewrites in `next.config.ts`) so analytics load from our own domain and
- * aren't dropped by ad/tracker blockers. `defaults: '2026-05-30'` opts into
- * PostHog's modern defaults, including automatic pageview capture on App
- * Router client-side navigations.
+ * posthog-js is ~60 KB gzipped — heavier than everything else on the mobile
+ * homepage combined — so instead of shipping it in the initial bundle it is
+ * dynamically imported (see `loadPostHog`) once the page has loaded and the
+ * main thread is idle, or on the visitor's first interaction, whichever comes
+ * first. The initial pageview is still captured at init, so nothing is lost;
+ * only network/CPU contention during First/Largest Contentful Paint is.
  *
  * If `POSTHOG_KEY` is empty (env var explicitly set to ''), this is a no-op
  * pass-through and nothing is sent.
  */
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    if (!POSTHOG_KEY || posthog.__loaded) return
-    posthog.init(POSTHOG_KEY, {
-      api_host: POSTHOG_API_HOST,
-      ui_host: POSTHOG_UI_HOST,
-      defaults: '2026-05-30',
-    })
+    if (!POSTHOG_KEY) return
+
+    let idleHandle: number | undefined
+    const start = () => {
+      cleanup()
+      void loadPostHog()
+    }
+    const scheduleIdle = () => {
+      idleHandle =
+        typeof requestIdleCallback === 'function'
+          ? requestIdleCallback(start, { timeout: 3000 })
+          : (setTimeout(start, 2000) as unknown as number)
+    }
+
+    for (const event of INTERACTION_EVENTS) {
+      window.addEventListener(event, start, { once: true, passive: true })
+    }
+    if (document.readyState === 'complete') scheduleIdle()
+    else window.addEventListener('load', scheduleIdle, { once: true })
+
+    function cleanup() {
+      for (const event of INTERACTION_EVENTS) window.removeEventListener(event, start)
+      window.removeEventListener('load', scheduleIdle)
+      if (idleHandle !== undefined) {
+        if (typeof cancelIdleCallback === 'function') cancelIdleCallback(idleHandle)
+        else clearTimeout(idleHandle)
+      }
+    }
+    return cleanup
   }, [])
 
-  if (!POSTHOG_KEY) return <>{children}</>
-
-  return <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
+  return <>{children}</>
 }

--- a/components/reveal.tsx
+++ b/components/reveal.tsx
@@ -1,7 +1,14 @@
 'use client'
 
-import { motion, useReducedMotion, type Variants } from 'framer-motion'
-import type { ReactNode } from 'react'
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
 
 /**
  * Scroll-reveal primitives — the motion vocabulary for the marketing pages.
@@ -10,60 +17,98 @@ import type { ReactNode } from 'react'
  * viewport (or on mount, above the fold), all sharing one easing curve so the
  * page moves with a single, calm voice rather than a grab-bag of effects.
  *
- * Every export degrades to a plain `<div>` under `prefers-reduced-motion`, so
- * the reduced-motion render is byte-for-byte identical in layout — only the
- * entrance is dropped. Pass `lift={false}` (opacity only) around interactive
- * widgets whose floating menus shouldn't sit inside a transformed ancestor.
+ * The animation itself is pure CSS (see the reveal block in `globals.css`):
+ * `trigger="mount"` runs a keyframe animation at first paint with **no
+ * JavaScript in the critical path** — vital for LCP, since the hero must not
+ * wait on hydration to become visible — while `trigger="scroll"` starts hidden
+ * and transitions in when the shared IntersectionObserver below stamps
+ * `data-revealed`. `prefers-reduced-motion` is handled entirely in CSS, where
+ * the reduced render keeps the exact same layout with the entrance dropped.
  */
-
-// "ease-out-expo"-ish: decelerates as it settles, reading as premium not springy.
-const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1]
-const DURATION = 0.6
-const DISTANCE = 24
 
 // Fire once, starting a little before the element is fully on-screen so the
 // motion resolves around the time it reaches a comfortable reading position.
-const VIEWPORT = { once: true, margin: '0px 0px -15% 0px' } as const
+const VIEWPORT_MARGIN = '0px 0px -15% 0px'
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: DISTANCE },
-  show: { opacity: 1, y: 0, transition: { duration: DURATION, ease: EASE } },
+// One shared observer for every scroll-revealed element on the page.
+let observer: IntersectionObserver | null = null
+function observe(el: Element) {
+  if (typeof IntersectionObserver === 'undefined') {
+    el.setAttribute('data-revealed', '')
+    return () => {}
+  }
+  observer ??= new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue
+        entry.target.setAttribute('data-revealed', '')
+        observer?.unobserve(entry.target)
+      }
+    },
+    { rootMargin: VIEWPORT_MARGIN },
+  )
+  observer.observe(el)
+  return () => observer?.unobserve(el)
+}
+
+/** Attach the shared reveal observer to a `data-reveal="scroll"` element. */
+function useScrollReveal(enabled: boolean) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!enabled || !ref.current) return
+    return observe(ref.current)
+  }, [enabled])
+  return ref
+}
+
+function revealVars(delay: number, x: number, y: number): CSSProperties {
+  const vars: Record<string, string> = {}
+  if (delay) vars['--reveal-delay'] = `${delay}s`
+  if (x) vars['--reveal-x'] = `${x}px`
+  if (y !== 24) vars['--reveal-y'] = `${y}px`
+  return vars as CSSProperties
 }
 
 /**
- * Fades + lifts its children into place the first time they scroll into view.
- * Above-the-fold usage animates on mount (the element is already in view).
+ * Fades + lifts its children into place. `trigger="scroll"` (default) fires
+ * the first time the element scrolls into view; `trigger="mount"` animates at
+ * first paint without waiting for JS — use it above the fold (e.g. the hero).
  */
 export function Reveal({
   children,
   delay = 0,
   className,
+  style,
   lift = true,
+  x = 0,
+  trigger = 'scroll',
 }: {
   children: ReactNode
   delay?: number
   className?: string
+  style?: CSSProperties
   /** Disable the vertical translate (opacity-only) — avoids a lingering
    *  `transform` ancestor that would re-anchor a child's fixed-position menus. */
   lift?: boolean
+  /** Horizontal offset (px) to slide in from, e.g. ±220 for the features grid. */
+  x?: number
+  trigger?: 'scroll' | 'mount'
 }) {
-  const reduce = useReducedMotion()
-  if (reduce) return <div className={className}>{children}</div>
+  const ref = useScrollReveal(trigger === 'scroll')
   return (
-    <motion.div
+    <div
+      ref={ref}
       className={className}
-      initial={lift ? { opacity: 0, y: DISTANCE } : { opacity: 0 }}
-      whileInView={lift ? { opacity: 1, y: 0 } : { opacity: 1 }}
-      viewport={VIEWPORT}
-      transition={{ duration: DURATION, ease: EASE, delay }}>
+      data-reveal={trigger}
+      style={{ ...style, ...revealVars(delay, x, lift ? 24 : 0) }}>
       {children}
-    </motion.div>
+    </div>
   )
 }
 
 /**
  * Staggers its {@link RevealItem} children so they cascade in one after another.
- * `trigger="scroll"` (default) starts when the group scrolls into view;
+ * `trigger="scroll"` (default) starts when each item scrolls into view;
  * `trigger="mount"` starts immediately — use it above the fold (e.g. the hero).
  */
 export function RevealGroup({
@@ -79,32 +124,38 @@ export function RevealGroup({
   stagger?: number
   delayChildren?: number
 }) {
-  const reduce = useReducedMotion()
-  if (reduce) return <div className={className}>{children}</div>
-
-  const variants: Variants = {
-    hidden: {},
-    show: { transition: { staggerChildren: stagger, delayChildren } },
-  }
-  const activate =
-    trigger === 'mount'
-      ? { animate: 'show' as const }
-      : { whileInView: 'show' as const, viewport: VIEWPORT }
-
+  let index = 0
   return (
-    <motion.div className={className} variants={variants} initial="hidden" {...activate}>
-      {children}
-    </motion.div>
+    <div className={className}>
+      {Children.map(children, (child) => {
+        if (isValidElement<RevealItemProps>(child) && child.type === RevealItem) {
+          return cloneElement(child, { trigger, delay: delayChildren + index++ * stagger })
+        }
+        return child
+      })}
+    </div>
   )
 }
 
+type RevealItemProps = {
+  children: ReactNode
+  className?: string
+  /** Injected by {@link RevealGroup}. */
+  trigger?: 'scroll' | 'mount'
+  /** Injected by {@link RevealGroup}. */
+  delay?: number
+}
+
 /** A single staggered child. Must be rendered inside a {@link RevealGroup}. */
-export function RevealItem({ children, className }: { children: ReactNode; className?: string }) {
-  const reduce = useReducedMotion()
-  if (reduce) return <div className={className}>{children}</div>
+export function RevealItem({
+  children,
+  className,
+  trigger = 'scroll',
+  delay = 0,
+}: RevealItemProps) {
   return (
-    <motion.div className={className} variants={itemVariants}>
+    <Reveal className={className} trigger={trigger} delay={delay}>
       {children}
-    </motion.div>
+    </Reveal>
   )
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,4 +1,4 @@
-import posthog from 'posthog-js'
+import type { PostHog } from 'posthog-js'
 
 declare global {
   interface Window {
@@ -25,6 +25,35 @@ export const POSTHOG_API_HOST = '/ingest'
 
 /** PostHog app host used for links from the SDK (e.g. toolbar, session links). */
 export const POSTHOG_UI_HOST = 'https://eu.posthog.com'
+
+let posthogPromise: Promise<PostHog | null> | null = null
+
+/**
+ * Lazily load and initialize the PostHog SDK.
+ *
+ * posthog-js is ~60 KB gzipped, so it is deliberately kept out of the initial
+ * bundle: nothing imports it statically. `PostHogProvider` calls this once the
+ * page has settled (or on first interaction), and `track` calls it on demand —
+ * events fired before the SDK arrives simply await the same promise, so
+ * nothing is lost. Resolves to `null` when PostHog is disabled.
+ *
+ * `defaults: '2026-05-30'` opts into PostHog's modern defaults, including
+ * automatic pageview capture on App Router client-side navigations.
+ */
+export function loadPostHog(): Promise<PostHog | null> {
+  if (!POSTHOG_KEY || typeof window === 'undefined') return Promise.resolve(null)
+  posthogPromise ??= import('posthog-js').then(({ default: posthog }) => {
+    if (!posthog.__loaded) {
+      posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_API_HOST,
+        ui_host: POSTHOG_UI_HOST,
+        defaults: '2026-05-30',
+      })
+    }
+    return posthog
+  })
+  return posthogPromise
+}
 
 /**
  * Marketing-site analytics — a thin, typed wrapper over PostHog.
@@ -108,6 +137,6 @@ export type AnalyticsEvent = keyof AnalyticsEventMap
  */
 export function track<E extends AnalyticsEvent>(event: E, properties: AnalyticsEventMap[E]): void {
   if (typeof window === 'undefined') return
-  if (POSTHOG_KEY) posthog.capture(event, properties)
+  if (POSTHOG_KEY) void loadPostHog().then((posthog) => posthog?.capture(event, properties))
   window.gtag?.('event', event, properties)
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@vercel/functions": "^3.7.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.42.0",
     "geist": "^1.7.2",
     "lucide-react": "^1.22.0",
     "next": "^16.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      framer-motion:
-        specifier: ^12.42.0
-        version: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       geist:
         specifier: ^1.7.2
         version: 1.7.2(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -2968,20 +2965,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.42.0:
-    resolution: {integrity: sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3804,12 +3787,6 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
-
-  motion-dom@12.42.0:
-    resolution: {integrity: sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -7492,8 +7469,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -7515,7 +7492,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7526,22 +7503,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7552,7 +7529,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7893,15 +7870,6 @@ snapshots:
       is-callable: 1.2.7
 
   forwarded@0.2.0: {}
-
-  framer-motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      motion-dom: 12.42.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   fresh@2.0.0: {}
 
@@ -8686,12 +8654,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
-
-  motion-dom@12.42.0:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## Summary

Removes the Framer Motion dependency and replaces all scroll-reveal animations with a pure CSS implementation backed by a shared IntersectionObserver. This eliminates ~40 KB of JavaScript from the critical path while maintaining the same visual effects and improving Core Web Vitals, particularly LCP on mobile.

## Key Changes

- **Reveal component rewrite** (`components/reveal.tsx`):
  - Replaced Framer Motion's `motion.div` with plain `<div>` elements
  - Moved animation logic to CSS keyframes and transitions in `globals.css`
  - Introduced `trigger` prop: `"mount"` for above-the-fold (animates at first paint via CSS animation with zero JS delay), `"scroll"` for below-the-fold (uses shared IntersectionObserver)
  - Added `x` parameter to support horizontal slide-in offsets (e.g., features grid)
  - Removed `useReducedMotion` hook; `prefers-reduced-motion` now handled entirely in CSS

- **CSS animation engine** (`app/globals.css`):
  - New `@keyframes reveal-in` animation with configurable `--reveal-x`, `--reveal-y`, and `--reveal-delay` CSS variables
  - `[data-reveal="mount"]` uses animation for instant visibility in server-rendered HTML (critical for LCP)
  - `[data-reveal="scroll"]` starts hidden and transitions in when observer sets `data-revealed` attribute
  - Added `cascade-drift` scroll-driven animation (progressive enhancement for parallax effect)

- **Shared IntersectionObserver** (`components/reveal.tsx`):
  - Single observer instance reused across all scroll-revealed elements on the page
  - `useScrollReveal` hook manages lifecycle and cleanup
  - Graceful fallback when IntersectionObserver is unavailable

- **PostHog lazy loading** (`components/posthog-provider.tsx`, `lib/analytics.ts`):
  - Deferred SDK load until page idle or first user interaction (whichever comes first)
  - Reduces initial bundle by ~60 KB gzipped
  - `loadPostHog()` function handles dynamic import and initialization
  - `track()` awaits SDK load on demand so no events are lost

- **StylesCarousel lazy loading** (`app/sections/styles-carousel.tsx`):
  - Heavy composer components now lazy-load when section scrolls into view
  - Keeps their chunks off critical path and markup out of initial HTML

- **ComponentsCascade refactor** (`app/sections/components-cascade.tsx`):
  - Removed Framer Motion scroll listener and `useTransform`
  - Replaced with CSS scroll-driven animation (`.cascade-drift`)
  - Simplified to use `Reveal` component with staggered delays

- **FeaturesGrid simplification** (`app/sections/features-grid.tsx`):
  - Replaced individual Framer Motion animations with `Reveal` component
  - Uses `x` prop for directional slide-in from grid edges

- **Layout and performance** (`app/layout.tsx`, `components/analytics.tsx`):
  - Removed root-level Suspense boundary that was blocking first paint
  - Moved Suspense to local boundaries (e.g., hero demo) to prevent full-page deferral
  - Changed Google Analytics script to `lazyOnload` strategy
  - Added `<noscript>` override to keep scroll-revealed content visible when JS is disabled

- **Dependency removal** (`package.json`):
  - Removed `framer-motion` dependency

## Notable Implementation Details

- **LCP optimization**: `trigger="mount"` animations run via CSS keyframes at first paint, before JavaScript hydration completes. The server-rendered HTML is immediately visible.
- **Progressive enhancement**: Scroll-driven animations and cascade drift are CSS-only features that gracefully degrade in older browsers.
- **No layout shift**: Scroll-revealed elements use CSS variables for offsets, ensuring the layout is identical whether animations are enabled or not.
- **Reduced-motion support**: All animations respect `prefers-reduced-motion` via a single media query wrapper in CSS; no JavaScript involvement needed.
- **

https://claude.ai/code/session_01VbneB1teN3dkqwRMnaxka8