### PR TITLE
Fix IME composition handling

### DIFF
--- a/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers.test.ts
@@ -166,6 +166,48 @@ describe('findDOMPosition', () => {
     expect(pos).toEqual({ node: editor, offset: editor.childNodes.length })
   })
 
+  it('positions before the filler BR of an emptied editor', () => {
+    // What the browser leaves behind after the last character is deleted.
+    const editor = makeEditor()
+    editor.appendChild(document.createElement('br'))
+    const pos = findDOMPosition(editor, 0)
+    expect(pos).toEqual({ node: editor, offset: 0 })
+  })
+
+  it('positions before a leading BR rather than after it', () => {
+    const editor = makeEditor()
+    editor.appendChild(document.createElement('br'))
+    editor.appendChild(document.createTextNode('b'))
+    const pos = findDOMPosition(editor, 0)
+    expect(pos).toEqual({ node: editor, offset: 0 })
+  })
+
+  it('positions before a lone sentinel BR', () => {
+    const editor = makeEditor()
+    editor.appendChild(makeSentinelBr())
+    const pos = findDOMPosition(editor, 0)
+    expect(pos).toEqual({ node: editor, offset: 0 })
+  })
+
+  it('positions before a leading chip rather than after it', () => {
+    const editor = makeEditor()
+    editor.appendChild(makeChip('@', 'Bob'))
+    editor.appendChild(document.createTextNode(' hi'))
+    const pos = findDOMPosition(editor, 0)
+    expect(pos).toEqual({ node: editor, offset: 0 })
+  })
+
+  it('round-trips offset 0 on an emptied editor through getTextLengthInRange', () => {
+    const editor = makeEditor()
+    editor.appendChild(document.createElement('br'))
+    const pos = findDOMPosition(editor, 0)
+    if (!pos) throw new Error('expected a position')
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    range.setEnd(pos.node, pos.offset)
+    expect(getTextLengthInRange(range)).toBe(0)
+  })
+
   it('positions after a chip when offset falls inside it', () => {
     const editor = makeEditor()
     const before = document.createTextNode('a ')

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-max-length.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-max-length.test.tsx
@@ -111,6 +111,8 @@ describe('PromptArea maxLength prop', () => {
     expect(getCursorOffset(editor)).toBe(3)
   })
 
+  // Only the final post-compositionend value is capped; the onChange values
+  // emitted mid-composition are not (follow-up issue pending).
   it('enforces the cap when IME composition ends', () => {
     const { editor, onChangeSpy } = renderWithCap(4)
 

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-max-length.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-max-length.test.tsx
@@ -110,4 +110,19 @@ describe('PromptArea maxLength prop', () => {
     // being forced to the end.
     expect(getCursorOffset(editor)).toBe(3)
   })
+
+  it('enforces the cap when IME composition ends', () => {
+    const { editor, onChangeSpy } = renderWithCap(4)
+
+    fireEvent.compositionStart(editor)
+    act(() => {
+      editor.textContent = 'abcdef'
+      fireEvent.input(editor)
+    })
+    fireEvent.compositionEnd(editor)
+
+    const last = onChangeSpy.mock.calls.at(-1)?.[0] as Segment[]
+    expect(segmentsToPlainText(last)).toBe('abcd')
+    expect(editor.textContent).toBe('abcd')
+  })
 })

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
@@ -246,9 +246,9 @@ describe('Shift+Enter surgical newline', () => {
       result.current.handleKeyDown(shiftEnter())
     })
 
-    // findDOMPosition maps offset 0 to AFTER a leading chip (caret bias); the
-    // surgical path must detect that and fall back so the <br> lands where
-    // the model put the newline — before the chip.
+    // findDOMPosition resolves offset 0 to the boundary BEFORE a leading
+    // chip, so the surgical path's round-trip check passes and it inserts
+    // there — where the model put the newline.
     expect(lastChangeText(onChange)).toBe('\n@alice tail')
     expect(editor.firstChild?.nodeName).toBe('BR')
     const domText = Array.from(editor.childNodes)
@@ -300,7 +300,7 @@ describe('Shift+Enter surgical newline', () => {
     expect((brs[2] as HTMLElement).dataset.sentinel).toBe('true')
   })
 
-  it('inserts on an empty line correctly via the round-trip fallback', () => {
+  it('inserts on an empty line at the offset the round-trip check confirms', () => {
     const { result, editor, onChange } = setup()
     editor.append(
       document.createTextNode('a'),

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-events.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-events.test.ts
@@ -167,7 +167,7 @@ describe('usePromptAreaEvents', () => {
   })
 
   describe('handleCompositionEnd', () => {
-    it('sets isComposing to false and runs trigger detection', () => {
+    it('sets isComposing to false', () => {
       const deps = createDeps()
       editorEl = deps._editor
       const { result } = renderHook(() => usePromptAreaEvents(deps))
@@ -182,7 +182,6 @@ describe('usePromptAreaEvents', () => {
       })
 
       expect(result.current.isComposing.current).toBe(false)
-      expect(deps.runTriggerDetection).toHaveBeenCalled()
     })
   })
 

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-identity.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-identity.test.ts
@@ -99,6 +99,12 @@ describe('usePromptArea referential stability', () => {
     act(() => {
       result.current.handleInput()
     })
+    // Each keystroke mutates the DOM before its input event fires; an input
+    // event whose content is byte-identical to the last rendered value is a
+    // duplicate (e.g. Firefox's post-composition echo) and is deduped, so a
+    // second real keystroke must actually change the text node.
+    ;(editor.firstChild as Text).data = 'hellos world'
+    placeCursor(editor.firstChild!, 6)
     act(() => {
       result.current.handleInput()
     })

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1247,6 +1247,38 @@ describe('usePromptArea', () => {
       document.body.removeChild(editor)
     })
 
+    it('re-enables the keyboard when a composition is interrupted by blur', () => {
+      const onSubmit = vi.fn()
+      const { result } = renderHook(() => usePromptArea(defaultProps({ onSubmit })))
+      const editor = attachEditor(result.current)
+      populateEditor(editor, 'draft')
+
+      // compositionstart with no compositionend: focus moved away mid-IME
+      // (click elsewhere, window switch), so the browser never delivers
+      // compositionend. Blur must reset the composition flag or every later
+      // keystroke is swallowed by handleKeyDown's composition guard.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onBlur())
+
+      const preventDefault = vi.fn()
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'Enter',
+          preventDefault,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 13 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(preventDefault).toHaveBeenCalled()
+      expect(onSubmit).toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
     it('undoes one completed composition after a trailing duplicate input', () => {
       vi.useFakeTimers()
       const onChange = vi.fn()
@@ -1287,6 +1319,116 @@ describe('usePromptArea', () => {
       })
 
       expect(onChange).toHaveBeenCalledWith([])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('keeps committed text undoable when compositionend lands after a blur', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      populateEditor(editor, 'pre')
+      placeCursor(editor.firstChild!, 3)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+
+      // Focus leaves mid-IME, so blur drops the composition baseline; the
+      // browser still delivers compositionend afterwards, with the committed
+      // text already in the DOM. That commit has no composition bookkeeping
+      // left to record it, so the ordinary debounced path must.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onBlur())
+      populateEditor(editor, 'preあ')
+      placeCursor(editor.firstChild!, 4)
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([{ type: 'text', text: 'pre' }])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('does not undo past a composition abandoned by blur', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      populateEditor(editor, 'A')
+      placeCursor(editor.firstChild!, 1)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+
+      // A composition interrupted by blur never gets its compositionend, so
+      // its baseline ("A") must not survive as the undo base of the next one.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onBlur())
+
+      populateEditor(editor, 'AB')
+      placeCursor(editor.firstChild!, 2)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'ABC')
+      placeCursor(editor.firstChild!, 3)
+      act(() => result.current.handleInput())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([{ type: 'text', text: 'AB' }])
 
       document.body.removeChild(editor)
       vi.useRealTimers()

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
+import { useState } from 'react'
 import { usePromptArea } from '../use-prompt-area'
 import { segmentsToPlainText } from '../prompt-area-engine'
-import type { Segment, TriggerConfig, ChipSegment } from '../types'
+import type { Segment, TriggerConfig } from '../types'
 
 // ---------------------------------------------------------------------------
 // jsdom polyfill: Range.getBoundingClientRect is not implemented
@@ -1182,8 +1183,111 @@ describe('usePromptArea', () => {
       act(() => {
         result.current.eventHandlers.onCompositionEnd()
       })
+      expect(mentionTrigger.onSearch).toHaveBeenCalled()
 
       document.body.removeChild(editor)
+    })
+
+    it('does not handle Enter while composition is active', () => {
+      const onChange = vi.fn()
+      const onSubmit = vi.fn()
+      const { result } = renderHook(() =>
+        usePromptArea(defaultProps({ onChange, onSubmit, triggers: [mentionTrigger] })),
+      )
+      const editor = attachEditor(result.current)
+
+      populateEditor(editor, '@a')
+      placeCursor(editor.firstChild!, 2)
+      act(() => result.current.handleInput())
+      expect(result.current.activeTrigger).not.toBeNull()
+      onChange.mockClear()
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      const preventDefault = vi.fn()
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'Enter',
+          preventDefault,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 13 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(onChange).not.toHaveBeenCalled()
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
+    it('ignores legacy IME keyCode 229 even when isComposing is false', () => {
+      const onSubmit = vi.fn()
+      const { result } = renderHook(() => usePromptArea(defaultProps({ onSubmit })))
+      const editor = attachEditor(result.current)
+      populateEditor(editor, 'draft')
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'Enter',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 229 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+    })
+
+    it('undoes one completed composition after a trailing duplicate input', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'hello')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      // Firefox may emit one more input with the same committed value.
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onChange).toHaveBeenCalledWith([])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
     })
   })
 
@@ -3109,6 +3213,44 @@ describe('usePromptArea', () => {
 
       document.body.removeChild(editor)
     })
+
+    it('keeps an external value update received during composition out of undo history', () => {
+      const onChange = vi.fn()
+      const { result, rerender } = renderHook(
+        ({ value }: { value: Segment[] }) => usePromptArea(defaultProps({ onChange, value })),
+        { initialProps: { value: [] as Segment[] } },
+      )
+      const editor = attachEditor(result.current)
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'local')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+
+      const externalValue: Segment[] = [{ type: 'text', text: 'remote' }]
+      rerender({ value: externalValue })
+      expect(editor.textContent).toBe('remote')
+
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      expect(onChange).toHaveBeenLastCalledWith(externalValue)
+
+      onChange.mockClear()
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onChange).not.toHaveBeenCalled()
+      expect(editor.textContent).toBe('remote')
+
+      document.body.removeChild(editor)
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -3469,6 +3611,7 @@ describe('usePromptArea', () => {
         result.current.handleKeyDown(e)
       })
 
+      expect(preventDefault).toHaveBeenCalled()
       // Should not have called onChange for formatting (may have been called by other logic)
       // The key check: preventDefault should have been called but toggleMarkdownWrap returns null
       // for collapsed selections, so onChange should NOT be called for formatting

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1501,6 +1501,64 @@ describe('usePromptArea', () => {
       vi.useRealTimers()
     })
 
+    it('flushes a pending typing undo group when a composition starts', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      // Plain typing whose undo group is still pending (debounce not elapsed)
+      // when the composition begins. compositionstart must flush that group;
+      // compositionend clears the debounce state, so without the flush the
+      // typed text would silently vanish from undo history.
+      populateEditor(editor, 'typed')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'typedあ')
+      placeCursor(editor.firstChild!, 6)
+      act(() => result.current.handleInput())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      const undoEvent = () =>
+        ({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        }) as unknown as React.KeyboardEvent<HTMLDivElement>
+
+      // First undo removes the composition...
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([{ type: 'text', text: 'typed' }])
+
+      // ...second undo removes the typed text.
+      onChange.mockClear()
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
     it('keeps committed text undoable when compositionend lands after a blur', () => {
       vi.useFakeTimers()
       const onChange = vi.fn()

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1183,6 +1183,7 @@ describe('usePromptArea', () => {
       act(() => {
         result.current.eventHandlers.onCompositionEnd()
       })
+      expect(onChange).toHaveBeenCalledTimes(1)
       expect(mentionTrigger.onSearch).toHaveBeenCalled()
 
       document.body.removeChild(editor)
@@ -1271,6 +1272,7 @@ describe('usePromptArea', () => {
       // Firefox may emit one more input with the same committed value.
       act(() => result.current.handleInput())
       act(() => vi.advanceTimersByTime(300))
+      expect(onChange).toHaveBeenCalledTimes(1)
       onChange.mockClear()
 
       act(() => {
@@ -3226,15 +3228,15 @@ describe('usePromptArea', () => {
       populateEditor(editor, 'local')
       placeCursor(editor.firstChild!, 5)
       act(() => result.current.handleInput())
+      onChange.mockClear()
 
       const externalValue: Segment[] = [{ type: 'text', text: 'remote' }]
       rerender({ value: externalValue })
       expect(editor.textContent).toBe('remote')
 
       act(() => result.current.eventHandlers.onCompositionEnd())
-      expect(onChange).toHaveBeenLastCalledWith(externalValue)
+      expect(onChange).not.toHaveBeenCalled()
 
-      onChange.mockClear()
       act(() => {
         result.current.handleKeyDown({
           key: 'z',

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area.test.ts
@@ -1324,6 +1324,183 @@ describe('usePromptArea', () => {
       vi.useRealTimers()
     })
 
+    it('creates one undo entry when a trailing input carries a further mutation (Chromium)', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'hello')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      // Chromium may emit one more non-composing input whose content differs
+      // from what compositionend observed. It belongs to the same user-visible
+      // composition, so it must not open a second undo entry.
+      populateEditor(editor, 'hello!')
+      placeCursor(editor.firstChild!, 6)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      const undoEvent = () =>
+        ({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        }) as unknown as React.KeyboardEvent<HTMLDivElement>
+
+      // First undo returns to the pre-composition state, not to the
+      // intermediate compositionend snapshot.
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
+
+      // The single entry is exhausted: a second undo is a no-op.
+      onChange.mockClear()
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('lets a real keystroke after a composition open its own undo entry', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      act(() => result.current.eventHandlers.onCompositionStart())
+      populateEditor(editor, 'hello')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      // No trailing input arrives (non-Chromium engines, or any ordering where
+      // compositionend is last). A genuine later keystroke always emits
+      // keydown before its input, which releases the ended composition's
+      // claim — so the keystroke below must get its own undo entry.
+      act(() => vi.advanceTimersByTime(1000))
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: '!',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: true,
+          nativeEvent: { isComposing: false, keyCode: 49 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+      populateEditor(editor, 'hello!')
+      placeCursor(editor.firstChild!, 6)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      const undoEvent = () =>
+        ({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        }) as unknown as React.KeyboardEvent<HTMLDivElement>
+
+      // First undo removes only the keystroke, landing on the composed text...
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([{ type: 'text', text: 'hello' }])
+
+      // ...second undo removes the composition.
+      onChange.mockClear()
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('creates one undo entry when only the trailing input mutates the DOM', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      // compositionend fires before the commit reaches the DOM: the editor
+      // still holds the pre-composition state, and the committed text arrives
+      // only with the trailing input event.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      populateEditor(editor, 'hello')
+      placeCursor(editor.firstChild!, 5)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      onChange.mockClear()
+
+      const undoEvent = () =>
+        ({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        }) as unknown as React.KeyboardEvent<HTMLDivElement>
+
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
+
+      onChange.mockClear()
+      act(() => result.current.handleKeyDown(undoEvent()))
+      expect(onChange).not.toHaveBeenCalled()
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
     it('keeps committed text undoable when compositionend lands after a blur', () => {
       vi.useFakeTimers()
       const onChange = vi.fn()
@@ -1429,6 +1606,110 @@ describe('usePromptArea', () => {
 
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(onChange).toHaveBeenCalledWith([{ type: 'text', text: 'AB' }])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('folds an over-cap trailing input into the composition undo entry', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            maxLength: 5,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      // compositionend fires before the commit reaches the DOM, and the
+      // trailing input carries text past the cap — handleInput truncates and
+      // returns early, so that branch owns the composition's undo entry.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      populateEditor(editor, 'helloX')
+      placeCursor(editor.firstChild!, 6)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      expect(segmentsToPlainText(onChange.mock.calls.at(-1)![0] as Segment[])).toBe('hello')
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
+
+      document.body.removeChild(editor)
+      vi.useRealTimers()
+    })
+
+    it('does not record an undo entry for a no-op composition over decorated text', () => {
+      vi.useFakeTimers()
+      const onChange = vi.fn()
+      const { result } = renderHook(() => {
+        const [value, setValue] = useState<Segment[]>([])
+        return usePromptArea(
+          defaultProps({
+            value,
+            markdown: true,
+            onChange: (nextValue) => {
+              onChange(nextValue)
+              setValue(nextValue)
+            },
+          }),
+        )
+      })
+      const editor = attachEditor(result.current)
+
+      populateEditor(editor, 'say **bold** now')
+      placeCursor(editor.firstChild!, 16)
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      // The decoration pass split the line into several DOM children, which
+      // the DOM reader and the single-pass scanner model differently.
+      expect(editor.querySelectorAll('span[data-md]').length).toBeGreaterThan(0)
+      expect(editor.childNodes.length).toBeGreaterThan(1)
+
+      // A composition that commits nothing, followed by the duplicate input
+      // some engines still fire. Neither changed the content, so neither may
+      // land an undo entry.
+      act(() => result.current.eventHandlers.onCompositionStart())
+      act(() => result.current.eventHandlers.onCompositionEnd())
+      act(() => result.current.handleInput())
+      act(() => vi.advanceTimersByTime(300))
+      onChange.mockClear()
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: 'z',
+          preventDefault: vi.fn(),
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          nativeEvent: { isComposing: false, keyCode: 90 },
+        } as unknown as React.KeyboardEvent<HTMLDivElement>)
+      })
+
+      // The one undo entry is the pre-composition typing, not a phantom entry
+      // holding the same text in the reader's representation.
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith([])
 
       document.body.removeChild(editor)
       vi.useRealTimers()

--- a/packages/prompt-area/src/prompt-area/cursor-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/cursor-helpers.ts
@@ -357,6 +357,15 @@ export function findDOMPosition(
       }
       remaining -= len
     } else if (isChipElement(child)) {
+      // A remaining of 0 means the caret belongs BEFORE this node. Text nodes
+      // express that for free (offset 0 inside the node), but atomic children
+      // have to say it explicitly — otherwise offset 0 collapses into the same
+      // "after the node" answer as offset === its length, landing the caret in
+      // a spot normal editing never produces. On the filler <br> the browser
+      // leaves in an emptied contentEditable, that spot is also unstable: the
+      // filler is dropped as soon as real content arrives, so an IME
+      // composition anchored there loses its node mid-flight and is cancelled.
+      if (remaining === 0) return { node: container, offset: i }
       const chipLen = chipNodeTextLength(child)
       if (remaining <= chipLen) {
         // Position after the chip element
@@ -364,6 +373,10 @@ export function findDOMPosition(
       }
       remaining -= chipLen
     } else if (isBRElement(child)) {
+      // Checked ahead of the sentinel skip: a lone sentinel is still a node the
+      // caret can sit before, and skipping it would fall through to the
+      // end-of-container fallback, i.e. after it.
+      if (remaining === 0) return { node: container, offset: i }
       if (child.dataset.sentinel) continue // skip sentinel <br>
       if (remaining <= 1) {
         return { node: container, offset: i + 1 }

--- a/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
@@ -402,9 +402,7 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
 
   const handleCompositionEnd = useCallback(() => {
     isComposing.current = false
-    // Run trigger detection after composition ends
-    runTriggerDetection()
-  }, [runTriggerDetection])
+  }, [])
 
   // -----------------------------------------------------------------------
   // Blur: dismiss trigger dropdown with delay (so popover clicks work)

--- a/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
@@ -393,7 +393,9 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
   }, [])
 
   // -----------------------------------------------------------------------
-  // IME Composition: track state, defer trigger detection
+  // IME Composition: track the composing flag. Trigger detection and undo
+  // bookkeeping for compositions live in usePromptArea's wrappers around
+  // these handlers.
   // -----------------------------------------------------------------------
 
   const handleCompositionStart = useCallback(() => {
@@ -409,11 +411,10 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
   // -----------------------------------------------------------------------
 
   const handleBlur = useCallback(() => {
-    // A blurred contentEditable cannot still be mid-composition. If focus was
-    // stolen mid-IME (click elsewhere, window switch) the browser may never
-    // deliver compositionend, and a stale flag here would swallow every later
-    // keystroke via handleKeyDown's composition guard. Reset synchronously —
-    // the dismiss below is deliberately delayed, this must not be.
+    // A blurred contentEditable cannot still be mid-composition, and the
+    // browser may never deliver compositionend once focus is gone. Reset
+    // synchronously — the dismiss below is deliberately delayed, this must
+    // not be.
     isComposing.current = false
 
     setTimeout(() => {

--- a/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
@@ -409,6 +409,13 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
   // -----------------------------------------------------------------------
 
   const handleBlur = useCallback(() => {
+    // A blurred contentEditable cannot still be mid-composition. If focus was
+    // stolen mid-IME (click elsewhere, window switch) the browser may never
+    // deliver compositionend, and a stale flag here would swallow every later
+    // keystroke via handleKeyDown's composition guard. Reset synchronously —
+    // the dismiss below is deliberately delayed, this must not be.
+    isComposing.current = false
+
     setTimeout(() => {
       const editor = editorRef.current
       if (!editor) return

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -359,6 +359,7 @@ export function usePromptArea({
   // Debounced undo: groups consecutive keystrokes into a single undo snapshot
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const undoBaseState = useRef<Segment[] | null>(null)
+  const compositionBaseState = useRef<Segment[] | null>(null)
 
   // -----------------------------------------------------------------------
   // DOM -> Model: read segments from the contentEditable DOM
@@ -659,7 +660,8 @@ export function usePromptArea({
     }
 
     renderSegmentsToDOM(value)
-  }, [value, renderSegmentsToDOM, markdownEnabled, normalizeBullets, onChange])
+    if (events.isComposing.current) compositionBaseState.current = value
+  }, [value, renderSegmentsToDOM, markdownEnabled, normalizeBullets, onChange, events.isComposing])
 
   // Re-render when markdown mode changes to apply/strip decorations
   // Also convert bullet characters: • ↔ - in text segments
@@ -792,20 +794,23 @@ export function usePromptArea({
 
     // Debounced undo: capture the pre-edit state at the start of a typing
     // session and push it to the undo stack after UNDO_DEBOUNCE_MS of idle.
-    if (!undoBaseState.current) {
+    const contentChanged = !segmentsEqual(nextSegments, lastRenderedValue.current)
+    if (contentChanged && !undoBaseState.current) {
       undoBaseState.current = lastRenderedValue.current
     }
 
     lastRenderedValue.current = nextSegments
     onChange(nextSegments)
-    if (undoTimer.current) clearTimeout(undoTimer.current)
-    undoTimer.current = setTimeout(() => {
-      if (undoBaseState.current) {
-        events.pushUndo(undoBaseState.current)
-        undoBaseState.current = null
-      }
-      undoTimer.current = null
-    }, UNDO_DEBOUNCE_MS)
+    if (contentChanged) {
+      if (undoTimer.current) clearTimeout(undoTimer.current)
+      undoTimer.current = setTimeout(() => {
+        if (undoBaseState.current) {
+          events.pushUndo(undoBaseState.current)
+          undoBaseState.current = null
+        }
+        undoTimer.current = null
+      }, UNDO_DEBOUNCE_MS)
+    }
 
     // Apply the recomputed model to the DOM. A renumber rewrites text nodes,
     // so it needs a full re-render (which also re-decorates). Otherwise the
@@ -1342,6 +1347,14 @@ export function usePromptArea({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (
+        events.isComposing.current ||
+        e.nativeEvent.isComposing ||
+        e.nativeEvent.keyCode === 229
+      ) {
+        return
+      }
+
       const applyEditResult = (
         editor: HTMLDivElement,
         result: { segments: Segment[]; cursorOffset: number },
@@ -1420,13 +1433,7 @@ export function usePromptArea({
       // the typed key actually matching a launch char, so it stays off the hot
       // path. insertChip still inserts a chip at the cursor if the consumer
       // wants one after the external selection.
-      if (
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.altKey &&
-        !e.nativeEvent.isComposing &&
-        e.key.length === 1
-      ) {
+      if (!e.metaKey && !e.ctrlKey && !e.altKey && e.key.length === 1) {
         const launcher = triggers.find((t) => t.mode === 'launch' && t.char === e.key)
         const editor = editorRef.current
         if (launcher?.onActivate && editor) {
@@ -1631,7 +1638,7 @@ export function usePromptArea({
       }
 
       // 2.8 Shift+Enter always inserts a newline (after a list-continuation check).
-      if (e.key === 'Enter' && e.shiftKey && !e.nativeEvent.isComposing) {
+      if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault()
         const editor = editorRef.current
         if (editor && !tryListContinuation(editor)) insertPlainNewline(editor)
@@ -1640,7 +1647,7 @@ export function usePromptArea({
 
       // 3. Enter without Shift (skipping IME): continue a list, else submit when
       // `submitOnEnter` is set, else insert a newline.
-      if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      if (e.key === 'Enter' && !e.shiftKey) {
         const editor = editorRef.current
         if (editor && tryListContinuation(editor)) {
           e.preventDefault()
@@ -1663,7 +1670,7 @@ export function usePromptArea({
       }
 
       // 4.5 Non-collapsed selection delete (Backspace/Delete across <a> boundaries)
-      if ((e.key === 'Backspace' || e.key === 'Delete') && !e.nativeEvent.isComposing) {
+      if (e.key === 'Backspace' || e.key === 'Delete') {
         const editor = editorRef.current
         if (editor) {
           const offsets = getSelectionOffsets(editor)
@@ -1816,6 +1823,33 @@ export function usePromptArea({
   // Compose event handlers
   // -----------------------------------------------------------------------
 
+  const handleCompositionStart = useCallback(() => {
+    if (undoTimer.current) {
+      clearTimeout(undoTimer.current)
+      undoTimer.current = null
+    }
+    if (undoBaseState.current) {
+      events.pushUndo(undoBaseState.current)
+      undoBaseState.current = null
+    }
+    compositionBaseState.current = readSegmentsFromDOM()
+    events.handleCompositionStart()
+  }, [events, readSegmentsFromDOM])
+
+  const handleCompositionEnd = useCallback(() => {
+    events.handleCompositionEnd()
+    handleInput()
+    if (undoTimer.current) clearTimeout(undoTimer.current)
+    undoTimer.current = null
+    undoBaseState.current = null
+
+    const before = compositionBaseState.current
+    compositionBaseState.current = null
+    if (before && !segmentsEqual(before, readSegmentsFromDOM())) {
+      events.pushUndo(before)
+    }
+  }, [events, handleInput, readSegmentsFromDOM])
+
   const eventHandlers = useMemo(
     () => ({
       onPaste: events.handlePaste,
@@ -1823,8 +1857,8 @@ export function usePromptArea({
       onCut: events.handleCut,
       onDrop: events.handleDrop,
       onDragOver: events.handleDragOver,
-      onCompositionStart: events.handleCompositionStart,
-      onCompositionEnd: events.handleCompositionEnd,
+      onCompositionStart: handleCompositionStart,
+      onCompositionEnd: handleCompositionEnd,
       onBlur: events.handleBlur,
     }),
     [
@@ -1833,8 +1867,8 @@ export function usePromptArea({
       events.handleCut,
       events.handleDrop,
       events.handleDragOver,
-      events.handleCompositionStart,
-      events.handleCompositionEnd,
+      handleCompositionStart,
+      handleCompositionEnd,
       events.handleBlur,
     ],
   )

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -360,6 +360,15 @@ export function usePromptArea({
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const undoBaseState = useRef<Segment[] | null>(null)
   const compositionBaseState = useRef<Segment[] | null>(null)
+  // After compositionend, Chromium can fire one more non-composing input
+  // event carrying the committed mutation. That event belongs to the
+  // composition that just ended, not to a new typing session: this ref hands
+  // the composition's undo base (and whether compositionend already pushed
+  // it) to handleInput so the trailing event folds into the same single undo
+  // entry instead of seeding a second one. Set at compositionend; consumed by
+  // the next non-composing handleInput; cleared on compositionstart and blur
+  // so it can never go stale across sessions.
+  const postCompositionUndo = useRef<{ base: Segment[]; pushed: boolean } | null>(null)
 
   // -----------------------------------------------------------------------
   // DOM -> Model: read segments from the contentEditable DOM
@@ -660,6 +669,9 @@ export function usePromptArea({
     }
 
     renderSegmentsToDOM(value)
+    // An authoritative external render invalidates the trailing-input handoff:
+    // the next input edits this value, not the ended composition's commit.
+    postCompositionUndo.current = null
     if (events.isComposing.current) compositionBaseState.current = value
   }, [value, renderSegmentsToDOM, markdownEnabled, normalizeBullets, onChange, events.isComposing])
 
@@ -699,6 +711,26 @@ export function usePromptArea({
       lastRenderedValue.current = segments
       onChange(segments)
       return
+    }
+
+    // A just-ended composition claims this one input event (the trailing
+    // input Chromium fires after compositionend), so detach the claim here,
+    // ahead of every early return below: whichever branch ends up handling
+    // this event owes the composition its undo entry, and no later unrelated
+    // input may inherit the claim.
+    const afterComposition = postCompositionUndo.current
+    postCompositionUndo.current = null
+
+    // The branches that return early still have to settle that claim: push
+    // the base when compositionend did not already and the content really
+    // moved away from it. The base was read by readSegmentsFromDOM, which
+    // splits decoration elements into their own segments where the scanner
+    // merges them, so identical content compares equal only as plain text.
+    const settleClaimedUndo = (finalText: string) => {
+      if (!afterComposition || afterComposition.pushed) return
+      if (segmentsToPlainText(afterComposition.base) !== finalText) {
+        events.pushUndo(afterComposition.base)
+      }
     }
 
     const editor = editorRef.current
@@ -745,6 +777,8 @@ export function usePromptArea({
     if (maxLength != null && editor && plainText.length > maxLength) {
       const caret = domNormalized ? getCursorOffset(editor) : savedCursorOffset
       const truncated = truncateSegmentsToLength(segments, maxLength)
+      const truncatedText = segmentsToPlainText(truncated)
+      settleClaimedUndo(truncatedText)
       lastRenderedValue.current = truncated
       onChange(truncated)
       renderSegmentsToDOM(truncated)
@@ -752,7 +786,7 @@ export function usePromptArea({
       setCursorAtOffset(editor, clamped)
       runTriggerDetection({
         segments: truncated,
-        plainText: segmentsToPlainText(truncated),
+        plainText: truncatedText,
         cursorPos: clamped,
       })
       return
@@ -762,13 +796,15 @@ export function usePromptArea({
     if (markdownEnabled && normalizeBullets && editor && savedCursorOffset !== null) {
       const formatted = autoFormatListPrefix(segments, savedCursorOffset, plainText)
       if (formatted) {
+        const formattedText = segmentsToPlainText(formatted.segments)
+        settleClaimedUndo(formattedText)
         lastRenderedValue.current = formatted.segments
         onChange(formatted.segments)
         renderSegmentsToDOM(formatted.segments)
         setCursorAtOffset(editor, formatted.cursorOffset)
         runTriggerDetection({
           segments: formatted.segments,
-          plainText: segmentsToPlainText(formatted.segments),
+          plainText: formattedText,
           cursorPos: formatted.cursorOffset,
         })
         return
@@ -795,13 +831,17 @@ export function usePromptArea({
     // Debounced undo: capture the pre-edit state at the start of a typing
     // session and push it to the undo stack after UNDO_DEBOUNCE_MS of idle.
     const contentChanged = !segmentsEqual(nextSegments, lastRenderedValue.current)
-    if (contentChanged && !undoBaseState.current) {
-      undoBaseState.current = lastRenderedValue.current
-    }
 
-    lastRenderedValue.current = nextSegments
-    if (contentChanged) onChange(nextSegments)
-    if (contentChanged) {
+    // The mutation a claimed event carries is part of the composition that
+    // just ended, so it must not open a new undo group seeded with the
+    // intermediate compositionend snapshot — the composition's own base is
+    // the only entry this session gets.
+    if (afterComposition) {
+      if (!afterComposition.pushed && contentChanged) {
+        events.pushUndo(afterComposition.base)
+      }
+    } else if (contentChanged) {
+      if (!undoBaseState.current) undoBaseState.current = lastRenderedValue.current
       if (undoTimer.current) clearTimeout(undoTimer.current)
       undoTimer.current = setTimeout(() => {
         if (undoBaseState.current) {
@@ -811,6 +851,9 @@ export function usePromptArea({
         undoTimer.current = null
       }, UNDO_DEBOUNCE_MS)
     }
+
+    lastRenderedValue.current = nextSegments
+    if (contentChanged) onChange(nextSegments)
 
     // Apply the recomputed model to the DOM. A renumber rewrites text nodes,
     // so it needs a full re-render (which also re-decorates). Otherwise the
@@ -963,6 +1006,10 @@ export function usePromptArea({
   // -----------------------------------------------------------------------
 
   const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // A click repositions the caret, so the next input is a fresh edit rather
+    // than an ended composition's trailing event.
+    postCompositionUndo.current = null
+
     const target = e.target
     const editor = editorRef.current
     if (!editor || !(target instanceof Node)) {
@@ -1354,6 +1401,13 @@ export function usePromptArea({
       ) {
         return
       }
+
+      // Any real keydown bounds a just-ended composition's claim on the next
+      // input event: Chromium's trailing input follows compositionend with no
+      // keydown possible in between, so a keydown here means the next input
+      // belongs to a new keystroke, not the ended composition. (Placed after
+      // the guard above so composition keydowns don't release the claim.)
+      postCompositionUndo.current = null
 
       const applyEditResult = (
         editor: HTMLDivElement,
@@ -1832,6 +1886,9 @@ export function usePromptArea({
       events.pushUndo(undoBaseState.current)
       undoBaseState.current = null
     }
+    // A new composition supersedes any unconsumed trailing-input claim from
+    // the previous one.
+    postCompositionUndo.current = null
     compositionBaseState.current = readSegmentsFromDOM()
     events.handleCompositionStart()
   }, [events, readSegmentsFromDOM])
@@ -1857,9 +1914,13 @@ export function usePromptArea({
     undoTimer.current = null
     undoBaseState.current = null
 
-    if (!segmentsEqual(before, readSegmentsFromDOM())) {
-      events.pushUndo(before)
-    }
+    // Push the pre-composition state as the composition's single undo entry
+    // (skipped when the commit didn't change anything — or hasn't reached
+    // the DOM yet). Either way, hand the base to handleInput for the one
+    // trailing input event Chromium may still fire for this composition.
+    const pushed = !segmentsEqual(before, readSegmentsFromDOM())
+    if (pushed) events.pushUndo(before)
+    postCompositionUndo.current = { base: before, pushed }
   }, [events, handleInput, readSegmentsFromDOM])
 
   const handleBlur = useCallback(() => {
@@ -1869,6 +1930,7 @@ export function usePromptArea({
     // the composition undo baseline for the same reason — without a
     // compositionend it must not seed a future composition's undo entry.
     compositionBaseState.current = null
+    postCompositionUndo.current = null
     events.handleBlur()
   }, [events])
 

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -800,7 +800,7 @@ export function usePromptArea({
     }
 
     lastRenderedValue.current = nextSegments
-    onChange(nextSegments)
+    if (contentChanged) onChange(nextSegments)
     if (contentChanged) {
       if (undoTimer.current) clearTimeout(undoTimer.current)
       undoTimer.current = setTimeout(() => {

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -1839,16 +1839,38 @@ export function usePromptArea({
   const handleCompositionEnd = useCallback(() => {
     events.handleCompositionEnd()
     handleInput()
+
+    const before = compositionBaseState.current
+    compositionBaseState.current = null
+    if (!before) {
+      // No baseline: blur already closed this session's bookkeeping and the
+      // compositionend arrived late. There is no composition undo entry to
+      // record, and the debounced group the handleInput above just opened
+      // holds the pre-composition value — cancelling it here would make the
+      // committed text un-undoable. Leave the ordinary path to record it.
+      return
+    }
+
+    // The composition owns this session's undo entry, so the debounced group
+    // handleInput opened for the commit is redundant.
     if (undoTimer.current) clearTimeout(undoTimer.current)
     undoTimer.current = null
     undoBaseState.current = null
 
-    const before = compositionBaseState.current
-    compositionBaseState.current = null
-    if (before && !segmentsEqual(before, readSegmentsFromDOM())) {
+    if (!segmentsEqual(before, readSegmentsFromDOM())) {
       events.pushUndo(before)
     }
   }, [events, handleInput, readSegmentsFromDOM])
+
+  const handleBlur = useCallback(() => {
+    // events.handleBlur resets the isComposing flag: a blurred editor cannot
+    // still be mid-composition, and the browser may never deliver the
+    // compositionend for an IME session interrupted by a focus change. Drop
+    // the composition undo baseline for the same reason — without a
+    // compositionend it must not seed a future composition's undo entry.
+    compositionBaseState.current = null
+    events.handleBlur()
+  }, [events])
 
   const eventHandlers = useMemo(
     () => ({
@@ -1859,7 +1881,7 @@ export function usePromptArea({
       onDragOver: events.handleDragOver,
       onCompositionStart: handleCompositionStart,
       onCompositionEnd: handleCompositionEnd,
-      onBlur: events.handleBlur,
+      onBlur: handleBlur,
     }),
     [
       events.handlePaste,
@@ -1869,7 +1891,7 @@ export function usePromptArea({
       events.handleDragOver,
       handleCompositionStart,
       handleCompositionEnd,
-      events.handleBlur,
+      handleBlur,
     ],
   )
 

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -359,15 +359,22 @@ export function usePromptArea({
   // Debounced undo: groups consecutive keystrokes into a single undo snapshot
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const undoBaseState = useRef<Segment[] | null>(null)
+  // Undo base for the IME session in flight: the segments as they were when
+  // the composition began. Written at compositionstart (from the DOM) and by
+  // the value-sync effect when an external value lands mid-composition; read
+  // and cleared at compositionend, where it becomes the session's single undo
+  // entry and seeds postCompositionUndo below; dropped on blur, since an
+  // interrupted composition may never get its compositionend.
   const compositionBaseState = useRef<Segment[] | null>(null)
   // After compositionend, Chromium can fire one more non-composing input
   // event carrying the committed mutation. That event belongs to the
   // composition that just ended, not to a new typing session: this ref hands
   // the composition's undo base (and whether compositionend already pushed
   // it) to handleInput so the trailing event folds into the same single undo
-  // entry instead of seeding a second one. Set at compositionend; consumed by
-  // the next non-composing handleInput; cleared on compositionstart and blur
-  // so it can never go stale across sessions.
+  // entry instead of seeding a second one. Set at compositionend and consumed
+  // by the next non-composing input; revoked by any real keydown, a new
+  // compositionstart, a blur, an external value render, or a mousedown — each
+  // means the next input cannot be the composition's trailing event.
   const postCompositionUndo = useRef<{ base: Segment[]; pushed: boolean } | null>(null)
 
   // -----------------------------------------------------------------------
@@ -673,7 +680,8 @@ export function usePromptArea({
     // the next input edits this value, not the ended composition's commit.
     postCompositionUndo.current = null
     if (events.isComposing.current) compositionBaseState.current = value
-  }, [value, renderSegmentsToDOM, markdownEnabled, normalizeBullets, onChange, events.isComposing])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- events.isComposing is a ref: identity-stable, and .current reads must not re-run the effect
+  }, [value, renderSegmentsToDOM, markdownEnabled, normalizeBullets, onChange])
 
   // Re-render when markdown mode changes to apply/strip decorations
   // Also convert bullet characters: • ↔ - in text segments
@@ -1649,12 +1657,14 @@ export function usePromptArea({
 
         const pos = findDOMPosition(editor, offset)
         if (!pos) return false
-        // findDOMPosition resolves boundary offsets with a caret bias: an
-        // offset at the start of a chip (or of a <br> on an empty line) maps
-        // to the position AFTER that element. Fine for placing a caret, wrong
-        // for structural insertion — the model puts the newline BEFORE the
-        // element. Only proceed when the mapping round-trips to the exact
-        // offset; otherwise the full re-render handles it.
+        // A boundary offset in front of an atomic child (a leading chip, a
+        // <br> on an empty line) resolves BEFORE that element, which is where
+        // the model puts the newline too, so those cases insert here. An
+        // offset that falls INSIDE a chip has no such position — the chip is
+        // atomic, so findDOMPosition answers with the spot after it, which is
+        // not where the model's newline goes. Only proceed when the mapping
+        // round-trips to the exact offset; otherwise the full re-render
+        // handles it.
         if (getTextOffsetAtPoint(editor, pos.node, pos.offset) !== offset) return false
 
         const br = document.createElement('br')
@@ -1924,11 +1934,8 @@ export function usePromptArea({
   }, [events, handleInput, readSegmentsFromDOM])
 
   const handleBlur = useCallback(() => {
-    // events.handleBlur resets the isComposing flag: a blurred editor cannot
-    // still be mid-composition, and the browser may never deliver the
-    // compositionend for an IME session interrupted by a focus change. Drop
-    // the composition undo baseline for the same reason — without a
-    // compositionend it must not seed a future composition's undo entry.
+    // Blur ends any in-flight composition (events.handleBlur resets the flag);
+    // composition undo state must not survive into a future session.
     compositionBaseState.current = null
     postCompositionUndo.current = null
     events.handleBlur()


### PR DESCRIPTION
## Summary

Improves IME handling around composition completion, undo, and controlled value updates, and fixes an independent caret-resolution bug at offset 0. No public API changes.

## What changed

### IME composition handling

- Skip editor keyboard handling while an IME composition is active; blur resets the composing state, so an interrupted composition cannot leave the keyboard disabled once focus moves away.
- Apply max-length enforcement and trigger detection when composition completes.
- Group a completed composition into a single undo step, across both browser orderings of `compositionend` and the final `input` event.
- Keep external controlled values authoritative and out of local undo history.
- Suppress `onChange` for input events that leave the model unchanged. This covers the duplicate post-composition notifications (Firefox's identical echo) but is a general contract change: previously every input event notified, now only real changes do.

### Independent fix: caret resolution at offset 0 (`cursor-helpers.ts`)

Not IME-specific. When the first child of the editor is atomic (a chip or `<br>`), `findDOMPosition` resolved offset 0 to the position after it, so both caret-placement paths (`setCursorAtOffset` and `setSelectionAtOffsets`) put the caret one position too far in content that starts with a chip. Offset 0 now resolves to the position before the atomic child. Verified in real Chromium against a chip-leading prompt: typing at offset 0 lands outside the chip, and a caret at offset 0 survives a controlled value update in place (previously it jumped past the chip).

## Testing

- Regression coverage for composition completion, undo grouping, controlled value updates, blur during composition, and both cross-browser trailing-input orderings.
- One pre-existing identity test was updated: it simulated a second keystroke without mutating the DOM, which now counts (by design) as a duplicate input event and is deduped.
- Rebased onto current `main`; the full suite, lint, type checks, package build, export checks, and size budgets are green.
