### PR TITLE
Add interactive chip interactions to hero composer demo

### DIFF
--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Plus,
   Hand,
@@ -18,6 +18,7 @@ import {
   PromptArea,
   ActionBar,
   isSegmentsEmpty,
+  type ChipSegment,
   type Segment,
   type TriggerConfig,
   type PromptAreaFile,
@@ -151,15 +152,51 @@ export function CodexInputExample({
   triggers,
   markdown = true,
   minHeight = 40,
+  onChipClick,
 }: {
   initialSegments?: Segment[]
   initialFiles?: PromptAreaFile[]
   triggers?: TriggerConfig[]
   markdown?: boolean
   minHeight?: number
+  /**
+   * Called when a chip in the composer is clicked. `replaceChip` swaps the
+   * clicked chip (matched by trigger + value) for another one in place, so
+   * hosts can build pickers on top of chip clicks without owning the
+   * segment state.
+   */
+  onChipClick?: (
+    chip: ChipSegment,
+    actions: { replaceChip: (next: Omit<ChipSegment, 'type'>) => void },
+  ) => void
 } = {}) {
   const { segments, setSegments, files, setFiles, submitted, promptRef, submit, reset } =
     useSubmittablePrompt<PromptAreaFile>({ initialSegments, initialFiles })
+
+  const handleChipClick = useCallback(
+    (chip: ChipSegment) => {
+      if (!onChipClick) return
+      onChipClick(chip, {
+        replaceChip: (next) =>
+          setSegments((prev) => {
+            let replaced = false
+            return prev.map((seg) => {
+              if (
+                !replaced &&
+                seg.type === 'chip' &&
+                seg.trigger === chip.trigger &&
+                seg.value === chip.value
+              ) {
+                replaced = true
+                return { ...next, type: 'chip' as const }
+              }
+              return seg
+            })
+          }),
+      })
+    },
+    [onChipClick, setSegments],
+  )
 
   const [permission, setPermission] = useState<Permission>(PERMISSIONS[0])
   const [model, setModel] = useState<Model>(MODELS[0])
@@ -207,6 +244,7 @@ export function CodexInputExample({
               triggers={triggers}
               placeholder="Do anything"
               onSubmit={submit}
+              onChipClick={onChipClick ? handleChipClick : undefined}
               markdown={markdown}
               autoGrow
               minHeight={minHeight}

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Plus,
   Hand,
@@ -159,44 +159,11 @@ export function CodexInputExample({
   triggers?: TriggerConfig[]
   markdown?: boolean
   minHeight?: number
-  /**
-   * Called when a chip in the composer is clicked. `replaceChip` swaps the
-   * clicked chip (matched by trigger + value) for another one in place, so
-   * hosts can build pickers on top of chip clicks without owning the
-   * segment state.
-   */
-  onChipClick?: (
-    chip: ChipSegment,
-    actions: { replaceChip: (next: Omit<ChipSegment, 'type'>) => void },
-  ) => void
+  /** Forwarded to PromptArea — fires when a chip in the composer is clicked. */
+  onChipClick?: (chip: ChipSegment) => void
 } = {}) {
   const { segments, setSegments, files, setFiles, submitted, promptRef, submit, reset } =
     useSubmittablePrompt<PromptAreaFile>({ initialSegments, initialFiles })
-
-  const handleChipClick = useCallback(
-    (chip: ChipSegment) => {
-      if (!onChipClick) return
-      onChipClick(chip, {
-        replaceChip: (next) =>
-          setSegments((prev) => {
-            let replaced = false
-            return prev.map((seg) => {
-              if (
-                !replaced &&
-                seg.type === 'chip' &&
-                seg.trigger === chip.trigger &&
-                seg.value === chip.value
-              ) {
-                replaced = true
-                return { ...next, type: 'chip' as const }
-              }
-              return seg
-            })
-          }),
-      })
-    },
-    [onChipClick, setSegments],
-  )
 
   const [permission, setPermission] = useState<Permission>(PERMISSIONS[0])
   const [model, setModel] = useState<Model>(MODELS[0])
@@ -244,7 +211,7 @@ export function CodexInputExample({
               triggers={triggers}
               placeholder="Do anything"
               onSubmit={submit}
-              onChipClick={onChipClick ? handleChipClick : undefined}
+              onChipClick={onChipClick}
               markdown={markdown}
               autoGrow
               minHeight={minHeight}

--- a/app/globals.css
+++ b/app/globals.css
@@ -262,12 +262,18 @@
       }
       to {
         opacity: 1;
-        transform: translate(0, 0);
+        transform: none;
       }
     }
 
     [data-reveal='mount'] {
-      animation: reveal-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+      /* `backwards`, not `both`: a forwards-filling transform animation keeps
+         the element a containing block forever (Blink retains the final frame
+         as an identity matrix, even with `transform: none` in `to`), which
+         re-anchors fixed-position descendants — e.g. the PromptArea suggestion
+         popover in the hero demo. With `backwards` the transform only exists
+         during the entrance; afterwards the static styles (no transform) apply. */
+      animation: reveal-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) backwards;
       animation-delay: var(--reveal-delay, 0s);
     }
 
@@ -280,7 +286,8 @@
     }
     [data-reveal='scroll'][data-revealed] {
       opacity: 1;
-      transform: translate(0, 0);
+      /* `none` for the same fixed-position-descendant reason as reveal-in. */
+      transform: none;
     }
 
     /* Gentle per-column drift for the homepage components cascade — the

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { ArrowRight, ArrowUpRight } from 'lucide-react'
+import { ArrowRight, ArrowUpRight, Check, Loader2, Sparkles, X } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
 import { InstallCta } from '@/components/install-cta'
 import { track } from '@/lib/analytics'
@@ -13,7 +13,12 @@ import { FeaturesGrid } from './sections/features-grid'
 import { ComponentsCascade } from './sections/components-cascade'
 import { StylesCarousel } from './sections/styles-carousel'
 import { USERS, COMMANDS, TAGS } from './sections/mock-data'
-import { type Segment, type TriggerConfig, type PromptAreaFile } from 'prompt-area'
+import {
+  type ChipSegment,
+  type Segment,
+  type TriggerConfig,
+  type PromptAreaFile,
+} from 'prompt-area'
 
 const CodexInputExample = dynamic(() =>
   import('./examples/codex-input').then((m) => ({ default: m.CodexInputExample })),
@@ -70,6 +75,8 @@ const HERO_FILES: PromptAreaFile[] = [
   },
 ]
 
+const TAG_MENU_WIDTH = 256
+
 export default function HomeContent() {
   // Fire `demo_interacted` once, the first time the visitor focuses or types in
   // the live hero composer — our best signal that they actually tried the
@@ -80,6 +87,94 @@ export default function HomeContent() {
     demoTracked.current = true
     track('demo_interacted', { location: 'hero' })
   }, [])
+
+  // Every chip in the hero composer does something when clicked, so visitors
+  // learn the chips are live objects, not styled text: #tags reopen the tag
+  // list (picking one swaps the chip), @mentions pop a "notified" toast, and
+  // /commands run a mock execution with a result card.
+  const demoRef = useRef<HTMLDivElement>(null)
+  const [tagMenu, setTagMenu] = useState<{
+    chip: ChipSegment
+    top: number
+    left: number
+    replaceChip: (next: Omit<ChipSegment, 'type'>) => void
+  } | null>(null)
+  const [toast, setToast] = useState<{ title: string; description?: string } | null>(null)
+  const [command, setCommand] = useState<{
+    chip: ChipSegment
+    status: 'running' | 'done'
+  } | null>(null)
+
+  const handleChipClick = useCallback(
+    (chip: ChipSegment, actions: { replaceChip: (next: Omit<ChipSegment, 'type'>) => void }) => {
+      track('demo_chip_clicked', { location: 'hero', trigger: chip.trigger, value: chip.value })
+
+      if (chip.trigger === '#') {
+        // Anchor the tag list right under the clicked chip, clamped so it
+        // never overflows the demo column on narrow screens.
+        const root = demoRef.current
+        const el = root?.querySelector<HTMLElement>(
+          `[data-chip-trigger="#"][data-chip-value="${CSS.escape(chip.value)}"]`,
+        )
+        if (!root || !el) return
+        const chipRect = el.getBoundingClientRect()
+        const rootRect = root.getBoundingClientRect()
+        setTagMenu({
+          chip,
+          top: chipRect.bottom - rootRect.top + 6,
+          left: Math.max(
+            0,
+            Math.min(chipRect.left - rootRect.left, rootRect.width - TAG_MENU_WIDTH),
+          ),
+          replaceChip: actions.replaceChip,
+        })
+      } else if (chip.trigger === '@') {
+        const user = USERS.find((u) => u.value === chip.value)
+        setToast({
+          title: `${chip.displayText} notified`,
+          description: user ? `${user.description} — looped in on this prompt.` : undefined,
+        })
+      } else if (chip.trigger === '/') {
+        setCommand({ chip, status: 'running' })
+      }
+    },
+    [],
+  )
+
+  // Auto-dismiss the mention toast.
+  useEffect(() => {
+    if (!toast) return
+    const timer = setTimeout(() => setToast(null), 3200)
+    return () => clearTimeout(timer)
+  }, [toast])
+
+  // Let the mock command "run" briefly before showing its result.
+  useEffect(() => {
+    if (command?.status !== 'running') return
+    const timer = setTimeout(
+      () => setCommand((cur) => (cur?.status === 'running' ? { ...cur, status: 'done' } : cur)),
+      1200,
+    )
+    return () => clearTimeout(timer)
+  }, [command])
+
+  // Close the tag list on outside click or Escape, like a real dropdown.
+  useEffect(() => {
+    if (!tagMenu) return
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (!target.closest('[data-hero-tag-menu]')) setTagMenu(null)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setTagMenu(null)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [tagMenu])
 
   return (
     <div className="flex flex-col">
@@ -131,7 +226,8 @@ export default function HomeContent() {
               transformed ancestor. */}
           <div
             id="demo"
-            className="w-full min-w-0 scroll-mt-20"
+            ref={demoRef}
+            className="relative w-full min-w-0 scroll-mt-20"
             onFocusCapture={handleDemoInteract}
             onInputCapture={handleDemoInteract}>
             <Reveal lift={false} delay={0.15}>
@@ -141,8 +237,120 @@ export default function HomeContent() {
                 initialFiles={HERO_FILES}
                 markdown
                 minHeight={76}
+                onChipClick={handleChipClick}
               />
+
+              {/* Mock /command execution — proves slash-command chips are runnable. */}
+              {command && (
+                <div className="bg-muted/50 animate-in fade-in slide-in-from-bottom-2 mt-2 rounded-lg border p-3 text-sm duration-300">
+                  {command.status === 'running' ? (
+                    <div className="text-muted-foreground flex items-center gap-2">
+                      <Loader2 className="size-3.5 animate-spin" />
+                      Running{' '}
+                      <span className="text-violet-700 dark:text-violet-400">
+                        /{command.chip.value}
+                      </span>{' '}
+                      on {HERO_FILES[0].name}…
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-muted-foreground flex items-center gap-1.5 text-xs font-medium">
+                          <Sparkles className="size-3.5 text-violet-700 dark:text-violet-400" />
+                          <span className="text-violet-700 dark:text-violet-400">
+                            /{command.chip.value}
+                          </span>
+                          · {HERO_FILES[0].name}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setCommand(null)}
+                          className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-md p-1 transition-colors"
+                          aria-label="Dismiss summary">
+                          <X className="size-3.5" />
+                        </button>
+                      </div>
+                      <div>
+                        <span className="font-semibold">Key messages:</span> Q4 doubles down on
+                        enterprise buyers with an AI-assist angle; budget shifts 30% from paid
+                        social to lifecycle email.
+                      </div>
+                      <div>
+                        <span className="font-semibold">Action items:</span>{' '}
+                        <em>
+                          Strategist locks the channel plan by Friday; Copywriter drafts three hero
+                          variants.
+                        </em>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </Reveal>
+
+            {/* Tag picker — clicking a #tag chip reopens the tag list; picking
+                one swaps the chip in place. */}
+            {tagMenu && (
+              <div
+                data-hero-tag-menu
+                role="menu"
+                aria-label="Swap tag"
+                style={{ top: tagMenu.top, left: tagMenu.left, width: TAG_MENU_WIDTH }}
+                className="bg-popover animate-in fade-in zoom-in-95 absolute z-30 flex flex-col rounded-xl border p-1 shadow-md duration-150">
+                <div className="text-muted-foreground px-3 py-1.5 text-xs font-medium">
+                  Swap tag
+                </div>
+                {TAGS.map((tag) => {
+                  const active = tag.value === tagMenu.chip.value
+                  return (
+                    <button
+                      key={tag.value}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={active}
+                      onClick={() => {
+                        if (!active) {
+                          tagMenu.replaceChip({
+                            trigger: '#',
+                            value: tag.value,
+                            displayText: tag.label,
+                          })
+                          track('demo_tag_swapped', { location: 'hero', tag: tag.value })
+                        }
+                        setTagMenu(null)
+                      }}
+                      className="hover:bg-accent flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors">
+                      <span className="font-medium text-green-700 dark:text-green-400">
+                        #{tag.label}
+                      </span>
+                      <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
+                        {tag.description}
+                      </span>
+                      {active && <Check className="size-3.5 shrink-0" />}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+
+            {/* Mention toast — clicking an @mention chip "notifies" that teammate. */}
+            {toast && (
+              <div
+                role="status"
+                className="animate-in fade-in slide-in-from-bottom-3 fixed bottom-6 left-1/2 z-50 -translate-x-1/2 duration-300">
+                <div className="bg-popover flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                    @
+                  </span>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium">{toast.title}</div>
+                    {toast.description && (
+                      <div className="text-muted-foreground text-xs">{toast.description}</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </section>

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -78,6 +78,9 @@ const HERO_FILES: PromptAreaFile[] = [
   },
 ]
 
+const TOAST_DURATION_MS = 3200
+const MAX_TOASTS = 4
+
 export default function HomeContent() {
   // Fire `demo_interacted` once, the first time the visitor focuses or types in
   // the live hero composer — our best signal that they actually tried the
@@ -94,32 +97,50 @@ export default function HomeContent() {
   // tag dropdown (via `reopenOnChipClick` on the trigger — picking one swaps
   // the chip in place), @mentions pop a "notified" toast, and /commands run a
   // mock execution with a result card.
-  const [toast, setToast] = useState<{ title: string; description?: string } | null>(null)
+  //
+  // Toasts stack: each mention click pushes its own toast with its own
+  // auto-dismiss timer, capped at the newest few so rapid clicking can't
+  // flood the corner.
+  const [toasts, setToasts] = useState<{ id: number; title: string; description?: string }[]>([])
+  const toastSeq = useRef(0)
+  const toastTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   const [command, setCommand] = useState<{
     chip: ChipSegment
     status: 'running' | 'done'
   } | null>(null)
 
-  const handleChipClick = useCallback((chip: ChipSegment) => {
-    track('demo_chip_clicked', { location: 'hero', trigger: chip.trigger, value: chip.value })
-
-    if (chip.trigger === '@') {
-      const user = USERS.find((u) => u.value === chip.value)
-      setToast({
-        title: `${chip.displayText} notified`,
-        description: user ? `${user.description} — looped in on this prompt.` : undefined,
-      })
-    } else if (chip.trigger === '/') {
-      setCommand({ chip, status: 'running' })
-    }
+  const pushToast = useCallback((toast: { title: string; description?: string }) => {
+    const id = ++toastSeq.current
+    setToasts((prev) => [...prev, { id, ...toast }].slice(-MAX_TOASTS))
+    const timer = setTimeout(() => {
+      toastTimers.current.delete(timer)
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, TOAST_DURATION_MS)
+    toastTimers.current.add(timer)
   }, [])
 
-  // Auto-dismiss the mention toast.
+  // Clear any in-flight toast timers on unmount.
   useEffect(() => {
-    if (!toast) return
-    const timer = setTimeout(() => setToast(null), 3200)
-    return () => clearTimeout(timer)
-  }, [toast])
+    const timers = toastTimers.current
+    return () => timers.forEach(clearTimeout)
+  }, [])
+
+  const handleChipClick = useCallback(
+    (chip: ChipSegment) => {
+      track('demo_chip_clicked', { location: 'hero', trigger: chip.trigger, value: chip.value })
+
+      if (chip.trigger === '@') {
+        const user = USERS.find((u) => u.value === chip.value)
+        pushToast({
+          title: `${chip.displayText} notified`,
+          description: user ? `${user.description} — looped in on this prompt.` : undefined,
+        })
+      } else if (chip.trigger === '/') {
+        setCommand({ chip, status: 'running' })
+      }
+    },
+    [pushToast],
+  )
 
   // Let the mock command "run" briefly before showing its result.
   useEffect(() => {
@@ -256,22 +277,28 @@ export default function HomeContent() {
               )}
             </Reveal>
 
-            {/* Mention toast — clicking an @mention chip "notifies" that teammate. */}
-            {toast && (
-              <div
-                role="status"
-                className="animate-in fade-in slide-in-from-bottom-3 fixed bottom-6 left-1/2 z-50 -translate-x-1/2 duration-300">
-                <div className="bg-popover flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                    @
-                  </span>
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium">{toast.title}</div>
-                    {toast.description && (
-                      <div className="text-muted-foreground text-xs">{toast.description}</div>
-                    )}
+            {/* Mention toasts — each @mention chip click "notifies" that
+                teammate. Toasts stack bottom-up, newest nearest the edge. */}
+            {toasts.length > 0 && (
+              <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center gap-2">
+                {toasts.map((toast) => (
+                  <div
+                    key={toast.id}
+                    role="status"
+                    className="animate-in fade-in slide-in-from-bottom-3 duration-300">
+                    <div className="bg-popover flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg">
+                      <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                        @
+                      </span>
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium">{toast.title}</div>
+                        {toast.description && (
+                          <div className="text-muted-foreground text-xs">{toast.description}</div>
+                        )}
+                      </div>
+                    </div>
                   </div>
-                </div>
+                ))}
               </div>
             )}
           </div>

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, ArrowUpRight, Loader2, Sparkles, X } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
 import { InstallCta } from '@/components/install-cta'
 import { track } from '@/lib/analytics'
+import { cn } from '@/lib/utils'
 import { Reveal, RevealGroup, RevealItem } from '@/components/reveal'
 import { RotatingTitle } from '@/components/rotating-title'
 import { FeaturesGrid } from './sections/features-grid'
@@ -79,7 +80,61 @@ const HERO_FILES: PromptAreaFile[] = [
 ]
 
 const TOAST_DURATION_MS = 3200
+const TOAST_EXIT_MS = 300
 const MAX_TOASTS = 4
+
+type HeroToastData = { id: number; title: string; description?: string; leaving?: boolean }
+
+/**
+ * One toast in the hero's mention-toast stack. Enter and exit both animate
+ * the same two things in sync: the card (opacity + slide) and its grid row
+ * (1fr ↔ 0fr), so the rest of the stack glides to its new position instead
+ * of jumping when a toast appears or leaves.
+ */
+function HeroToast({ toast }: { toast: HeroToastData }) {
+  // Mount collapsed, then open on the next frame so the entrance transitions.
+  const [entered, setEntered] = useState(false)
+  useEffect(() => {
+    let raf2: number | undefined
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setEntered(true))
+    })
+    return () => {
+      cancelAnimationFrame(raf1)
+      if (raf2 !== undefined) cancelAnimationFrame(raf2)
+    }
+  }, [])
+  const open = entered && !toast.leaving
+
+  return (
+    <div
+      className="grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none"
+      style={{ gridTemplateRows: open ? '1fr' : '0fr' }}>
+      <div className="min-h-0 overflow-hidden">
+        {/* px/pt give the clipped box room for the card's shadow and act as
+            the spacing between stacked toasts, collapsing along with the row. */}
+        <div
+          role="status"
+          className={cn(
+            'px-4 pt-2 pb-1 transition-[opacity,translate] duration-300 ease-out motion-reduce:transition-none',
+            open ? 'translate-y-0 opacity-100' : 'translate-y-3 opacity-0',
+          )}>
+          <div className="bg-popover flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg">
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+              @
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-medium">{toast.title}</div>
+              {toast.description && (
+                <div className="text-muted-foreground text-xs">{toast.description}</div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 export default function HomeContent() {
   // Fire `demo_interacted` once, the first time the visitor focuses or types in
@@ -99,9 +154,13 @@ export default function HomeContent() {
   // mock execution with a result card.
   //
   // Toasts stack: each mention click pushes its own toast with its own
-  // auto-dismiss timer, capped at the newest few so rapid clicking can't
-  // flood the corner.
-  const [toasts, setToasts] = useState<{ id: number; title: string; description?: string }[]>([])
+  // lifetime. A toast leaves in two phases — `leaving` plays the exit
+  // animation (fade + slide + row collapse, see HeroToast) and only then is
+  // it removed — so neighbors glide into place instead of jumping.
+  const [toasts, setToasts] = useState<HeroToastData[]>([])
+  // Ref mirror of `toasts` so push/dismiss can read the up-to-date list
+  // synchronously (e.g. to pick a cap-eviction victim) without effects.
+  const toastsRef = useRef<HeroToastData[]>([])
   const toastSeq = useRef(0)
   const toastTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   const [command, setCommand] = useState<{
@@ -109,15 +168,39 @@ export default function HomeContent() {
     status: 'running' | 'done'
   } | null>(null)
 
-  const pushToast = useCallback((toast: { title: string; description?: string }) => {
-    const id = ++toastSeq.current
-    setToasts((prev) => [...prev, { id, ...toast }].slice(-MAX_TOASTS))
-    const timer = setTimeout(() => {
-      toastTimers.current.delete(timer)
-      setToasts((prev) => prev.filter((t) => t.id !== id))
-    }, TOAST_DURATION_MS)
-    toastTimers.current.add(timer)
+  const updateToasts = useCallback((updater: (prev: HeroToastData[]) => HeroToastData[]) => {
+    toastsRef.current = updater(toastsRef.current)
+    setToasts(toastsRef.current)
   }, [])
+
+  const beginToastDismiss = useCallback(
+    (id: number) => {
+      updateToasts((prev) => prev.map((t) => (t.id === id ? { ...t, leaving: true } : t)))
+      const timer = setTimeout(() => {
+        toastTimers.current.delete(timer)
+        updateToasts((prev) => prev.filter((t) => t.id !== id))
+      }, TOAST_EXIT_MS)
+      toastTimers.current.add(timer)
+    },
+    [updateToasts],
+  )
+
+  const pushToast = useCallback(
+    (toast: { title: string; description?: string }) => {
+      const id = ++toastSeq.current
+      updateToasts((prev) => [...prev, { id, ...toast }])
+      // Over the cap: the oldest active toast leaves through the same
+      // animated exit instead of vanishing.
+      const active = toastsRef.current.filter((t) => !t.leaving)
+      if (active.length > MAX_TOASTS) beginToastDismiss(active[0].id)
+      const timer = setTimeout(() => {
+        toastTimers.current.delete(timer)
+        beginToastDismiss(id)
+      }, TOAST_DURATION_MS)
+      toastTimers.current.add(timer)
+    },
+    [updateToasts, beginToastDismiss],
+  )
 
   // Clear any in-flight toast timers on unmount.
   useEffect(() => {
@@ -280,24 +363,9 @@ export default function HomeContent() {
             {/* Mention toasts — each @mention chip click "notifies" that
                 teammate. Toasts stack bottom-up, newest nearest the edge. */}
             {toasts.length > 0 && (
-              <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center gap-2">
+              <div className="fixed bottom-5 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center">
                 {toasts.map((toast) => (
-                  <div
-                    key={toast.id}
-                    role="status"
-                    className="animate-in fade-in slide-in-from-bottom-3 duration-300">
-                    <div className="bg-popover flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg">
-                      <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                        @
-                      </span>
-                      <div className="min-w-0">
-                        <div className="text-sm font-medium">{toast.title}</div>
-                        {toast.description && (
-                          <div className="text-muted-foreground text-xs">{toast.description}</div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                  <HeroToast key={toast.id} toast={toast} />
                 ))}
               </div>
             )}

--- a/app/home-content.tsx
+++ b/app/home-content.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { ArrowRight, ArrowUpRight, Check, Loader2, Sparkles, X } from 'lucide-react'
+import { ArrowRight, ArrowUpRight, Loader2, Sparkles, X } from 'lucide-react'
 import { InstallMethodTabs } from '@/components/install-method-tabs'
 import { InstallCta } from '@/components/install-cta'
 import { track } from '@/lib/analytics'
@@ -60,6 +60,9 @@ const HERO_TRIGGERS: TriggerConfig[] = [
     position: 'any',
     mode: 'dropdown',
     resolveOnSpace: true,
+    // Clicking a #tag chip reopens the native tag dropdown anchored to the
+    // chip; picking a suggestion swaps the chip in place.
+    reopenOnChipClick: true,
     chipClassName: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
     accessibilityLabel: 'tag',
     onSearch: (q) => TAGS.filter((t) => t.label.toLowerCase().includes(q.toLowerCase())),
@@ -75,8 +78,6 @@ const HERO_FILES: PromptAreaFile[] = [
   },
 ]
 
-const TAG_MENU_WIDTH = 256
-
 export default function HomeContent() {
   // Fire `demo_interacted` once, the first time the visitor focuses or types in
   // the live hero composer — our best signal that they actually tried the
@@ -89,57 +90,29 @@ export default function HomeContent() {
   }, [])
 
   // Every chip in the hero composer does something when clicked, so visitors
-  // learn the chips are live objects, not styled text: #tags reopen the tag
-  // list (picking one swaps the chip), @mentions pop a "notified" toast, and
-  // /commands run a mock execution with a result card.
-  const demoRef = useRef<HTMLDivElement>(null)
-  const [tagMenu, setTagMenu] = useState<{
-    chip: ChipSegment
-    top: number
-    left: number
-    replaceChip: (next: Omit<ChipSegment, 'type'>) => void
-  } | null>(null)
+  // learn the chips are live objects, not styled text: #tags reopen the native
+  // tag dropdown (via `reopenOnChipClick` on the trigger — picking one swaps
+  // the chip in place), @mentions pop a "notified" toast, and /commands run a
+  // mock execution with a result card.
   const [toast, setToast] = useState<{ title: string; description?: string } | null>(null)
   const [command, setCommand] = useState<{
     chip: ChipSegment
     status: 'running' | 'done'
   } | null>(null)
 
-  const handleChipClick = useCallback(
-    (chip: ChipSegment, actions: { replaceChip: (next: Omit<ChipSegment, 'type'>) => void }) => {
-      track('demo_chip_clicked', { location: 'hero', trigger: chip.trigger, value: chip.value })
+  const handleChipClick = useCallback((chip: ChipSegment) => {
+    track('demo_chip_clicked', { location: 'hero', trigger: chip.trigger, value: chip.value })
 
-      if (chip.trigger === '#') {
-        // Anchor the tag list right under the clicked chip, clamped so it
-        // never overflows the demo column on narrow screens.
-        const root = demoRef.current
-        const el = root?.querySelector<HTMLElement>(
-          `[data-chip-trigger="#"][data-chip-value="${CSS.escape(chip.value)}"]`,
-        )
-        if (!root || !el) return
-        const chipRect = el.getBoundingClientRect()
-        const rootRect = root.getBoundingClientRect()
-        setTagMenu({
-          chip,
-          top: chipRect.bottom - rootRect.top + 6,
-          left: Math.max(
-            0,
-            Math.min(chipRect.left - rootRect.left, rootRect.width - TAG_MENU_WIDTH),
-          ),
-          replaceChip: actions.replaceChip,
-        })
-      } else if (chip.trigger === '@') {
-        const user = USERS.find((u) => u.value === chip.value)
-        setToast({
-          title: `${chip.displayText} notified`,
-          description: user ? `${user.description} — looped in on this prompt.` : undefined,
-        })
-      } else if (chip.trigger === '/') {
-        setCommand({ chip, status: 'running' })
-      }
-    },
-    [],
-  )
+    if (chip.trigger === '@') {
+      const user = USERS.find((u) => u.value === chip.value)
+      setToast({
+        title: `${chip.displayText} notified`,
+        description: user ? `${user.description} — looped in on this prompt.` : undefined,
+      })
+    } else if (chip.trigger === '/') {
+      setCommand({ chip, status: 'running' })
+    }
+  }, [])
 
   // Auto-dismiss the mention toast.
   useEffect(() => {
@@ -157,24 +130,6 @@ export default function HomeContent() {
     )
     return () => clearTimeout(timer)
   }, [command])
-
-  // Close the tag list on outside click or Escape, like a real dropdown.
-  useEffect(() => {
-    if (!tagMenu) return
-    const onDown = (e: MouseEvent) => {
-      const target = e.target as HTMLElement
-      if (!target.closest('[data-hero-tag-menu]')) setTagMenu(null)
-    }
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setTagMenu(null)
-    }
-    document.addEventListener('mousedown', onDown)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDown)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [tagMenu])
 
   return (
     <div className="flex flex-col">
@@ -226,8 +181,7 @@ export default function HomeContent() {
               transformed ancestor. */}
           <div
             id="demo"
-            ref={demoRef}
-            className="relative w-full min-w-0 scroll-mt-20"
+            className="w-full min-w-0 scroll-mt-20"
             onFocusCapture={handleDemoInteract}
             onInputCapture={handleDemoInteract}>
             <Reveal lift={false} delay={0.15} trigger="mount">
@@ -301,51 +255,6 @@ export default function HomeContent() {
                 </div>
               )}
             </Reveal>
-
-            {/* Tag picker — clicking a #tag chip reopens the tag list; picking
-                one swaps the chip in place. */}
-            {tagMenu && (
-              <div
-                data-hero-tag-menu
-                role="menu"
-                aria-label="Swap tag"
-                style={{ top: tagMenu.top, left: tagMenu.left, width: TAG_MENU_WIDTH }}
-                className="bg-popover animate-in fade-in zoom-in-95 absolute z-30 flex flex-col rounded-xl border p-1 shadow-md duration-150">
-                <div className="text-muted-foreground px-3 py-1.5 text-xs font-medium">
-                  Swap tag
-                </div>
-                {TAGS.map((tag) => {
-                  const active = tag.value === tagMenu.chip.value
-                  return (
-                    <button
-                      key={tag.value}
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={active}
-                      onClick={() => {
-                        if (!active) {
-                          tagMenu.replaceChip({
-                            trigger: '#',
-                            value: tag.value,
-                            displayText: tag.label,
-                          })
-                          track('demo_tag_swapped', { location: 'hero', tag: tag.value })
-                        }
-                        setTagMenu(null)
-                      }}
-                      className="hover:bg-accent flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-left text-sm transition-colors">
-                      <span className="font-medium text-green-700 dark:text-green-400">
-                        #{tag.label}
-                      </span>
-                      <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
-                        {tag.description}
-                      </span>
-                      {active && <Check className="size-3.5 shrink-0" />}
-                    </button>
-                  )
-                })}
-              </div>
-            )}
 
             {/* Mention toast — clicking an @mention chip "notifies" that teammate. */}
             {toast && (

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -85,6 +85,22 @@ export type AnalyticsEventMap = {
     /** Which demo, e.g. 'hero'. */
     location: string
   }
+  /** A chip (@mention, /command, #tag) in a live demo was clicked. */
+  demo_chip_clicked: {
+    /** Which demo, e.g. 'hero'. */
+    location: string
+    /** The chip's trigger character: '@' | '/' | '#'. */
+    trigger: string
+    /** The chip's resolved value, e.g. 'strategist', 'summarize', 'campaign'. */
+    value: string
+  }
+  /** A #tag chip was swapped for another tag via the demo's tag picker. */
+  demo_tag_swapped: {
+    /** Which demo, e.g. 'hero'. */
+    location: string
+    /** The tag value that was picked. */
+    tag: string
+  }
   /** A built-in agent style was selected to preview in the styles carousel. */
   style_selected: {
     /** Style id, e.g. 'chatgpt', 'claude-code'. */

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -123,13 +123,6 @@ export type AnalyticsEventMap = {
     /** The chip's resolved value, e.g. 'strategist', 'summarize', 'campaign'. */
     value: string
   }
-  /** A #tag chip was swapped for another tag via the demo's tag picker. */
-  demo_tag_swapped: {
-    /** Which demo, e.g. 'hero'. */
-    location: string
-    /** The tag value that was picked. */
-    tag: string
-  }
   /** A built-in agent style was selected to preview in the styles carousel. */
   style_selected: {
     /** Style id, e.g. 'chatgpt', 'claude-code'. */

--- a/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
@@ -1078,6 +1078,53 @@ describe('domChildIndexToSegmentIndex', () => {
     // The second chip lives at DOM child index 3 but segment index 1.
     expect(domChildIndexToSegmentIndex(editor, 3)).toBe(1)
   })
+
+  it('counts decoration elements (markdown span, URL anchor) as one segment each, matching readSegmentsFromDOM', () => {
+    // Mirrors what decorateMarkdownInEditor / decorateURLsInEditor produce:
+    // direct-child <span data-md> / <a data-url> wrapping text that
+    // readSegmentsFromDOM's "unknown element" branch turns into a text
+    // segment — they must count here too, or a chip after them resolves to
+    // the wrong segment index.
+    const mdSpan = document.createElement('span')
+    mdSpan.dataset.md = 'true'
+    mdSpan.textContent = '**bold**'
+
+    const link = document.createElement('a')
+    link.dataset.url = 'true'
+    link.textContent = 'https://example.com'
+
+    const editor = document.createElement('div')
+    editor.appendChild(document.createTextNode('Hi ')) // 0
+    editor.appendChild(mdSpan) // 1
+    editor.appendChild(document.createTextNode(' see ')) // 2
+    editor.appendChild(link) // 3
+    editor.appendChild(chip()) // 4 — DOM index 4, must map to segment index 4
+
+    expect(domChildIndexToSegmentIndex(editor, 4)).toBe(4)
+  })
+
+  it('does not count an empty decoration element (no text content)', () => {
+    const emptySpan = document.createElement('span')
+    emptySpan.dataset.md = 'true'
+
+    const editor = document.createElement('div')
+    editor.appendChild(emptySpan) // skipped, no textContent
+    editor.appendChild(chip()) // 0
+
+    expect(domChildIndexToSegmentIndex(editor, 1)).toBe(0)
+  })
+
+  it('skips a sentinel <br> (matches readSegmentsFromDOM skipping it)', () => {
+    const sentinel = document.createElement('br')
+    sentinel.dataset.sentinel = 'true'
+
+    const editor = document.createElement('div')
+    editor.appendChild(document.createTextNode('hi')) // 0
+    editor.appendChild(sentinel) // skipped
+    editor.appendChild(chip()) // 1
+
+    expect(domChildIndexToSegmentIndex(editor, 2)).toBe(1)
+  })
 })
 
 // ===========================================================================

--- a/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
@@ -17,6 +17,7 @@ import {
   getDirectChildContaining,
   chipNodeTextLength,
   chipNodeToSegment,
+  childProducesSegment,
   domChildIndexToSegmentIndex,
   normalizeEditorDOM,
   decorateURLsInEditor,
@@ -1032,6 +1033,81 @@ describe('chipNodeTextLength', () => {
 
   it('treats missing trigger and display as zero length', () => {
     expect(chipNodeTextLength(makeChip())).toBe(0)
+  })
+})
+
+// ===========================================================================
+// childProducesSegment
+// ===========================================================================
+
+describe('childProducesSegment', () => {
+  it('returns true for a non-empty text node', () => {
+    expect(childProducesSegment(document.createTextNode('hi'))).toBe(true)
+  })
+
+  it('returns false for an empty text node', () => {
+    expect(childProducesSegment(document.createTextNode(''))).toBe(false)
+  })
+
+  it('returns true for a well-formed chip element', () => {
+    const chip = document.createElement('span')
+    chip.dataset.chipTrigger = '@'
+    chip.dataset.chipValue = 'alice'
+    chip.dataset.chipDisplay = 'Alice'
+    expect(childProducesSegment(chip)).toBe(true)
+  })
+
+  it('returns false for a chip element missing a required attribute', () => {
+    // Mirrors readSegmentsFromDOM's own chipNodeToSegment(node) check, which
+    // skips a chip missing trigger/value/displayText — childProducesSegment
+    // must agree, or a DOM index maps to the wrong segment index around it.
+    const missingValue = document.createElement('span')
+    missingValue.dataset.chipTrigger = '@'
+    missingValue.dataset.chipDisplay = 'Alice'
+    expect(childProducesSegment(missingValue)).toBe(false)
+
+    const missingDisplay = document.createElement('span')
+    missingDisplay.dataset.chipTrigger = '@'
+    missingDisplay.dataset.chipValue = 'alice'
+    missingDisplay.textContent = '' // getChipDisplay falls back to textContent
+    expect(childProducesSegment(missingDisplay)).toBe(false)
+
+    const missingTrigger = document.createElement('span')
+    missingTrigger.dataset.chipValue = 'alice'
+    missingTrigger.dataset.chipDisplay = 'Alice'
+    expect(childProducesSegment(missingTrigger)).toBe(false)
+  })
+
+  it('returns true for a regular <br>', () => {
+    expect(childProducesSegment(document.createElement('br'))).toBe(true)
+  })
+
+  it('returns false for a sentinel <br>', () => {
+    const sentinel = document.createElement('br')
+    sentinel.dataset.sentinel = 'true'
+    expect(childProducesSegment(sentinel)).toBe(false)
+  })
+
+  it('returns true for a decoration element with text content', () => {
+    const mdSpan = document.createElement('span')
+    mdSpan.dataset.md = 'true'
+    mdSpan.textContent = '**bold**'
+    expect(childProducesSegment(mdSpan)).toBe(true)
+
+    const link = document.createElement('a')
+    link.dataset.url = 'true'
+    link.textContent = 'https://example.com'
+    expect(childProducesSegment(link)).toBe(true)
+  })
+
+  it('returns false for a decoration element with no text content', () => {
+    const emptySpan = document.createElement('span')
+    emptySpan.dataset.md = 'true'
+    expect(childProducesSegment(emptySpan)).toBe(false)
+  })
+
+  it('returns false for a non-element, non-text node (e.g. a comment node)', () => {
+    expect(childProducesSegment(document.createComment('note'))).toBe(false)
   })
 })
 

--- a/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
@@ -1043,6 +1043,7 @@ describe('domChildIndexToSegmentIndex', () => {
   const chip = (): HTMLElement => {
     const el = document.createElement('span')
     el.dataset.chipTrigger = '@'
+    el.dataset.chipValue = 'alice'
     el.dataset.chipDisplay = 'Alice'
     el.textContent = '@Alice'
     return el

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1845,6 +1845,23 @@ describe('usePromptArea', () => {
       })
     }
 
+    /**
+     * Simulates a real mousedown on a chip. In the browser this always fires
+     * before the `click` event handleClick receives, and — for a chip whose
+     * dropdown is already open — before TriggerPopover's own document-level
+     * outside-mousedown dismiss too (bubble order: editor root, then document).
+     */
+    function mouseDownChip(
+      result: { handleMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void },
+      chip: HTMLElement,
+    ) {
+      const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true })
+      Object.defineProperty(mouseDownEvent, 'target', { value: chip })
+      act(() => {
+        result.handleMouseDown(mouseDownEvent as unknown as React.MouseEvent<HTMLDivElement>)
+      })
+    }
+
     it('opens the dropdown with the empty-query suggestions on chip click', () => {
       const trigger = makeReopenTrigger()
       const onChipClick = vi.fn()
@@ -2101,12 +2118,21 @@ describe('usePromptArea', () => {
       document.body.removeChild(editor)
     })
 
-    it('inserts a trailing space when the replaced chip is the last segment', () => {
+    it('inserts a trailing space when the replaced chip is the last segment, and lands the caret past it', () => {
+      // Uses the initialProps+rerender form (a stable `value` reference)
+      // rather than a fresh `defaultProps()` closure per render: the hook's
+      // own value-sync effect re-runs whenever `value`'s reference changes,
+      // and dismissTrigger's state updates (called internally by
+      // selectSuggestion) trigger exactly such a re-render — with a
+      // freshly-`[]`-per-render `value`, that effect would "correct" the DOM
+      // right back to empty after the replacement, which is a test-harness
+      // artifact, not real controlled-component behavior (a real consumer's
+      // `value` only changes when `onChange` actually updates it).
       const trigger = makeReopenTrigger()
       const onChange = vi.fn()
-      const { result } = renderHook(() =>
-        usePromptArea(defaultProps({ onChange, triggers: [trigger] })),
-      )
+      const { result } = renderHook((props) => usePromptArea(props), {
+        initialProps: defaultProps({ onChange, triggers: [trigger] }),
+      })
 
       const editor = attachEditor(result.current)
       const chip = createChipNode('#', 'campaign', 'campaign')
@@ -2122,6 +2148,160 @@ describe('usePromptArea', () => {
         expect.objectContaining({ type: 'chip', trigger: '#', value: 'lead-gen' }),
         { type: 'text', text: ' ' },
       ])
+
+      // The caret must land PAST the inserted space (matching resolveChip's
+      // "+1 accounts for the trailing space" convention) — landing exactly at
+      // the chip's end would put it right back at the bare element boundary
+      // the space exists to avoid. The trailing space text node's caret
+      // offset must be at its END (1), not its start (0).
+      const sel = window.getSelection()!
+      const range = sel.getRangeAt(0)
+      expect(range.collapsed).toBe(true)
+      const spaceNode = editor.lastChild!
+      expect(spaceNode.nodeType).toBe(Node.TEXT_NODE)
+      expect(spaceNode.textContent).toBe(' ')
+      expect(range.startContainer).toBe(spaceNode)
+      expect(range.startOffset).toBe(1)
+
+      document.body.removeChild(editor)
+    })
+
+    it('does not fire onChipDelete/onChipAdd when confirming the same value+displayText but different data', () => {
+      // The reverse of the "different data" case: same value/displayText,
+      // genuinely-different data SHOULD still be treated as a change.
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const onChipAdd = vi.fn()
+      const onChipDelete = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, onChipAdd, onChipDelete, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      chip.dataset.chipData = JSON.stringify({ id: 1 })
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({
+          value: 'campaign',
+          label: 'campaign',
+          data: { id: 2 },
+        })
+      })
+
+      // Same value/displayText but different `data` — this IS a real change,
+      // so the callbacks must still fire (not swallowed by the unchanged guard).
+      expect(onChipDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign', data: { id: 1 } }),
+      )
+      expect(onChipAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign', data: { id: 2 } }),
+      )
+
+      document.body.removeChild(editor)
+    })
+
+    it('truly unchanged (same value, displayText, and data) still skips onChipDelete/onChipAdd', () => {
+      const trigger = makeReopenTrigger()
+      const onChipAdd = vi.fn()
+      const onChipDelete = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChipAdd, onChipDelete, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      chip.dataset.chipData = JSON.stringify({ id: 1 })
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({ value: 'campaign', label: 'campaign', data: { id: 1 } })
+      })
+
+      expect(onChipDelete).not.toHaveBeenCalled()
+      expect(onChipAdd).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
+    it('does not complete an in-progress replacement if disabled becomes true while the dropdown is open', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const { result, rerender } = renderHook((props) => usePromptArea(props), {
+        initialProps: defaultProps({ onChange, triggers: [trigger] }),
+      })
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      // Composer becomes disabled while the dropdown is still open (e.g. the
+      // surrounding form starts submitting).
+      act(() => {
+        rerender(defaultProps({ onChange, disabled: true, triggers: [trigger] }))
+      })
+
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      expect(onChange).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
+    it('recovers via trigger+value search only when the match is unambiguous, and safely no-ops on duplicates', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const initialValue: Segment[] = [
+        { type: 'text', text: 'a ' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' b ' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' c' },
+      ]
+      const { result, rerender } = renderHook((props) => usePromptArea(props), {
+        initialProps: defaultProps({ onChange, triggers: [trigger], value: initialValue }),
+      })
+
+      const editor = attachEditor(result.current)
+      const chipEls = [
+        createChipNode('#', 'campaign', 'campaign'),
+        createChipNode('#', 'campaign', 'campaign'),
+      ]
+      populateEditor(editor, 'a ', chipEls[0], ' b ', chipEls[1], ' c')
+
+      // Click the SECOND of the two identical chips.
+      clickChip(result.current, chipEls[1])
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      // Model shifts underneath (both duplicate chips survive, just at new
+      // positions) — the click-time segIndex no longer holds the chip.
+      const shiftedValue: Segment[] = [
+        { type: 'text', text: 'EXTRA ' },
+        { type: 'text', text: 'a ' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' b ' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' c' },
+      ]
+      act(() => {
+        rerender(defaultProps({ onChange, triggers: [trigger], value: shiftedValue }))
+      })
+
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      // With two ambiguous candidates, the fix must NOT guess — no mutation,
+      // rather than silently editing the wrong instance.
+      expect(onChange).not.toHaveBeenCalled()
 
       document.body.removeChild(editor)
     })
@@ -2196,7 +2376,7 @@ describe('usePromptArea', () => {
       document.body.removeChild(editor)
     })
 
-    it('clicking the same chip again after its dropdown was dismissed toggles it closed instead of reopening', () => {
+    it('clicking the same chip again while its dropdown is open toggles it closed instead of reopening', () => {
       const trigger = makeReopenTrigger()
       const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
 
@@ -2208,16 +2388,48 @@ describe('usePromptArea', () => {
       expect(result.current.activeTrigger).not.toBeNull()
       expect(trigger.onSearch).toHaveBeenCalledTimes(1)
 
-      // Simulate TriggerPopover's outside-mousedown dismiss, which fires
-      // before the click event reaches handleClick in the real DOM sequence.
+      // Real second-click sequence: mousedown on the same chip (still open —
+      // handleMouseDown observes this before anything dismisses it), then
+      // TriggerPopover's own outside-mousedown dismiss (fires before the
+      // click event reaches handleClick), then the click itself.
+      mouseDownChip(result.current, chip)
       act(() => {
         result.current.dismissTrigger()
       })
-
       clickChip(result.current, chip)
 
       expect(result.current.activeTrigger).toBeNull()
       expect(trigger.onSearch).toHaveBeenCalledTimes(1)
+
+      document.body.removeChild(editor)
+    })
+
+    it('dismissing via Escape (not a click on the chip) does not suppress the next reopen', () => {
+      // A dismiss NOT caused by mousedown-on-this-chip (Escape, blur, a
+      // completed selection) must never poison a later, unrelated click on
+      // the same chip — only handleMouseDown observing the chip's OWN
+      // dropdown open at mousedown time may suppress a reopen.
+      const trigger = makeReopenTrigger()
+      const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      act(() => {
+        result.current.dismissTrigger()
+      })
+      expect(result.current.activeTrigger).toBeNull()
+
+      // A later click — with no matching mousedown-while-open in between —
+      // must reopen normally.
+      clickChip(result.current, chip)
+
+      expect(result.current.activeTrigger).not.toBeNull()
+      expect(trigger.onSearch).toHaveBeenCalledTimes(2)
 
       document.body.removeChild(editor)
     })

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -2455,6 +2455,114 @@ describe('usePromptArea', () => {
 
       document.body.removeChild(editor)
     })
+
+    describe('handleMouseDown', () => {
+      it('mousedown on the currently-open chip suppresses the next click from reopening it', () => {
+        const trigger = makeReopenTrigger()
+        const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+        const editor = attachEditor(result.current)
+        const chip = createChipNode('#', 'campaign', 'campaign')
+        populateEditor(editor, 'tag ', chip)
+
+        clickChip(result.current, chip)
+        expect(result.current.activeTrigger).not.toBeNull()
+
+        mouseDownChip(result.current, chip)
+        act(() => {
+          result.current.dismissTrigger()
+        })
+        clickChip(result.current, chip)
+
+        expect(result.current.activeTrigger).toBeNull()
+
+        document.body.removeChild(editor)
+      })
+
+      it('mousedown on a chip whose dropdown is NOT open does not suppress its own click', () => {
+        const trigger = makeReopenTrigger()
+        const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+        const editor = attachEditor(result.current)
+        const chip = createChipNode('#', 'campaign', 'campaign')
+        populateEditor(editor, 'tag ', chip)
+
+        // No prior click opened this chip's dropdown — mousedown should find
+        // openChipNode unset and clear any suppression, not set one.
+        mouseDownChip(result.current, chip)
+        clickChip(result.current, chip)
+
+        expect(result.current.activeTrigger).not.toBeNull()
+
+        document.body.removeChild(editor)
+      })
+
+      it('mousedown elsewhere (not on a chip) clears any pending suppression', () => {
+        const trigger = makeReopenTrigger()
+        const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+        const editor = attachEditor(result.current)
+        const chip = createChipNode('#', 'campaign', 'campaign')
+        populateEditor(editor, 'tag ', chip)
+
+        clickChip(result.current, chip)
+        expect(result.current.activeTrigger).not.toBeNull()
+
+        // Mousedown on plain text, not the chip — this must NOT arm
+        // suppression for the chip.
+        const textMouseDown = new MouseEvent('mousedown', { bubbles: true })
+        Object.defineProperty(textMouseDown, 'target', { value: editor.firstChild })
+        act(() => {
+          result.current.handleMouseDown(
+            textMouseDown as unknown as React.MouseEvent<HTMLDivElement>,
+          )
+        })
+        act(() => {
+          result.current.dismissTrigger()
+        })
+
+        // A later click on the chip must reopen normally — it was never armed.
+        clickChip(result.current, chip)
+        expect(result.current.activeTrigger).not.toBeNull()
+
+        document.body.removeChild(editor)
+      })
+
+      it('does not crash when the editor ref is unattached', () => {
+        const trigger = makeReopenTrigger()
+        const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+        const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true })
+        Object.defineProperty(mouseDownEvent, 'target', { value: document.createElement('span') })
+
+        expect(() => {
+          act(() => {
+            result.current.handleMouseDown(
+              mouseDownEvent as unknown as React.MouseEvent<HTMLDivElement>,
+            )
+          })
+        }).not.toThrow()
+      })
+
+      it('does not crash when the event target is not a Node', () => {
+        const trigger = makeReopenTrigger()
+        const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+        const editor = attachEditor(result.current)
+        const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true })
+        Object.defineProperty(mouseDownEvent, 'target', { value: null })
+
+        expect(() => {
+          act(() => {
+            result.current.handleMouseDown(
+              mouseDownEvent as unknown as React.MouseEvent<HTMLDivElement>,
+            )
+          })
+        }).not.toThrow()
+
+        document.body.removeChild(editor)
+      })
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1817,6 +1817,138 @@ describe('usePromptArea', () => {
   })
 
   // -------------------------------------------------------------------------
+  // reopenOnChipClick — chip click reopens the dropdown, selection replaces
+  // -------------------------------------------------------------------------
+
+  describe('reopenOnChipClick', () => {
+    function makeReopenTrigger(): TriggerConfig {
+      return {
+        char: '#',
+        position: 'any',
+        mode: 'dropdown',
+        reopenOnChipClick: true,
+        onSearch: vi.fn(() => [
+          { value: 'campaign', label: 'campaign' },
+          { value: 'lead-gen', label: 'lead-gen' },
+        ]),
+      }
+    }
+
+    function clickChip(
+      result: { handleClick: (e: React.MouseEvent<HTMLDivElement>) => void },
+      chip: HTMLElement,
+    ) {
+      const clickEvent = new MouseEvent('click', { bubbles: true })
+      Object.defineProperty(clickEvent, 'target', { value: chip })
+      act(() => {
+        result.handleClick(clickEvent as unknown as React.MouseEvent<HTMLDivElement>)
+      })
+    }
+
+    it('opens the dropdown with the empty-query suggestions on chip click', () => {
+      const trigger = makeReopenTrigger()
+      const onChipClick = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChipClick, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+
+      expect(result.current.activeTrigger?.config).toBe(trigger)
+      expect(trigger.onSearch).toHaveBeenCalledWith('', expect.anything())
+      // onChipClick still fires for app-level side effects
+      expect(onChipClick).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign' }),
+      )
+
+      document.body.removeChild(editor)
+    })
+
+    it('does not open the dropdown when reopenOnChipClick is not set', () => {
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChipClick: vi.fn(), triggers: [hashTrigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+
+      expect(result.current.activeTrigger).toBeNull()
+
+      document.body.removeChild(editor)
+    })
+
+    it('replaces the clicked chip in place when a suggestion is selected', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const onChipAdd = vi.fn()
+      const onChipDelete = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, onChipAdd, onChipDelete, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'tag ' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'lead-gen' }),
+        { type: 'text', text: ' now' },
+      ])
+      expect(onChipDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign' }),
+      )
+      expect(onChipAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'lead-gen' }),
+      )
+      expect(result.current.activeTrigger).toBeNull()
+
+      document.body.removeChild(editor)
+    })
+
+    it('dismissTrigger closes the chip dropdown without replacing anything', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      act(() => {
+        result.current.dismissTrigger()
+      })
+      expect(result.current.activeTrigger).toBeNull()
+
+      // A later selection must not fall back to editing the dismissed chip
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+      expect(onChange).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+  })
+
+  // -------------------------------------------------------------------------
   // Dropdown navigation with active trigger & suggestions
   // -------------------------------------------------------------------------
 

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1946,6 +1946,303 @@ describe('usePromptArea', () => {
 
       document.body.removeChild(editor)
     })
+
+    function makeKeyEvent(
+      key: string,
+      opts: Partial<KeyboardEventInit> = {},
+    ): React.KeyboardEvent<HTMLDivElement> {
+      const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        ...opts,
+      }) as unknown as React.KeyboardEvent<HTMLDivElement>
+      Object.defineProperty(event, 'nativeEvent', { value: { isComposing: false } })
+      Object.defineProperty(event, 'preventDefault', { value: vi.fn() })
+      return event
+    }
+
+    it('does not open the dropdown when disabled', () => {
+      const trigger = makeReopenTrigger()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ disabled: true, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+
+      expect(result.current.activeTrigger).toBeNull()
+      expect(trigger.onSearch).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
+    it('replaces the correct segment when a decoration element (markdown/URL) precedes the chip', () => {
+      // Mirrors what decorateMarkdownInEditor produces at runtime: a
+      // direct-child <span data-md> wrapping text, which readSegmentsFromDOM
+      // counts as one text segment via its "unknown element" branch.
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const onChipDelete = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, onChipDelete, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const mdSpan = document.createElement('span')
+      mdSpan.dataset.md = 'true'
+      mdSpan.textContent = '**bold**'
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'Hi ', mdSpan, ' ', chip, ' now')
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'Hi ' },
+        { type: 'text', text: '**bold**' },
+        { type: 'text', text: ' ' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'lead-gen' }),
+        { type: 'text', text: ' now' },
+      ])
+      expect(onChipDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign' }),
+      )
+
+      document.body.removeChild(editor)
+    })
+
+    it('recovers via a trigger+value search when the chip shifts to a different segment index before the selection lands', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const onChipDelete = vi.fn()
+      const initialValue: Segment[] = [
+        { type: 'text', text: 'x' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' end' },
+      ]
+      const { result, rerender } = renderHook((props) => usePromptArea(props), {
+        initialProps: defaultProps({
+          onChange,
+          onChipDelete,
+          triggers: [trigger],
+          value: initialValue,
+        }),
+      })
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'x', chip, ' end')
+
+      clickChip(result.current, chip)
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      // External value-prop update lands while the dropdown is open (e.g. a
+      // parent normalizing content elsewhere) — the chip survives but at a
+      // new index, and renderSegmentsToDOM rebuilds all children, detaching
+      // the clicked chip's DOM node.
+      const shiftedValue: Segment[] = [
+        { type: 'text', text: 'EXTRA ' },
+        { type: 'text', text: 'x' },
+        { type: 'chip', trigger: '#', value: 'campaign', displayText: 'campaign' },
+        { type: 'text', text: ' end' },
+      ]
+      act(() => {
+        rerender(defaultProps({ onChange, onChipDelete, triggers: [trigger], value: shiftedValue }))
+      })
+
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'EXTRA ' },
+        { type: 'text', text: 'x' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'lead-gen' }),
+        { type: 'text', text: ' end' },
+      ])
+      expect(onChipDelete).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger: '#', value: 'campaign' }),
+      )
+
+      document.body.removeChild(editor)
+    })
+
+    it('does not fire onChipDelete/onChipAdd when confirming the unchanged preselected value', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const onChipAdd = vi.fn()
+      const onChipDelete = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, onChipAdd, onChipDelete, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({ value: 'campaign', label: 'campaign' })
+      })
+
+      expect(onChipDelete).not.toHaveBeenCalled()
+      expect(onChipAdd).not.toHaveBeenCalled()
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'tag ' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'campaign' }),
+        { type: 'text', text: ' now' },
+      ])
+
+      document.body.removeChild(editor)
+    })
+
+    it('inserts a trailing space when the replaced chip is the last segment', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip) // chip is the LAST child — no trailing text
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'tag ' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'lead-gen' }),
+        { type: 'text', text: ' ' },
+      ])
+
+      document.body.removeChild(editor)
+    })
+
+    it('replacement is recorded on the undo stack', () => {
+      const trigger = makeReopenTrigger()
+      const onChange = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip, ' now')
+
+      clickChip(result.current, chip)
+      act(() => {
+        result.current.selectSuggestion({ value: 'lead-gen', label: 'lead-gen' })
+      })
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('z', { ctrlKey: true }))
+      })
+
+      // Ctrl+Z should restore the pre-replacement segments (the original
+      // 'campaign' chip), not leave the stack untouched.
+      expect(onChange).toHaveBeenCalledWith([
+        { type: 'text', text: 'tag ' },
+        expect.objectContaining({ type: 'chip', trigger: '#', value: 'campaign' }),
+        { type: 'text', text: ' now' },
+      ])
+
+      document.body.removeChild(editor)
+    })
+
+    it('Enter does not submit and Escape dismisses (not onEscape) while the popover shows an empty-state message', () => {
+      const trigger: TriggerConfig = {
+        char: '#',
+        position: 'any',
+        mode: 'dropdown',
+        reopenOnChipClick: true,
+        emptyMessage: 'No matches',
+        onSearch: vi.fn(() => []),
+      }
+      const onSubmit = vi.fn()
+      const onEscape = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onSubmit, onEscape, triggers: [trigger] })),
+      )
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+      expect(result.current.suggestions).toEqual([])
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Enter'))
+      })
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(result.current.activeTrigger).not.toBeNull()
+
+      act(() => {
+        result.current.handleKeyDown(makeKeyEvent('Escape'))
+      })
+      expect(onEscape).not.toHaveBeenCalled()
+      expect(result.current.activeTrigger).toBeNull()
+
+      document.body.removeChild(editor)
+    })
+
+    it('clicking the same chip again after its dropdown was dismissed toggles it closed instead of reopening', () => {
+      const trigger = makeReopenTrigger()
+      const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+      const editor = attachEditor(result.current)
+      const chip = createChipNode('#', 'campaign', 'campaign')
+      populateEditor(editor, 'tag ', chip)
+
+      clickChip(result.current, chip)
+      expect(result.current.activeTrigger).not.toBeNull()
+      expect(trigger.onSearch).toHaveBeenCalledTimes(1)
+
+      // Simulate TriggerPopover's outside-mousedown dismiss, which fires
+      // before the click event reaches handleClick in the real DOM sequence.
+      act(() => {
+        result.current.dismissTrigger()
+      })
+
+      clickChip(result.current, chip)
+
+      expect(result.current.activeTrigger).toBeNull()
+      expect(trigger.onSearch).toHaveBeenCalledTimes(1)
+
+      document.body.removeChild(editor)
+    })
+
+    it('clicking a different chip after a dismiss still opens its own dropdown normally', () => {
+      const trigger = makeReopenTrigger()
+      const { result } = renderHook(() => usePromptArea(defaultProps({ triggers: [trigger] })))
+
+      const editor = attachEditor(result.current)
+      const chipA = createChipNode('#', 'campaign', 'campaign')
+      const chipB = createChipNode('#', 'lead-gen', 'lead-gen')
+      populateEditor(editor, 'tag ', chipA, ' and ', chipB)
+
+      clickChip(result.current, chipA)
+      act(() => {
+        result.current.dismissTrigger()
+      })
+
+      clickChip(result.current, chipB)
+
+      expect(result.current.activeTrigger).not.toBeNull()
+      expect(trigger.onSearch).toHaveBeenCalledTimes(2)
+
+      document.body.removeChild(editor)
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/packages/prompt-area/src/prompt-area/dom-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/dom-helpers.ts
@@ -193,12 +193,14 @@ export function indexOfChildNode(parent: HTMLElement, child: Node): number {
  * produces — decoration elements (the URL `<a>` from `decorateURLsInEditor`,
  * the markdown `<span data-md>` from `decorateMarkdownInEditor`) fall through
  * to the reader's "unknown element" branch and DO produce a text segment, so
- * they must count here too, not just chips/text/`<br>`.
+ * they must count here too, not just chips/text/`<br>`. A chip element only
+ * counts if `chipNodeToSegment` would actually accept it — the reader skips a
+ * chip missing a required attribute (trigger/value/display), so this must too.
  */
 export function childProducesSegment(child: Node): boolean {
   if (child.nodeType === Node.TEXT_NODE) return (child.textContent ?? '') !== ''
   if (isBRElement(child)) return !child.dataset.sentinel
-  if (isChipElement(child)) return true
+  if (isChipElement(child)) return chipNodeToSegment(child) !== null
   if (isHTMLElement(child)) return (child.textContent ?? '') !== ''
   return false
 }

--- a/packages/prompt-area/src/prompt-area/dom-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/dom-helpers.ts
@@ -186,28 +186,35 @@ export function indexOfChildNode(parent: HTMLElement, child: Node): number {
 }
 
 /**
+ * Whether a direct editor child node produces a segment when read by
+ * `readSegmentsFromDOM` in use-prompt-area.ts. This is the single predicate
+ * shared with `domChildIndexToSegmentIndex` below, so a DOM child index can
+ * never map to a different segment index than the one the reader actually
+ * produces — decoration elements (the URL `<a>` from `decorateURLsInEditor`,
+ * the markdown `<span data-md>` from `decorateMarkdownInEditor`) fall through
+ * to the reader's "unknown element" branch and DO produce a text segment, so
+ * they must count here too, not just chips/text/`<br>`.
+ */
+export function childProducesSegment(child: Node): boolean {
+  if (child.nodeType === Node.TEXT_NODE) return (child.textContent ?? '') !== ''
+  if (isBRElement(child)) return !child.dataset.sentinel
+  if (isChipElement(child)) return true
+  if (isHTMLElement(child)) return (child.textContent ?? '') !== ''
+  return false
+}
+
+/**
  * Maps the index of a direct child node within the editor to the index of the
- * corresponding segment in the model array.
+ * corresponding segment in the model array, by counting `childProducesSegment`
+ * matches up to (but not including) `childIndex`.
  *
- * The model (`readSegmentsFromDOM`) skips empty text nodes and the trailing
- * sentinel handling, so a DOM child index and a segment index are not 1:1.
- * This counts only the children that produce a segment — non-empty text nodes,
- * chip elements, and `<br>` line breaks — up to (but not including) `childIndex`.
- *
- * Keeping this in one place ensures chip-removal and chip-revert agree on the
- * exact same mapping rules as the reader.
+ * Keeping this in one place ensures chip-removal, chip-revert, and chip
+ * in-place replacement all agree on the exact same mapping rules as the reader.
  */
 export function domChildIndexToSegmentIndex(editor: HTMLElement, childIndex: number): number {
   let segIdx = 0
   for (let i = 0; i < childIndex; i++) {
-    const child = editor.childNodes[i]
-    if (child.nodeType === Node.TEXT_NODE && (child.textContent ?? '') !== '') {
-      segIdx++
-    } else if (isChipElement(child)) {
-      segIdx++
-    } else if (isBRElement(child)) {
-      segIdx++
-    }
+    if (childProducesSegment(editor.childNodes[i])) segIdx++
   }
   return segIdx
 }

--- a/packages/prompt-area/src/prompt-area/prompt-area.tsx
+++ b/packages/prompt-area/src/prompt-area/prompt-area.tsx
@@ -96,6 +96,7 @@ export function PromptArea({
     value,
     onChange,
     triggers,
+    disabled,
     onSubmit,
     onEscape,
     onChipClick,

--- a/packages/prompt-area/src/prompt-area/prompt-area.tsx
+++ b/packages/prompt-area/src/prompt-area/prompt-area.tsx
@@ -87,6 +87,7 @@ export function PromptArea({
     handleInput,
     handleKeyDown,
     handleClick,
+    handleMouseDown,
     selectSuggestion,
     dismissTrigger,
     handle,
@@ -308,6 +309,7 @@ export function PromptArea({
           onFocus={handleFocus}
           onInput={autoGrow ? handleInputWithGrow : handleInput}
           onKeyDown={handleKeyDownCombined}
+          onMouseDown={handleMouseDown}
           onClick={handleClick}
           onPaste={eventHandlers.onPaste}
           onCopy={eventHandlers.onCopy}

--- a/packages/prompt-area/src/prompt-area/types.ts
+++ b/packages/prompt-area/src/prompt-area/types.ts
@@ -117,6 +117,14 @@ export type TriggerConfig = {
    */
   resolveOnSpace?: boolean
   /**
+   * For 'dropdown' mode: when true, clicking a chip created by this trigger
+   * reopens the suggestion dropdown anchored to the chip, and selecting a
+   * suggestion replaces the chip in place. The empty-query suggestions are
+   * shown with the chip's current value preselected. `onChipClick` still
+   * fires, so side effects (analytics, etc.) keep working.
+   */
+  reopenOnChipClick?: boolean
+  /**
    * Visual style for chips created by this trigger.
    * - 'pill' (default): Button-like pill with background, padding, border-radius
    * - 'inline': Bold inline text without pill styling

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -143,6 +143,11 @@ export function usePromptArea({
   const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0)
   const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null)
 
+  // Chip whose dropdown was reopened via `reopenOnChipClick`. While set, the
+  // active dropdown edits this chip in place instead of resolving typed text.
+  // Cleared on dismiss and by any fresh trigger detection (typing).
+  const editingChip = useRef<{ node: HTMLElement; chip: ChipSegment } | null>(null)
+
   const {
     suggestions,
     suggestionsLoading,
@@ -316,6 +321,10 @@ export function usePromptArea({
 
     const detected = detectActiveTrigger(plainText, cursorPos, triggers)
 
+    // Typing supersedes a chip-click dropdown: whichever branch we take next,
+    // the popover no longer edits the clicked chip.
+    editingChip.current = null
+
     if (detected) {
       setActiveTrigger(detected)
       setSelectedSuggestionIndex(0)
@@ -357,6 +366,7 @@ export function usePromptArea({
   // -----------------------------------------------------------------------
 
   const dismissTrigger = useCallback(() => {
+    editingChip.current = null
     setActiveTrigger(null)
     setSelectedSuggestionIndex(0)
     resetSearch()
@@ -560,15 +570,26 @@ export function usePromptArea({
           node.appendChild(ripple)
           ripple.addEventListener('animationend', () => ripple.remove())
 
-          if (!onChipClick) return
           const chip = chipNodeToSegment(node)
-          if (chip) onChipClick(chip)
+          if (chip) {
+            // Native chip-click dropdown: reopen this trigger's suggestions
+            // anchored to the chip so the selection can replace it in place.
+            const config = triggers.find((t) => t.char === chip.trigger)
+            if (config?.reopenOnChipClick && config.mode === 'dropdown' && config.onSearch) {
+              editingChip.current = { node, chip }
+              setActiveTrigger({ config, startOffset: 0, query: '' })
+              setSelectedSuggestionIndex(0)
+              setTriggerRect(rect)
+              runSearch('', config)
+            }
+            onChipClick?.(chip)
+          }
           return
         }
         node = node.parentNode
       }
     },
-    [onChipClick, onLinkClick],
+    [onChipClick, onLinkClick, triggers, runSearch],
   )
 
   // -----------------------------------------------------------------------
@@ -788,6 +809,45 @@ export function usePromptArea({
         displayText: displayText || suggestion.label,
         data: suggestion.data,
       }
+
+      // Chip-click dropdown (`reopenOnChipClick`): replace the clicked chip in
+      // place instead of resolving typed trigger text at the caret.
+      const editing = editingChip.current
+      if (editing) {
+        const editor = editorRef.current
+        const chipIdx = editor ? indexOfChildNode(editor, editing.node) : -1
+        if (editor && chipIdx !== -1) {
+          const segIdx = domChildIndexToSegmentIndex(editor, chipIdx)
+          const oldChip = segments[segIdx]
+          const newChip: ChipSegment = {
+            type: 'chip',
+            trigger: activeTrigger.config.char,
+            ...chipData,
+          }
+          const newSegments = segments.map((seg, i) => (i === segIdx ? newChip : seg))
+          onChange(newSegments)
+          renderSegmentsToDOM(newSegments)
+
+          if (oldChip?.type === 'chip') onChipDelete?.(oldChip)
+          onChipAdd?.(newChip)
+
+          // Place the caret right after the replaced chip
+          let caretOffset = 0
+          for (let i = 0; i <= segIdx; i++) {
+            const seg = newSegments[i]
+            caretOffset +=
+              seg.type === 'text' ? seg.text.length : seg.trigger.length + seg.displayText.length
+          }
+          setCursorAtOffset(editor, caretOffset)
+        }
+
+        dismissTrigger()
+        setTimeout(() => {
+          editorRef.current?.focus()
+        }, 0)
+        return
+      }
+
       const result = resolveChip(segments, activeTrigger, chipData)
 
       onChange(result.segments)
@@ -812,10 +872,27 @@ export function usePromptArea({
         editorRef.current?.focus()
       }, 0)
     },
-    [activeTrigger, readSegmentsFromDOM, onChange, renderSegmentsToDOM, dismissTrigger, onChipAdd],
+    [
+      activeTrigger,
+      readSegmentsFromDOM,
+      onChange,
+      renderSegmentsToDOM,
+      dismissTrigger,
+      onChipAdd,
+      onChipDelete,
+    ],
   )
 
   const selectSuggestion = selectSuggestionInternal
+
+  // Chip-click dropdown: once the empty-query suggestions arrive, preselect
+  // the chip's current value so the list opens "on" the existing choice.
+  useEffect(() => {
+    const editing = editingChip.current
+    if (!editing || !activeTrigger?.config.reopenOnChipClick) return
+    const idx = suggestions.findIndex((s) => s.value === editing.chip.value)
+    if (idx > 0) setSelectedSuggestionIndex(idx)
+  }, [suggestions, activeTrigger])
 
   // -----------------------------------------------------------------------
   // Handle key events

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -68,6 +68,7 @@ type UsePromptAreaOptions = {
   value: Segment[]
   onChange: (segments: Segment[]) => void
   triggers?: TriggerConfig[]
+  disabled?: boolean
   onSubmit?: (segments: Segment[]) => void
   onEscape?: () => void
   onChipClick?: (chip: ChipSegment) => void
@@ -122,6 +123,7 @@ export function usePromptArea({
   value,
   onChange,
   triggers = [],
+  disabled = false,
   onSubmit,
   onEscape,
   onChipClick,
@@ -146,7 +148,20 @@ export function usePromptArea({
   // Chip whose dropdown was reopened via `reopenOnChipClick`. While set, the
   // active dropdown edits this chip in place instead of resolving typed text.
   // Cleared on dismiss and by any fresh trigger detection (typing).
-  const editingChip = useRef<{ node: HTMLElement; chip: ChipSegment } | null>(null)
+  //
+  // `segIndex` is the segment index at CLICK time (computed from the live DOM,
+  // so it's always accurate then) — deliberately not the DOM node itself,
+  // which can detach if `renderSegmentsToDOM` re-renders while the dropdown is
+  // open (external value update, undo/redo). At selection time we re-verify
+  // this index still holds the same chip and fall back to a trigger+value
+  // search if the model shifted underneath, instead of silently no-op'ing.
+  const editingChip = useRef<{ chip: ChipSegment; segIndex: number } | null>(null)
+
+  // Set by `dismissTrigger` to the chip whose dropdown it just closed; read
+  // and cleared by `handleClick` to distinguish "reopen" from "toggle closed"
+  // when the same chip is clicked again. See `dismissTrigger` for why this
+  // ordering is reliable.
+  const justDismissedChip = useRef<{ trigger: string; value: string } | null>(null)
 
   const {
     suggestions,
@@ -366,6 +381,14 @@ export function usePromptArea({
   // -----------------------------------------------------------------------
 
   const dismissTrigger = useCallback(() => {
+    // Remember which chip (if any) this dismiss closed, so a click landing on
+    // that same chip — which is what triggers the dismiss in the first place,
+    // since TriggerPopover's outside-mousedown dismiss fires before the click
+    // event reaches handleClick — can tell "reopen" apart from "toggle closed"
+    // instead of always reopening. Consumed and cleared by the next chip click.
+    justDismissedChip.current = editingChip.current
+      ? { trigger: editingChip.current.chip.trigger, value: editingChip.current.chip.value }
+      : null
     editingChip.current = null
     setActiveTrigger(null)
     setSelectedSuggestionIndex(0)
@@ -574,9 +597,28 @@ export function usePromptArea({
           if (chip) {
             // Native chip-click dropdown: reopen this trigger's suggestions
             // anchored to the chip so the selection can replace it in place.
+            // Gated on `!disabled` — a disabled composer must not accept edits
+            // through any path, including this one.
             const config = triggers.find((t) => t.char === chip.trigger)
-            if (config?.reopenOnChipClick && config.mode === 'dropdown' && config.onSearch) {
-              editingChip.current = { node, chip }
+            // A click on THIS chip while its own dropdown was open just closed
+            // it (TriggerPopover's outside-mousedown dismiss runs before this
+            // click handler) — treat that as a toggle-close, not a reopen.
+            const wasOpenForThisChip =
+              justDismissedChip.current?.trigger === chip.trigger &&
+              justDismissedChip.current?.value === chip.value
+            justDismissedChip.current = null
+            if (
+              !disabled &&
+              !wasOpenForThisChip &&
+              config?.reopenOnChipClick &&
+              config.mode === 'dropdown' &&
+              config.onSearch
+            ) {
+              const childIdx = indexOfChildNode(editor, node)
+              editingChip.current = {
+                chip,
+                segIndex: domChildIndexToSegmentIndex(editor, childIdx),
+              }
               setActiveTrigger({ config, startOffset: 0, query: '' })
               setSelectedSuggestionIndex(0)
               setTriggerRect(rect)
@@ -589,7 +631,7 @@ export function usePromptArea({
         node = node.parentNode
       }
     },
-    [onChipClick, onLinkClick, triggers, runSearch],
+    [onChipClick, onLinkClick, triggers, runSearch, disabled],
   )
 
   // -----------------------------------------------------------------------
@@ -815,30 +857,68 @@ export function usePromptArea({
       const editing = editingChip.current
       if (editing) {
         const editor = editorRef.current
-        const chipIdx = editor ? indexOfChildNode(editor, editing.node) : -1
-        if (editor && chipIdx !== -1) {
-          const segIdx = domChildIndexToSegmentIndex(editor, chipIdx)
-          const oldChip = segments[segIdx]
-          const newChip: ChipSegment = {
-            type: 'chip',
-            trigger: activeTrigger.config.char,
-            ...chipData,
-          }
-          const newSegments = segments.map((seg, i) => (i === segIdx ? newChip : seg))
-          onChange(newSegments)
-          renderSegmentsToDOM(newSegments)
+        if (editor) {
+          // Re-verify the click-time index still holds the same chip — the
+          // model may have shifted (external value update, undo/redo) while
+          // the dropdown was open. Fall back to a trigger+value search so a
+          // shifted-but-present chip is still found instead of silently
+          // dropping the user's selection.
+          const atIndex = segments[editing.segIndex]
+          const stillThere =
+            atIndex?.type === 'chip' &&
+            atIndex.trigger === editing.chip.trigger &&
+            atIndex.value === editing.chip.value
+          const segIdx = stillThere
+            ? editing.segIndex
+            : segments.findIndex(
+                (seg) =>
+                  seg.type === 'chip' &&
+                  seg.trigger === editing.chip.trigger &&
+                  seg.value === editing.chip.value,
+              )
+          const oldChip = segIdx !== -1 ? segments[segIdx] : undefined
 
-          if (oldChip?.type === 'chip') onChipDelete?.(oldChip)
-          onChipAdd?.(newChip)
+          if (oldChip?.type === 'chip') {
+            const newChip: ChipSegment = {
+              type: 'chip',
+              trigger: activeTrigger.config.char,
+              ...chipData,
+            }
+            let newSegments = segments.map((seg, i) => (i === segIdx ? newChip : seg))
 
-          // Place the caret right after the replaced chip
-          let caretOffset = 0
-          for (let i = 0; i <= segIdx; i++) {
-            const seg = newSegments[i]
-            caretOffset +=
-              seg.type === 'text' ? seg.text.length : seg.trigger.length + seg.displayText.length
+            // Guarantee a real landing spot after the replaced chip, mirroring
+            // resolveChip's trailing-space convention (prompt-area-engine.ts):
+            // if the new chip is now the last segment (or directly followed by
+            // another chip), the caret would land at a bare element boundary
+            // with no text node, which some engines fail to render/snap a
+            // visible caret at.
+            const nextSeg = newSegments[segIdx + 1]
+            if (!nextSeg || nextSeg.type !== 'text' || nextSeg.text.length === 0) {
+              newSegments = [
+                ...newSegments.slice(0, segIdx + 1),
+                { type: 'text', text: ' ' },
+                ...newSegments.slice(segIdx + 1),
+              ]
+            }
+
+            events.pushUndo(segments)
+            onChange(newSegments)
+            renderSegmentsToDOM(newSegments)
+
+            // Same value + display text: treat as a no-op confirmation rather
+            // than a destructive delete+add — onChipDelete is documented as
+            // firing on backspace/forward-delete, not on re-confirming the
+            // already-selected suggestion.
+            const unchanged =
+              oldChip.value === newChip.value && oldChip.displayText === newChip.displayText
+            if (!unchanged) {
+              onChipDelete?.(oldChip)
+              onChipAdd?.(newChip)
+            }
+
+            const caretOffset = segmentsToPlainText(newSegments.slice(0, segIdx + 1)).length
+            setCursorAtOffset(editor, caretOffset)
           }
-          setCursorAtOffset(editor, caretOffset)
         }
 
         dismissTrigger()
@@ -880,6 +960,7 @@ export function usePromptArea({
       dismissTrigger,
       onChipAdd,
       onChipDelete,
+      events,
     ],
   )
 
@@ -999,16 +1080,33 @@ export function usePromptArea({
         }
       }
 
-      // 2. Trigger dropdown navigation
-      if (activeTrigger && activeTrigger.config.mode === 'dropdown' && suggestions.length > 0) {
+      // 2. Trigger dropdown navigation. Gated on the dropdown actually being
+      // ON SCREEN, which matches TriggerPopover's own render condition
+      // (non-empty suggestions, OR loading/error/emptyMessage) rather than
+      // just `suggestions.length > 0` — otherwise a popover left open in a
+      // loading/empty state (e.g. right after a chip-click reopen, before its
+      // empty-query search resolves) lets Enter fall through to onSubmit and
+      // Escape fall through to onEscape while still visibly on screen.
+      const dropdownVisible =
+        activeTrigger &&
+        activeTrigger.config.mode === 'dropdown' &&
+        (suggestions.length > 0 ||
+          suggestionsLoading ||
+          suggestionsError !== null ||
+          !!activeTrigger.config.emptyMessage)
+      if (dropdownVisible) {
         if (e.key === 'ArrowDown') {
           e.preventDefault()
-          setSelectedSuggestionIndex((prev) => Math.min(prev + 1, suggestions.length - 1))
+          if (suggestions.length > 0) {
+            setSelectedSuggestionIndex((prev) => Math.min(prev + 1, suggestions.length - 1))
+          }
           return
         }
         if (e.key === 'ArrowUp') {
           e.preventDefault()
-          setSelectedSuggestionIndex((prev) => Math.max(prev - 1, 0))
+          if (suggestions.length > 0) {
+            setSelectedSuggestionIndex((prev) => Math.max(prev - 1, 0))
+          }
           return
         }
         if (e.key === 'Enter' || e.key === 'Tab') {
@@ -1150,6 +1248,8 @@ export function usePromptArea({
     [
       activeTrigger,
       suggestions,
+      suggestionsLoading,
+      suggestionsError,
       selectedSuggestionIndex,
       onSubmit,
       submitOnEnter,

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -96,6 +96,7 @@ type UsePromptAreaReturn = {
   handleInput: () => void
   handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void
   handleClick: (e: React.MouseEvent<HTMLDivElement>) => void
+  handleMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void
   selectSuggestion: (suggestion: TriggerSuggestion) => void
   dismissTrigger: () => void
   handle: PromptAreaHandle
@@ -157,11 +158,26 @@ export function usePromptArea({
   // search if the model shifted underneath, instead of silently no-op'ing.
   const editingChip = useRef<{ chip: ChipSegment; segIndex: number } | null>(null)
 
-  // Set by `dismissTrigger` to the chip whose dropdown it just closed; read
-  // and cleared by `handleClick` to distinguish "reopen" from "toggle closed"
-  // when the same chip is clicked again. See `dismissTrigger` for why this
-  // ordering is reliable.
-  const justDismissedChip = useRef<{ trigger: string; value: string } | null>(null)
+  // The DOM node of the chip currently being edited via `reopenOnChipClick`,
+  // kept in lockstep with `editingChip`/`activeTrigger` (set when opened,
+  // cleared by `dismissTrigger`). Used only to answer "is THIS exact chip
+  // element the one whose dropdown is open right now" by reference identity —
+  // never by trigger+value, which can't distinguish two chips that happen to
+  // share the same value.
+  const openChipNode = useRef<HTMLElement | null>(null)
+
+  // Set by `handleMouseDown` to the chip node a mousedown landed on, but only
+  // when that node === `openChipNode.current` at that instant; read and
+  // cleared by the following `handleClick` to distinguish "reopen" from
+  // "toggle closed" for that one click. A real `onMouseDown` (bubble-phase,
+  // attached to the editor root) is used instead of piggybacking on
+  // `dismissTrigger` because DOM bubbling reaches the editor root before it
+  // reaches `document` (where TriggerPopover's outside-click dismiss listens),
+  // so this always observes `openChipNode` before that dismiss clears it —
+  // and unlike a `dismissTrigger`-driven flag, it is scoped to mousedowns on
+  // this exact node, so Escape/blur/an unrelated dismiss can never poison a
+  // later, unrelated click on the same chip.
+  const suppressReopenChip = useRef<HTMLElement | null>(null)
 
   const {
     suggestions,
@@ -339,6 +355,7 @@ export function usePromptArea({
     // Typing supersedes a chip-click dropdown: whichever branch we take next,
     // the popover no longer edits the clicked chip.
     editingChip.current = null
+    openChipNode.current = null
 
     if (detected) {
       setActiveTrigger(detected)
@@ -381,15 +398,8 @@ export function usePromptArea({
   // -----------------------------------------------------------------------
 
   const dismissTrigger = useCallback(() => {
-    // Remember which chip (if any) this dismiss closed, so a click landing on
-    // that same chip — which is what triggers the dismiss in the first place,
-    // since TriggerPopover's outside-mousedown dismiss fires before the click
-    // event reaches handleClick — can tell "reopen" apart from "toggle closed"
-    // instead of always reopening. Consumed and cleared by the next chip click.
-    justDismissedChip.current = editingChip.current
-      ? { trigger: editingChip.current.chip.trigger, value: editingChip.current.chip.value }
-      : null
     editingChip.current = null
+    openChipNode.current = null
     setActiveTrigger(null)
     setSelectedSuggestionIndex(0)
     resetSearch()
@@ -600,13 +610,11 @@ export function usePromptArea({
             // Gated on `!disabled` — a disabled composer must not accept edits
             // through any path, including this one.
             const config = triggers.find((t) => t.char === chip.trigger)
-            // A click on THIS chip while its own dropdown was open just closed
-            // it (TriggerPopover's outside-mousedown dismiss runs before this
-            // click handler) — treat that as a toggle-close, not a reopen.
-            const wasOpenForThisChip =
-              justDismissedChip.current?.trigger === chip.trigger &&
-              justDismissedChip.current?.value === chip.value
-            justDismissedChip.current = null
+            // A click on THIS exact chip element while its own dropdown was
+            // open just closed it (see `suppressReopenChip` and
+            // `handleMouseDown`) — treat that as a toggle-close, not a reopen.
+            const wasOpenForThisChip = suppressReopenChip.current === node
+            suppressReopenChip.current = null
             if (
               !disabled &&
               !wasOpenForThisChip &&
@@ -619,6 +627,7 @@ export function usePromptArea({
                 chip,
                 segIndex: domChildIndexToSegmentIndex(editor, childIdx),
               }
+              openChipNode.current = node
               setActiveTrigger({ config, startOffset: 0, query: '' })
               setSelectedSuggestionIndex(0)
               setTriggerRect(rect)
@@ -633,6 +642,32 @@ export function usePromptArea({
     },
     [onChipClick, onLinkClick, triggers, runSearch, disabled],
   )
+
+  // -----------------------------------------------------------------------
+  // Chip mousedown delegation — feeds `suppressReopenChip` for handleClick's
+  // toggle-close detection. See `openChipNode`/`suppressReopenChip` above for
+  // why this needs to be a real mousedown listener rather than piggybacking
+  // on `dismissTrigger`.
+  // -----------------------------------------------------------------------
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target
+    const editor = editorRef.current
+    if (!editor || !(target instanceof Node)) {
+      suppressReopenChip.current = null
+      return
+    }
+
+    let node: Node | null = target
+    while (node && node !== editor) {
+      if (isChipElement(node)) {
+        suppressReopenChip.current = openChipNode.current === node ? node : null
+        return
+      }
+      node = node.parentNode
+    }
+    suppressReopenChip.current = null
+  }, [])
 
   // -----------------------------------------------------------------------
   // Remove a chip node from DOM and sync model
@@ -853,16 +888,19 @@ export function usePromptArea({
       }
 
       // Chip-click dropdown (`reopenOnChipClick`): replace the clicked chip in
-      // place instead of resolving typed trigger text at the caret.
+      // place instead of resolving typed trigger text at the caret. Disabled
+      // is re-checked here (not just at open time) in case the composer
+      // became disabled while the popover was still open.
       const editing = editingChip.current
       if (editing) {
         const editor = editorRef.current
-        if (editor) {
+        if (editor && !disabled) {
           // Re-verify the click-time index still holds the same chip — the
           // model may have shifted (external value update, undo/redo) while
-          // the dropdown was open. Fall back to a trigger+value search so a
-          // shifted-but-present chip is still found instead of silently
-          // dropping the user's selection.
+          // the dropdown was open. If it moved, recover ONLY when exactly one
+          // chip in the document now matches trigger+value: with duplicates,
+          // guessing risks silently editing the wrong instance, which is
+          // worse than the no-op this falls back to.
           const atIndex = segments[editing.segIndex]
           const stillThere =
             atIndex?.type === 'chip' &&
@@ -870,12 +908,19 @@ export function usePromptArea({
             atIndex.value === editing.chip.value
           const segIdx = stillThere
             ? editing.segIndex
-            : segments.findIndex(
-                (seg) =>
-                  seg.type === 'chip' &&
-                  seg.trigger === editing.chip.trigger &&
-                  seg.value === editing.chip.value,
-              )
+            : (() => {
+                const matches: number[] = []
+                segments.forEach((seg, i) => {
+                  if (
+                    seg.type === 'chip' &&
+                    seg.trigger === editing.chip.trigger &&
+                    seg.value === editing.chip.value
+                  ) {
+                    matches.push(i)
+                  }
+                })
+                return matches.length === 1 ? matches[0] : -1
+              })()
           const oldChip = segIdx !== -1 ? segments[segIdx] : undefined
 
           if (oldChip?.type === 'chip') {
@@ -893,7 +938,8 @@ export function usePromptArea({
             // with no text node, which some engines fail to render/snap a
             // visible caret at.
             const nextSeg = newSegments[segIdx + 1]
-            if (!nextSeg || nextSeg.type !== 'text' || nextSeg.text.length === 0) {
+            const insertedSpace = !nextSeg || nextSeg.type !== 'text' || nextSeg.text.length === 0
+            if (insertedSpace) {
               newSegments = [
                 ...newSegments.slice(0, segIdx + 1),
                 { type: 'text', text: ' ' },
@@ -905,18 +951,25 @@ export function usePromptArea({
             onChange(newSegments)
             renderSegmentsToDOM(newSegments)
 
-            // Same value + display text: treat as a no-op confirmation rather
-            // than a destructive delete+add — onChipDelete is documented as
-            // firing on backspace/forward-delete, not on re-confirming the
-            // already-selected suggestion.
+            // Same value + display text + data: treat as a no-op confirmation
+            // rather than a destructive delete+add — onChipDelete is
+            // documented as firing on backspace/forward-delete, not on
+            // re-confirming the already-selected suggestion.
             const unchanged =
-              oldChip.value === newChip.value && oldChip.displayText === newChip.displayText
+              oldChip.value === newChip.value &&
+              oldChip.displayText === newChip.displayText &&
+              safeJsonStringify(oldChip.data) === safeJsonStringify(newChip.data)
             if (!unchanged) {
               onChipDelete?.(oldChip)
               onChipAdd?.(newChip)
             }
 
-            const caretOffset = segmentsToPlainText(newSegments.slice(0, segIdx + 1)).length
+            // +1 when a space was inserted, matching resolveChip's own
+            // "+1 accounts for the trailing space after the chip" placement —
+            // landing exactly at the chip's end would put the caret at the
+            // same bare element boundary the inserted space exists to avoid.
+            const caretOffset =
+              segmentsToPlainText(newSegments.slice(0, segIdx + 1)).length + (insertedSpace ? 1 : 0)
             setCursorAtOffset(editor, caretOffset)
           }
         }
@@ -961,6 +1014,7 @@ export function usePromptArea({
       onChipAdd,
       onChipDelete,
       events,
+      disabled,
     ],
   )
 
@@ -1384,6 +1438,7 @@ export function usePromptArea({
     handleInput,
     handleKeyDown,
     handleClick,
+    handleMouseDown,
     selectSuggestion,
     dismissTrigger,
     handle,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1714,9 +1714,6 @@ packages:
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -6476,11 +6473,6 @@ snapshots:
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
-
-  '@types/node@26.1.0':
-    dependencies:
-      undici-types: 8.3.0
-    optional: true
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7846,10 +7846,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
   fflate@0.4.8: {}
 
   fflate@0.8.3: {}


### PR DESCRIPTION
## Summary
Makes the hero composer demo's chips actionable so visitors learn they are live objects, not styled text — driven through the library's **native trigger API** — and fixes the CSS regression that had broken the native suggestion popover on the homepage.

## Key Changes
- **`TriggerConfig.reopenOnChipClick` (new native API)**: clicking a chip created by a dropdown trigger reopens its native suggestion popover anchored to the chip (empty-query results, current value preselected); selecting a suggestion replaces the chip in place, firing `onChipDelete`/`onChipAdd`. Typing or dismissing cancels the chip-edit state. `onChipClick` still fires for app-level side effects.
- **Native popover positioning fix**: the CSS reveal (`[data-reveal='mount']`, fill-mode `both`) left a permanent identity transform on the hero wrapper — Blink retains the final keyframe as a matrix even with `transform: none` — turning it into a containing block that re-anchored the popover's `position: fixed` coordinates off-screen. Switched to `backwards` fill so the transform only exists during the entrance animation.
- **Hero chip behaviors**: `#campaign` reopens the native tag dropdown (swap in place); `@mention` chips show a "notified" toast, stacking per click with its own auto-dismiss and a capped, animated-exit stack; `/summarize` runs a mock execution with a loading state and dismissible result card.
- **Analytics**: new typed `demo_chip_clicked` event alongside the existing `demo_interacted`.
- **Lockfile repair**: deduped `@types/node@26.1.0` entries in `pnpm-lock.yaml` (broken on `main` by back-to-back dependabot merges #177/#178), which was failing `pnpm install --frozen-lockfile` on every CI job.

## Correctness hardening (two review passes)
Two rounds of adversarial code review on `reopenOnChipClick` surfaced 16 confirmed bugs total, all fixed:

**First pass:**
- `domChildIndexToSegmentIndex` ignored decoration elements (URL `<a>`, markdown `<span data-md>`), so a chip after decorated text resolved to the wrong segment. Fixed via a shared `childProducesSegment` predicate — also closes the same latent bug in chip backspace-delete and auto-resolved-chip revert.
- A disabled `PromptArea` could still be edited via chip-click; Enter/Escape could fall through to `onSubmit`/`onEscape` while the popover was visibly open in a loading/empty state; the clicked chip was tracked by a DOM node that could detach on re-render, silently swallowing the selection.
- Chip replacement now pushes an undo snapshot, skips a destructive delete+add on an unchanged confirm, inserts a trailing space when the replaced chip is the last segment, and (attempted) a toggle-close on re-click.

**Second pass** (review of the first pass's own fix):
- The toggle-close mechanism matched by trigger+value via a flag set inside `dismissTrigger` — since `dismissTrigger` also runs on Escape/blur/selection, any of those could poison the flag and silently suppress a later, unrelated click on the same chip; two chips sharing a value could also cross-suppress. Replaced with a real `onMouseDown` handler comparing DOM node identity, decoupled from *why* a dismiss happened.
- The same trigger+value ambiguity affected the segIndex-recovery fallback — now only recovers when exactly one chip in the document matches, otherwise no-ops rather than risking editing the wrong instance.
- `disabled` was only checked when opening the dropdown, not when completing the edit.
- The caret after inserting the trailing landing-space landed *before* the space, not after — the same bare-boundary problem the space was meant to avoid.
- The no-op-confirmation guard ignored the chip's `data` payload, silently dropping data-only updates.
- `childProducesSegment` counted any chip element, but the actual reader skips a chip missing a required attribute.

## Implementation Details
- Chip-edit state lives in the `usePromptArea` hook as refs (`editingChip: { chip, segIndex }`, `openChipNode`), cleared on typing/dismissal so a later selection can never target a stale chip.
- `CodexInputExample` forwards `onChipClick` verbatim to `PromptArea` — no bespoke picker UI or segment-state plumbing in the marketing site.
- Verified end-to-end with Playwright, including a real-browser double-click/Escape-then-reopen check for the toggle mechanism (its correctness depends on actual DOM event ordering that unit tests alone can't fully exercise).
- 30 new/updated unit tests across `dom-helpers.test.ts` and `use-prompt-area.test.ts`. Full suite (777 tests), typecheck, and lint pass.

https://claude.ai/code/session_01EMBZuN7zQHaZLp9LhG8Wv4