### PR TITLE
Fix placeholder reappearing after editor is fully cleared

### DIFF
--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createRef } from 'react'
+import { createRef, useState } from 'react'
 import { PromptArea } from '../prompt-area'
 import type { PromptAreaHandle, PromptAreaImage, PromptAreaFile, Segment } from '../types'
 
@@ -519,6 +519,76 @@ describe('PromptArea', () => {
           placeholder="Type here..."
         />,
       )
+      expect(screen.queryByText('Type here...')).not.toBeInTheDocument()
+    })
+
+    // Regression: after the user types into the editor and then deletes it all,
+    // the browser leaves a lone filler <br> in the contentEditable. That <br>
+    // must be read as an empty document (not a "\n" text segment) so the
+    // placeholder reappears instead of staying hidden forever.
+    it('restores the placeholder after the editor is typed into and fully cleared', () => {
+      const onChange = vi.fn()
+      function Controlled() {
+        const [value, setValue] = useState<Segment[]>([])
+        return (
+          <PromptArea
+            value={value}
+            onChange={(next) => {
+              onChange(next)
+              setValue(next)
+            }}
+            placeholder="Type here..."
+          />
+        )
+      }
+      render(<Controlled />)
+      const editor = screen.getByRole('textbox')
+
+      expect(screen.getByText('Type here...')).toBeInTheDocument()
+
+      // Simulate typing "hello": the browser adds a text node.
+      editor.appendChild(document.createTextNode('hello'))
+      fireEvent.input(editor)
+      expect(screen.queryByText('Type here...')).not.toBeInTheDocument()
+
+      // Simulate deleting everything: the browser leaves a lone filler <br>.
+      while (editor.firstChild) editor.removeChild(editor.firstChild)
+      editor.appendChild(document.createElement('br'))
+      fireEvent.input(editor)
+
+      // The model returns to empty and the placeholder comes back.
+      expect(onChange).toHaveBeenLastCalledWith([])
+      expect(screen.getByText('Type here...')).toBeInTheDocument()
+    })
+
+    // Guard the fix's boundary: a newline we actually rendered is a content <br>
+    // paired with a trailing sentinel <br>. That is real content and must NOT be
+    // collapsed to empty, so the placeholder stays hidden.
+    it('keeps a rendered trailing newline (with sentinel <br>) as content', () => {
+      const onChange = vi.fn()
+      function Controlled() {
+        const [value, setValue] = useState<Segment[]>([])
+        return (
+          <PromptArea
+            value={value}
+            onChange={(next) => {
+              onChange(next)
+              setValue(next)
+            }}
+            placeholder="Type here..."
+          />
+        )
+      }
+      render(<Controlled />)
+      const editor = screen.getByRole('textbox')
+
+      editor.appendChild(document.createElement('br'))
+      const sentinel = document.createElement('br')
+      sentinel.dataset.sentinel = 'true'
+      editor.appendChild(sentinel)
+      fireEvent.input(editor)
+
+      expect(onChange).toHaveBeenLastCalledWith([{ type: 'text', text: '\n' }])
       expect(screen.queryByText('Type here...')).not.toBeInTheDocument()
     })
   })

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -206,6 +206,11 @@ export function usePromptArea({
     if (!editor) return []
 
     const segments: Segment[] = []
+    // Track whether the editor holds any real content (text/chip) or a sentinel
+    // <br> that renderSegmentsToDOM added. When it holds neither, any <br> nodes
+    // present are the browser's filler <br> (see the empty-editor check below).
+    let hasRealContent = false
+    let hasSentinel = false
 
     for (let i = 0; i < editor.childNodes.length; i++) {
       const node = editor.childNodes[i]
@@ -214,21 +219,38 @@ export function usePromptArea({
         const text = node.textContent ?? ''
         if (text) {
           segments.push({ type: 'text', text })
+          hasRealContent = true
         }
       } else if (isChipElement(node)) {
         const chip = chipNodeToSegment(node)
-        if (chip) segments.push(chip)
+        if (chip) {
+          segments.push(chip)
+          hasRealContent = true
+        }
       } else if (isBRElement(node)) {
-        if (node.dataset.sentinel) continue // skip sentinel <br>
+        if (node.dataset.sentinel) {
+          hasSentinel = true
+          continue // skip sentinel <br>
+        }
         segments.push({ type: 'text', text: '\n' })
       } else if (isHTMLElement(node)) {
         // Unknown element — extract text content
         const text = node.textContent ?? ''
         if (text) {
           segments.push({ type: 'text', text })
+          hasRealContent = true
         }
       }
     }
+
+    // When the user empties the editor (types something, then deletes it all),
+    // the browser leaves a lone filler <br> so the contentEditable block stays
+    // visible and focusable. Reading that <br> as a "\n" text segment would make
+    // `value` permanently non-empty and keep the placeholder hidden forever.
+    // A newline we actually rendered always carries surrounding text/chip
+    // content or a trailing sentinel <br>, so when neither is present the only
+    // <br> nodes are filler and the editor is genuinely empty.
+    if (!hasRealContent && !hasSentinel) return []
 
     return segments
   }, [])


### PR DESCRIPTION
## Summary
Fixed a regression where the placeholder text would not reappear after a user typed into the PromptArea editor and then deleted all content. The issue occurred because the browser leaves a lone filler `<br>` element in contentEditable divs when they're emptied, which was being incorrectly interpreted as a newline segment.

## Key Changes
- **Updated `usePromptArea` parsing logic** to distinguish between:
  - Real content (text nodes or chip elements)
  - Sentinel `<br>` elements (intentionally rendered by the component)
  - Filler `<br>` elements (added by the browser when the editor is empty)
  
- **Added tracking flags** (`hasRealContent` and `hasSentinel`) to detect when the editor contains only a browser filler `<br>`

- **Return empty segments** when no real content or sentinel is present, allowing the placeholder to reappear

- **Added comprehensive test coverage**:
  - Test for the regression: typing "hello" then deleting it all restores the placeholder
  - Boundary test: verifies that intentionally rendered newlines (with sentinel `<br>`) are preserved as content and don't show the placeholder

## Implementation Details
The fix recognizes that a newline we actually render always has either surrounding text/chip content or a trailing sentinel `<br>` marker. When neither is present, any `<br>` nodes are the browser's filler and the editor is genuinely empty. This allows the component to correctly reset to its empty state and show the placeholder again.

https://claude.ai/code/session_01B5xMHa29vE9Et9BJ4fe4FM