### PR TITLE
Update AI model versions across example components

### DIFF
--- a/app/docs/examples/vercel-ai-sdk/page.tsx
+++ b/app/docs/examples/vercel-ai-sdk/page.tsx
@@ -30,7 +30,7 @@ function handleSubmit() {
       body: {
         mentions: mentions.map((c) => c.value),
         command: commands[0]?.value,
-        model: 'claude-opus-4-8',
+        model: 'claude-opus-5',
       },
     },
   )
@@ -44,7 +44,7 @@ import { z } from 'zod'
 // Allowlist everything you accept — the request body is untrusted input.
 const bodySchema = z.object({
   messages: z.array(z.custom<UIMessage>()),
-  model: z.enum(['claude-opus-4-8', 'claude-haiku-4-5']).default('claude-opus-4-8'),
+  model: z.enum(['claude-opus-5', 'claude-haiku-4-5']).default('claude-opus-5'),
   command: z.enum(['summarize', 'translate']).optional(),
   mentions: z.array(z.string().max(64)).max(10).default([]),
 })

--- a/app/examples/claude-code-input.tsx
+++ b/app/examples/claude-code-input.tsx
@@ -36,8 +36,8 @@ type CcModel = { id: string; name: string; shortcut?: string; unavailable?: bool
 
 const MODELS: CcModel[] = [
   { id: 'fable-5', name: 'Fable 5', unavailable: true },
-  { id: 'opus-4.8', name: 'Opus 4.8', shortcut: '1' },
-  { id: 'sonnet-4.6', name: 'Sonnet 4.6', shortcut: '2' },
+  { id: 'opus-5', name: 'Opus 5', shortcut: '1' },
+  { id: 'sonnet-5', name: 'Sonnet 5', shortcut: '2' },
   { id: 'haiku-4.5', name: 'Haiku 4.5', shortcut: '3' },
 ]
 
@@ -590,8 +590,8 @@ import type { Segment, PromptAreaHandle } from '@/components/types'
 type CcModel = { id: string; name: string; shortcut?: string; unavailable?: boolean }
 const MODELS: CcModel[] = [
   { id: 'fable-5', name: 'Fable 5', unavailable: true },
-  { id: 'opus-4.8', name: 'Opus 4.8', shortcut: '1' },
-  { id: 'sonnet-4.6', name: 'Sonnet 4.6', shortcut: '2' },
+  { id: 'opus-5', name: 'Opus 5', shortcut: '1' },
+  { id: 'sonnet-5', name: 'Sonnet 5', shortcut: '2' },
   { id: 'haiku-4.5', name: 'Haiku 4.5', shortcut: '3' },
 ]
 const PERMISSION_MODES = ['Ask each time', 'Accept edits', 'Plan mode', 'Bypass permissions'] as const

--- a/app/examples/claude-input.tsx
+++ b/app/examples/claude-input.tsx
@@ -42,8 +42,8 @@ type ClaudeModel = {
 
 const MODELS: ClaudeModel[] = [
   { id: 'fable-5', name: 'Fable 5', desc: 'For your toughest challenges', unavailable: true },
-  { id: 'opus-4.8', name: 'Opus 4.8', desc: 'For complex tasks' },
-  { id: 'sonnet-4.6', name: 'Sonnet 4.6', desc: 'Most efficient for everyday tasks' },
+  { id: 'opus-5', name: 'Opus 5', desc: 'For complex tasks' },
+  { id: 'sonnet-5', name: 'Sonnet 5', desc: 'Most efficient for everyday tasks' },
   { id: 'haiku-4.5', name: 'Haiku 4.5', desc: 'Fastest for quick answers' },
 ]
 
@@ -381,8 +381,8 @@ import type { Segment, PromptAreaHandle } from '@/components/types'
 type ClaudeModel = { id: string; name: string; desc: string; unavailable?: boolean }
 const MODELS: ClaudeModel[] = [
   { id: 'fable-5', name: 'Fable 5', desc: 'For your toughest challenges', unavailable: true },
-  { id: 'opus-4.8', name: 'Opus 4.8', desc: 'For complex tasks' },
-  { id: 'sonnet-4.6', name: 'Sonnet 4.6', desc: 'Most efficient for everyday tasks' },
+  { id: 'opus-5', name: 'Opus 5', desc: 'For complex tasks' },
+  { id: 'sonnet-5', name: 'Sonnet 5', desc: 'Most efficient for everyday tasks' },
   { id: 'haiku-4.5', name: 'Haiku 4.5', desc: 'Fastest for quick answers' },
 ]
 const EFFORTS = ['High', 'Medium', 'Low'] as const

--- a/app/examples/codex-input.tsx
+++ b/app/examples/codex-input.tsx
@@ -34,10 +34,10 @@ const PERMISSIONS = ['Default permissions', 'Read only', 'Full access'] as const
 type Permission = (typeof PERMISSIONS)[number]
 
 const MODELS = [
-  { id: 'gpt-5.5-xhigh', version: '5.5', effort: 'Extra High' },
-  { id: 'gpt-5.5-high', version: '5.5', effort: 'High' },
-  { id: 'gpt-5.5-medium', version: '5.5', effort: 'Medium' },
-  { id: 'gpt-5.1-high', version: '5.1', effort: 'High' },
+  { id: 'gpt-5.6-sol-xhigh', version: '5.6 Sol', effort: 'Extra High' },
+  { id: 'gpt-5.6-sol-high', version: '5.6 Sol', effort: 'High' },
+  { id: 'gpt-5.6-terra-medium', version: '5.6 Terra', effort: 'Medium' },
+  { id: 'gpt-5.6-luna-low', version: '5.6 Luna', effort: 'Low' },
 ] as const
 type Model = (typeof MODELS)[number]
 
@@ -358,7 +358,7 @@ function CodexInputExample() {
   const [segments, setSegments] = useState<Segment[]>([])
   // Snapshot of the last submission so Reset can restore it for another send.
   const [submitted, setSubmitted] = useState<Segment[] | null>(null)
-  const [model, setModel] = useState({ version: '5.5', effort: 'Extra High' })
+  const [model, setModel] = useState({ version: '5.6 Sol', effort: 'Extra High' })
   const [openMenu, setOpenMenu] = useState<string | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const promptRef = useRef<PromptAreaHandle>(null)
@@ -436,7 +436,7 @@ function CodexInputExample() {
                   </button>
                   {openMenu === 'model' && (
                     <div className={cn(MENU, 'right-0 bottom-full mb-1.5 w-52')}>
-                      {[{ version: '5.5', effort: 'Extra High' }, { version: '5.5', effort: 'High' }, { version: '5.1', effort: 'High' }].map((m, i) => (
+                      {[{ version: '5.6 Sol', effort: 'Extra High' }, { version: '5.6 Terra', effort: 'Medium' }, { version: '5.6 Luna', effort: 'Low' }].map((m, i) => (
                         <button key={i} className={MENU_ITEM} onClick={() => { setModel(m); setOpenMenu(null) }}>
                           <Zap className="size-4" />
                           <span className="text-foreground font-semibold">{m.version}</span>

--- a/app/examples/gemini-input.tsx
+++ b/app/examples/gemini-input.tsx
@@ -42,8 +42,8 @@ type GeminiModel = { id: string; name: string; desc: string; tier: string }
 // The pill shows the short `tier`; the menu lists the full name over a
 // one-line description, with a check on the active model.
 const MODELS: GeminiModel[] = [
-  { id: 'flash-lite', name: '3.1 Flash-Lite', desc: 'Fastest answers', tier: 'Flash-Lite' },
-  { id: 'flash', name: '3.5 Flash', desc: 'All-around help', tier: 'Flash' },
+  { id: 'flash-lite', name: '3.5 Flash-Lite', desc: 'Fastest answers', tier: 'Flash-Lite' },
+  { id: 'flash', name: '3.6 Flash', desc: 'All-around help', tier: 'Flash' },
   { id: 'pro', name: '3.1 Pro', desc: 'Advanced math and code', tier: 'Pro' },
 ]
 
@@ -546,8 +546,8 @@ import type { Segment, PromptAreaHandle } from '@/components/types'
 
 type GeminiModel = { id: string; name: string; desc: string; tier: string }
 const MODELS: GeminiModel[] = [
-  { id: 'flash-lite', name: '3.1 Flash-Lite', desc: 'Fastest answers', tier: 'Flash-Lite' },
-  { id: 'flash', name: '3.5 Flash', desc: 'All-around help', tier: 'Flash' },
+  { id: 'flash-lite', name: '3.5 Flash-Lite', desc: 'Fastest answers', tier: 'Flash-Lite' },
+  { id: 'flash', name: '3.6 Flash', desc: 'All-around help', tier: 'Flash' },
   { id: 'pro', name: '3.1 Pro', desc: 'Advanced math and code', tier: 'Pro' },
 ]
 type Thinking = { id: string; label: string; desc: string }

--- a/app/examples/juma-input.tsx
+++ b/app/examples/juma-input.tsx
@@ -145,12 +145,12 @@ type JumaModel = { id: string; name: string; desc: string; advanced?: boolean }
 
 const MODELS: JumaModel[] = [
   { id: 'juma-agent', name: 'Juma Agent', desc: 'Most optimized for Juma' },
-  { id: 'gpt-5.5', name: 'GPT-5.5', desc: "Free during World Cup '26" },
+  { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', desc: "Free during World Cup '26" },
 ]
 // Tucked behind the "Advanced" disclosure at the bottom of the model menu.
 const ADVANCED_MODELS: JumaModel[] = [
-  { id: 'opus-4.8', name: 'Claude Opus 4.8', desc: 'For your hardest tasks', advanced: true },
-  { id: 'gemini-3-pro', name: 'Gemini 3 Pro', desc: 'Long-context research', advanced: true },
+  { id: 'opus-5', name: 'Claude Opus 5', desc: 'For your hardest tasks', advanced: true },
+  { id: 'gemini-3.1-pro', name: 'Gemini 3.1 Pro', desc: 'Long-context research', advanced: true },
 ]
 
 // Representative placeholder names — not real workspaces or brands.
@@ -697,7 +697,7 @@ function ModelMenu({
   )
 }
 
-// Each model's leading glyph: Juma Agent wears the brand spark, GPT-5.5 a World
+// Each model's leading glyph: Juma Agent wears the brand spark, GPT-5.6 Terra a World
 // Cup ball (its "Free during World Cup" promo), and the Advanced models their
 // real vendor marks — so the selector button reflects the picked vendor, just
 // like the product (whose button showed the Anthropic mark for Claude).
@@ -705,7 +705,7 @@ function ModelGlyph({ id, className }: { id: string; className?: string }) {
   if (id === 'juma-agent') {
     return <JumaSpark className={cn('text-[#0f8bab] dark:text-[#40c4d3]', className)} />
   }
-  if (id === 'gpt-5.5') {
+  if (id === 'gpt-5.6-terra') {
     return (
       <span
         aria-hidden
@@ -717,10 +717,10 @@ function ModelGlyph({ id, className }: { id: string; className?: string }) {
       </span>
     )
   }
-  if (id === 'opus-4.8') {
+  if (id === 'opus-5') {
     return <AnthropicMark className={cn('text-[#d97757]', className)} />
   }
-  if (id === 'gemini-3-pro') {
+  if (id === 'gemini-3.1-pro') {
     return <GeminiMark className={className} />
   }
   return (
@@ -1031,11 +1031,11 @@ function CursorIcon({ className }: { className?: string }) {
 type JumaModel = { id: string; name: string; desc: string }
 const MODELS: JumaModel[] = [
   { id: 'juma-agent', name: 'Juma Agent', desc: 'Most optimized for Juma' },
-  { id: 'gpt-5.5', name: 'GPT-5.5', desc: "Free during World Cup '26" },
+  { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', desc: "Free during World Cup '26" },
 ]
 const ADVANCED_MODELS: JumaModel[] = [
-  { id: 'opus-4.8', name: 'Claude Opus 4.8', desc: 'For your hardest tasks' },
-  { id: 'gemini-3-pro', name: 'Gemini 3 Pro', desc: 'Long-context research' },
+  { id: 'opus-5', name: 'Claude Opus 5', desc: 'For your hardest tasks' },
+  { id: 'gemini-3.1-pro', name: 'Gemini 3.1 Pro', desc: 'Long-context research' },
 ]
 const PROJECTS = ['Spring Campaign', 'Newsletter Revamp', 'Website Refresh', 'Social Calendar', 'Product Launch']
 type Brand = { id: string; name: string; colors: string[] }

--- a/app/examples/perplexity-input.tsx
+++ b/app/examples/perplexity-input.tsx
@@ -54,19 +54,19 @@ type ModelRow = { id: string; name: string; icon: LucideIcon; badge?: 'Max' | 'N
 // provider gets an evocative monochrome glyph; rows are locked behind an upgrade.
 const SEARCH_MODELS: ModelRow[] = [
   { id: 'sonar-2', name: 'Sonar 2', icon: Radar },
-  { id: 'gpt-5.4', name: 'GPT-5.4', icon: Atom },
-  { id: 'gpt-5.5', name: 'GPT-5.5', icon: Atom, badge: 'Max' },
+  { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', icon: Atom },
+  { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', icon: Atom, badge: 'Max' },
   { id: 'gemini-3.1-pro', name: 'Gemini 3.1 Pro', icon: Sparkles },
-  { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', icon: Asterisk },
-  { id: 'claude-opus-4.8', name: 'Claude Opus 4.8', icon: Asterisk, badge: 'Max' },
+  { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', icon: Asterisk },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', icon: Asterisk, badge: 'Max' },
   { id: 'nemotron-3-ultra', name: 'Nemotron 3 Ultra', icon: Hexagon, badge: 'New' },
 ]
 
 // The shorter Computer-mode list, surfaced under the "Orchestrator" picker.
 const COMPUTER_MODELS: ModelRow[] = [
-  { id: 'gpt-5.5', name: 'GPT-5.5', icon: Atom },
-  { id: 'claude-opus-4.8', name: 'Claude Opus 4.8', icon: Asterisk },
-  { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', icon: Asterisk },
+  { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', icon: Atom },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', icon: Asterisk },
+  { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', icon: Asterisk },
 ]
 
 const STARTERS: { label: string; icon: LucideIcon }[] = [
@@ -515,17 +515,17 @@ type ModelRow = { id: string; name: string; icon: LucideIcon; badge?: 'Max' | 'N
 
 const SEARCH_MODELS: ModelRow[] = [
   { id: 'sonar-2', name: 'Sonar 2', icon: Radar },
-  { id: 'gpt-5.4', name: 'GPT-5.4', icon: Atom },
-  { id: 'gpt-5.5', name: 'GPT-5.5', icon: Atom, badge: 'Max' },
+  { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', icon: Atom },
+  { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', icon: Atom, badge: 'Max' },
   { id: 'gemini-3.1-pro', name: 'Gemini 3.1 Pro', icon: Sparkles },
-  { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', icon: Asterisk },
-  { id: 'claude-opus-4.8', name: 'Claude Opus 4.8', icon: Asterisk, badge: 'Max' },
+  { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', icon: Asterisk },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', icon: Asterisk, badge: 'Max' },
   { id: 'nemotron-3-ultra', name: 'Nemotron 3 Ultra', icon: Hexagon, badge: 'New' },
 ]
 const COMPUTER_MODELS: ModelRow[] = [
-  { id: 'gpt-5.5', name: 'GPT-5.5', icon: Atom },
-  { id: 'claude-opus-4.8', name: 'Claude Opus 4.8', icon: Asterisk },
-  { id: 'claude-sonnet-4.6', name: 'Claude Sonnet 4.6', icon: Asterisk },
+  { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', icon: Atom },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', icon: Asterisk },
+  { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', icon: Asterisk },
 ]
 const STARTERS: { label: string; icon: LucideIcon }[] = [
   { label: 'Build an app', icon: Smartphone },

--- a/app/examples/status-bar.tsx
+++ b/app/examples/status-bar.tsx
@@ -64,7 +64,7 @@ export function StatusBarBelowExample() {
           <button
             type="button"
             className="text-muted-foreground hover:text-foreground flex items-center gap-1">
-            Opus 4.8
+            Opus 5
             <ChevronDown className="size-3" />
           </button>
         }
@@ -111,7 +111,7 @@ export function StatusBarBothExample() {
             <button
               type="button"
               className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs">
-              Opus 4.8
+              Opus 5
               <ChevronDown className="size-3" />
             </button>
           }
@@ -188,7 +188,7 @@ function StatusBarBelowExample() {
         }
         right={
           <button className="text-muted-foreground flex items-center gap-1">
-            Opus 4.8 <ChevronDown className="size-3" />
+            Opus 5 <ChevronDown className="size-3" />
           </button>
         }
       />
@@ -234,7 +234,7 @@ function StatusBarBothExample() {
           left={<span className="text-muted-foreground text-xs">+ &lt;/&gt; Auto accept edits</span>}
           right={
             <button className="text-muted-foreground flex items-center gap-1 text-xs">
-              Opus 4.8 <ChevronDown className="size-3" />
+              Opus 5 <ChevronDown className="size-3" />
             </button>
           }
         />

--- a/app/examples/vercel-ai-sdk.tsx
+++ b/app/examples/vercel-ai-sdk.tsx
@@ -197,7 +197,7 @@ export async function POST(req: Request) {
   }
 
   const result = streamText({
-    model: anthropic('claude-opus-4-8'),
+    model: anthropic('claude-opus-5'),
     system: 'You are a helpful assistant.',
     messages: convertToModelMessages(parsed.data.messages),
   })

--- a/app/sections/demo-section.tsx
+++ b/app/sections/demo-section.tsx
@@ -92,8 +92,8 @@ const DEMO_FILES: PromptAreaFile[] = [
 ]
 
 const MODELS = [
-  { id: 'opus', label: 'Opus 4.8', icon: '/claude-icon.svg', invertInDark: false },
-  { id: 'gpt', label: 'GPT 5.5', icon: '/openai-icon.svg', invertInDark: true },
+  { id: 'opus', label: 'Opus 5', icon: '/claude-icon.svg', invertInDark: false },
+  { id: 'gpt', label: 'GPT-5.6 Sol', icon: '/openai-icon.svg', invertInDark: true },
 ] as const
 
 const ICON_BTN = 'rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground'

--- a/campaign/producthunt/slide-generator.tsx.txt
+++ b/campaign/producthunt/slide-generator.tsx.txt
@@ -286,7 +286,7 @@ function ComposerCard({
           right={
             <div className="flex items-center gap-3">
               <span className="text-muted-foreground inline-flex items-center gap-1 text-xs font-medium">
-                <Sparkles className="size-3.5" /> Opus 4.8 <ChevronDown className="size-3" />
+                <Sparkles className="size-3.5" /> Opus 5 <ChevronDown className="size-3" />
               </span>
               <span className="bg-primary text-primary-foreground flex size-8 items-center justify-center rounded-full">
                 <ArrowUp className="size-4" />

--- a/packages/prompt-area/src/status-bar/__tests__/status-bar.test.tsx
+++ b/packages/prompt-area/src/status-bar/__tests__/status-bar.test.tsx
@@ -15,8 +15,8 @@ describe('StatusBar', () => {
   })
 
   it('renders right slot content', () => {
-    render(<StatusBar right={<span>Opus 4.8</span>} />)
-    expect(screen.getByText('Opus 4.8')).toBeInTheDocument()
+    render(<StatusBar right={<span>Opus 5</span>} />)
+    expect(screen.getByText('Opus 5')).toBeInTheDocument()
   })
 
   it('renders both slots simultaneously', () => {


### PR DESCRIPTION
## Summary
This PR updates references to AI model versions across multiple example components and documentation to reflect the latest model releases from OpenAI, Anthropic, and Google.

## Key Changes
- **OpenAI models**: Updated GPT versions from 5.4/5.5 to 5.6 variants (Terra, Sol, Luna) across perplexity, juma, and codex examples
- **Anthropic models**: Updated Claude versions from 4.6/4.8 to version 5 (Opus 5, Sonnet 5) across claude, claude-code, juma, and perplexity examples
- **Google models**: Updated Gemini versions from 3.1/3.5 to 3.5/3.6 Flash variants in gemini example
- **Documentation & demos**: Updated model references in status bar examples, demo section, Vercel AI SDK documentation, and test files
- **Model naming**: Introduced new naming scheme for GPT-5.6 with variant names (Sol, Terra, Luna) to distinguish capability tiers

## Notable Details
- The "Max" badge was reassigned from GPT-5.5 to GPT-5.6 Sol in the perplexity example
- Model IDs and display names were updated consistently across both the component definitions and any hardcoded references
- The Gemini Flash-Lite variant was updated from 3.1 to 3.5, while Flash was updated from 3.5 to 3.6
- All model picker menus and status bar displays now reflect the new version numbers

https://claude.ai/code/session_013fNDrSi1z3FCGhP4WZvkQn