### PR TITLE
ci: gate formatting, and let Dependabot surface majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,17 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Catch-all for majors. Every group above is scoped to minor/patch, so
+      # without this a major update matches no group and is never opened at
+      # all — that is how jest-dom 7 and jest-axe 11 sat unnoticed. Grouping
+      # them into one weekly PR keeps them visible without reintroducing the
+      # pnpm-lock.yaml conflict pileup that individual PRs cause. Entries in
+      # `ignore` below still win over this group.
+      majors:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
     ignore:
       # lucide-react v1 dropped brand icons (Github) used in nav-sidebar.
       # Lift once those icons are replaced or brand support returns.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm format:check
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes two config gaps found during the maintenance pass. Both were silent — nothing was failing, which is exactly why they went unnoticed.

## 1. `format` job in CI

`pnpm format:check` was defined in `package.json` but ran nowhere in CI, so formatting was only advisory via the lefthook pre-commit hook. That is how `compact-prompt-area.tsx` drifted out of prettier format without anything complaining.

Added a `Format` job alongside `Lint`.

**Verified the gate passes before wiring it in.** Local `format:check` currently fails, but on 45 untracked WIP files (`campaign/`, `remotion/`, `todos/`) — not on anything in the repo. To confirm CI would actually go green I cloned `HEAD` to a scratch dir, so local untracked files could not skew the result, and ran `prettier --check .`:

```
Checking formatting...
All matched files use Prettier code style!
```

**Deliberately not added to `build`'s `needs`.** `build` gates on `[lint, typecheck, test]`; a formatting nit should not stop the heavier build / package / registry-install jobs from reporting their own results.

One consequence worth knowing: `campaign/`, `remotion/`, and `todos/` are untracked today, so CI never sees them. If any of those get committed later, this job will start failing on them — they'd want a `.prettierignore` entry at that point.

## 2. `majors` group for Dependabot

Every npm group was scoped to `update-types: [minor, patch]` — **including the `*` catch-all**. A major update therefore matched no group and was never opened at all.

That is the root cause of `@testing-library/jest-dom` 6→7 and `jest-axe` 10→11 sitting unnoticed until #207 bumped them by hand. It's an easy gap to miss because the `ignore` block holds three majors back explicitly (`lucide-react`, `eslint`, `typescript`), which reads as though other majors *do* come through.

Added a `majors` group matching `*` with `update-types: [major]`, placed last:

```
next -> react -> eslint -> testing -> tailwind -> types -> minor-and-patch -> majors
```

Group matching is first-match-wins, and every earlier group excludes majors, so majors fall through to this one cleanly. The `ignore` entries still take precedence over it, so the three deliberate holds are unaffected.

Grouping majors into one weekly PR rather than one PR each is intentional — individual PRs are what produced the eight-way `pnpm-lock.yaml` conflict pileup cleared in #205.

**No change needed for GitHub Actions.** Its `actions` group has no `update-types` restriction, so it already carries majors — that's how the `setup-node` v6→v7 PR appeared.

## Verification

Both files parsed as YAML and structurally inspected (group order, resulting job list, `build.needs`) before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
