### PR TITLE
ci: restore CodeQL scanning via advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  schedule:
+    # Weekly, matching the cadence the previous default setup ran on.
+    - cron: '12 5 * * 6'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@v4
+        with:
+          # Must match the category the previous default setup used so the
+          # existing alert history stays attached to these configurations.
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Problem

The [CodeQL tool status page](https://github.com/just-marketing/prompt-area/security/code-scanning/tools/CodeQL/status/configurations/automatic/e2b17b35bd2603481bc03e9fd5c5a61d846f37f5dea24a1a3fff289055d45627) reports `Code Scanning results may be out of date` on both configurations.

This is not a code defect. There are **zero open alerts**: all 8 alerts ever raised are `fixed`, and the last 10 analyses each returned `results: 0`.

| Signal | Value |
|---|---|
| Last CodeQL scan | commit `8cb07667`, Apr 11 2026 |
| CodeQL runs that failed | none, every run ever succeeded |
| `GET /code-scanning/default-setup` | `state: "not-configured"` |

CodeQL default setup was switched off around Apr 11, so the weekly scans stopped being scheduled and the results went stale.

## Fix

Replaces the disabled default setup with a committed workflow, so the configuration lives in git and cannot be silently toggled off again.

- Matrix over `actions` + `javascript-typescript` with `build-mode: none`, matching what default setup analyzed
- `category: '/language:<lang>'` matches the previous category strings, so existing alert history stays attached to these two configurations instead of starting fresh ones
- Explicit root and job-scoped permissions, so this workflow does not itself trip `actions/missing-workflow-permissions` (the rule behind 7 of the 8 past alerts)
- `actions/checkout@v7` and the `concurrency` block match the conventions already in `ci.yml`; `github/codeql-action@v4` is the current major
- Weekly `cron: '12 5 * * 6'` preserves the previous scan cadence

## Verification

YAML parses cleanly and permissions/matrix resolve as intended. Default setup is already `not-configured`, so there is no conflict blocking advanced setup. The real check is the CodeQL run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)