### PR TITLE
fix(prompt-area): paste Word clipboards as text and convert mso lists

### DIFF
--- a/app/docs/api/prompt-area/page.tsx
+++ b/app/docs/api/prompt-area/page.tsx
@@ -50,7 +50,7 @@ export default function PromptAreaApiPage() {
             name: 'markdown',
             type: 'boolean',
             description:
-              'Render inline markdown (bold, italic, URLs, lists). Also enables rich paste: content from Slack, Notion, Google Docs, GitHub, or the web is converted to markdown source (preferring text/markdown, then text/html), and pasted list bullets normalize to •.',
+              'Render inline markdown (bold, italic, URLs, lists). Also enables rich paste: content from Word, Slack, Notion, Google Docs, GitHub, or the web is converted to markdown source (preferring text/markdown, then text/html), and pasted list bullets normalize to •.',
           },
           {
             name: 'markdownHeadings',

--- a/app/docs/examples/formatting/page.tsx
+++ b/app/docs/examples/formatting/page.tsx
@@ -17,7 +17,7 @@ const SITE_URL = 'https://prompt-area.com'
 export const metadata: Metadata = {
   title: 'Formatting',
   description:
-    'Live examples of inline markdown formatting (bold, italic, URLs, lists), a markdown / plain-text toggle with useMarkdownMode, rich paste to markdown from Slack / Notion / Google Docs, and animated rotating placeholders in Prompt Area.',
+    'Live examples of inline markdown formatting (bold, italic, URLs, lists), a markdown / plain-text toggle with useMarkdownMode, rich paste to markdown from Word / Slack / Notion / Google Docs, and animated rotating placeholders in Prompt Area.',
   alternates: { canonical: `${SITE_URL}/docs/examples/formatting` },
 }
 
@@ -45,7 +45,7 @@ export default function FormattingExamplesPage() {
       <DocsExample
         id="rich-paste"
         title="Rich paste to markdown"
-        description="With markdown on, paste from Slack, Notion, Google Docs, GitHub, or any web page and it converts to clean markdown source — nested lists, bold, italic, links, and code. Bullets normalize to •, and Slack's text/markdown (with proper nesting) is preferred over its flattened plain text."
+        description="With markdown on, paste from Word, Slack, Notion, Google Docs, GitHub, or any web page and it converts to clean markdown source — nested lists, bold, italic, links, and code. Bullets normalize to •, and Slack's text/markdown (with proper nesting) is preferred over its flattened plain text."
         code={richPasteCode}>
         <RichPasteExample />
       </DocsExample>

--- a/app/examples/rich-paste.tsx
+++ b/app/examples/rich-paste.tsx
@@ -13,7 +13,7 @@ export function RichPasteExample() {
           value={segments}
           onChange={setSegments}
           markdown
-          placeholder="Paste from Slack, Notion, Google Docs, GitHub, or any web page — rich text becomes clean markdown..."
+          placeholder="Paste from Word, Slack, Notion, Google Docs, GitHub, or any web page — rich text becomes clean markdown..."
           minHeight={110}
         />
       </div>
@@ -36,7 +36,7 @@ function RichPasteExample() {
 
   // With \`markdown\` on, paste reads the richest clipboard flavor available:
   //   1. text/markdown — e.g. Slack "Copy message" (keeps nested lists)
-  //   2. text/html     — Notion, Google Docs, GitHub, web pages
+  //   2. text/html     — Word, Notion, Google Docs, GitHub, web pages
   //   3. text/plain    — fallback
   // The result is stored as markdown source, so \`value\` is ready to send.
   const markdown = segmentsToPlainText(segments)
@@ -47,7 +47,7 @@ function RichPasteExample() {
         value={segments}
         onChange={setSegments}
         markdown
-        placeholder="Paste from Slack, Notion, Google Docs, GitHub, or any web page..."
+        placeholder="Paste from Word, Slack, Notion, Google Docs, GitHub, or any web page..."
         minHeight={110}
       />
       <pre>{markdown}</pre>

--- a/app/sections/features-grid.tsx
+++ b/app/sections/features-grid.tsx
@@ -27,7 +27,7 @@ const FEATURES = [
     icon: Type,
     title: 'Inline Markdown & Rich Paste',
     description:
-      'Bold, italic, lists, and auto-linked URLs render live as you type. Paste from Slack, Notion, or Google Docs and it converts to clean markdown.',
+      'Bold, italic, lists, and auto-linked URLs render live as you type. Paste from Word, Slack, Notion, or Google Docs and it converts to clean markdown.',
   },
   {
     icon: RotateCcw,

--- a/packages/prompt-area/.size-limit.json
+++ b/packages/prompt-area/.size-limit.json
@@ -4,14 +4,14 @@
     "path": "dist/index.js",
     "import": "*",
     "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
-    "limit": "18 KB"
+    "limit": "18.5 KB"
   },
   {
     "name": "prompt-area (component)",
     "path": "dist/prompt-area/index.js",
     "import": "*",
     "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
-    "limit": "16.5 KB"
+    "limit": "17 KB"
   },
   {
     "name": "helpers (RSC-safe)",

--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.6.5
+
+### Fixed
+
+- **Pasting from Microsoft Word inserts the text instead of silently dropping
+  it.** Word (macOS especially) puts a bitmap rendering of the copied selection
+  on the clipboard next to its HTML; the image branch of the paste handler
+  consumed it and returned before any text flavor was read, so with no
+  `onImagePaste` consumer wired nothing happened at all. Office clipboards
+  (detected via their `mso-`/`Mso`/ProgId/office-xmlns fingerprints) now let
+  the text path win; the bitmap is only delivered to `onImagePaste` when the
+  clipboard yields no text — e.g. an image or drawing object copied inside
+  Word. Non-Office pastes are unchanged: a copied image still takes precedence
+  over incidental `<img>` HTML.
+- **Word lists convert to real markdown lists.** Word's clipboard HTML has no
+  `<ul>`/`<ol>` — each item is an `mso-list` paragraph carrying its marker
+  glyph (`·`, `o`, `1.`, `a.`, …) in a hidden `mso-list:Ignore` span behind
+  conditional comments. Runs of those paragraphs now become nested markdown
+  lists (2-space indent per level, per-level numbering seeded from Word's own
+  digits, bullets normalizing to `•`) instead of literal `·` lines separated by
+  blank lines, and Word's `<o:p>` placeholders and `<xml>` data islands no
+  longer leak junk text into the paste.
+
 ## 0.6.3
 
 ### Fixed

--- a/packages/prompt-area/src/prompt-area/__tests__/html-to-markdown.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/html-to-markdown.test.ts
@@ -1,5 +1,53 @@
 import { describe, it, expect } from 'vitest'
-import { htmlToMarkdown } from '../html-to-markdown'
+import { htmlToMarkdown, isOfficeHtml } from '../html-to-markdown'
+
+/**
+ * Abridged but structurally faithful Word-for-Mac clipboard HTML: office xmlns
+ * declarations, ProgId meta, an `<xml>` data island (which the HTML parser
+ * reparents out of `<head>` into `<body>`), a `<style>` block, StartFragment
+ * markers, and an mso-list paragraph run — levels 1/2/1 with the `·` (Symbol)
+ * and `o` (Courier New) marker glyphs inside `mso-list:Ignore` spans behind
+ * downlevel-revealed `<![if !supportLists]>` conditional comments, plus `<o:p>`
+ * placeholders. Word emits unquoted classes and single-quoted styles.
+ */
+const WORD_MAC_BULLETS = `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 15">
+<xml><w:WordDocument><w:View>Normal</w:View><w:Zoom>0</w:Zoom></w:WordDocument></xml>
+<style><!--
+p.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst
+\t{mso-style-priority:34;margin-bottom:0in;mso-add-space:auto;text-indent:-.25in;}
+--></style>
+</head>
+<body lang=EN-US style='tab-interval:.5in'>
+<!--StartFragment-->
+<p class=MsoListParagraphCxSpFirst style='text-indent:-.25in;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+style='font-family:Symbol;mso-fareast-font-family:Symbol;mso-bidi-font-family:Symbol'><span
+style='mso-list:Ignore'>·<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]>Alpha<o:p></o:p></p>
+<p class=MsoListParagraphCxSpMiddle style='margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;mso-list:l0 level2 lfo1'><![if !supportLists]><span
+style='font-family:"Courier New";mso-fareast-font-family:"Courier New"'><span
+style='mso-list:Ignore'>o<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;
+</span></span></span><![endif]>Beta<o:p></o:p></p>
+<p class=MsoListParagraphCxSpLast style='text-indent:-.25in;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+style='font-family:Symbol'><span style='mso-list:Ignore'>·<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]>Gamma<o:p></o:p></p>
+<!--EndFragment-->
+</body>
+</html>`
+
+/** Word list item in the Windows form: normal-comment-wrapped Ignore span. */
+function wordItem(level: number, marker: string, text: string): string {
+  return (
+    `<p class=MsoListParagraphCxSpMiddle style='text-indent:-.25in;mso-list:l0 level${level} lfo1'>` +
+    `<!--[if !supportLists]--><span style='mso-list:Ignore'>${marker}<span ` +
+    `style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp; </span></span><!--[endif]-->` +
+    `${text}<o:p></o:p></p>`
+  )
+}
 
 describe('htmlToMarkdown', () => {
   // -------------------------------------------------------------------------
@@ -211,6 +259,81 @@ describe('htmlToMarkdown', () => {
   })
 
   // -------------------------------------------------------------------------
+  // Microsoft Word clipboard HTML (mso-list paragraphs — no <ul>/<ol>)
+  // -------------------------------------------------------------------------
+
+  it('converts a Word bullet list (mso-list paragraphs) to markdown bullets', () => {
+    // Also proves: no blank lines between items, marker glyphs (·/o) and their
+    // nbsp runs removed, level 2 → 2-space indent, <xml>/<o:p> junk excluded.
+    expect(htmlToMarkdown(WORD_MAC_BULLETS)).toBe('- Alpha\n  - Beta\n- Gamma')
+  })
+
+  it('converts a Word ordered list with per-level numbering (1. / a. markers)', () => {
+    const html =
+      wordItem(1, '1.', 'First') +
+      wordItem(2, 'a.', 'Sub one') +
+      wordItem(2, 'b.', 'Sub two') +
+      wordItem(1, '2.', 'Second')
+    expect(htmlToMarkdown(html)).toBe('1. First\n  1. Sub one\n  2. Sub two\n2. Second')
+  })
+
+  it('separates a Word list from surrounding paragraphs by one blank line', () => {
+    const html =
+      '<p class=MsoNormal>Intro:</p>' +
+      wordItem(1, '·', 'A') +
+      wordItem(1, '·', 'B') +
+      '<p class=MsoNormal>After</p>'
+    expect(htmlToMarkdown(html)).toBe('Intro:\n\n- A\n- B\n\nAfter')
+  })
+
+  it("restarts a Word list run after an interrupting paragraph, keeping Word's numbers", () => {
+    const html =
+      wordItem(1, '1.', 'a') +
+      wordItem(1, '2.', 'b') +
+      '<p class=MsoNormal>para</p>' +
+      wordItem(1, '3.', 'c') +
+      wordItem(1, '4.', 'd')
+    expect(htmlToMarkdown(html)).toBe('1. a\n2. b\n\npara\n\n3. c\n4. d')
+  })
+
+  it('handles the bogus-comment <![if !supportLists]> form (Word for Mac)', () => {
+    const html =
+      "<p class=MsoListParagraph style='mso-list:l0 level1 lfo1'><![if !supportLists]>" +
+      "<span style='mso-list:Ignore'>·&nbsp;&nbsp;</span><![endif]>Item</p>"
+    expect(htmlToMarkdown(html)).toBe('- Item')
+  })
+
+  it('handles the commented <!--[if !supportLists]--> form (Word for Windows)', () => {
+    expect(htmlToMarkdown(wordItem(1, '·', 'Item'))).toBe('- Item')
+  })
+
+  it('falls back to a bullet when the marker is hidden inside one conditional comment', () => {
+    // Filtered/Outlook HTML hides the whole marker span in a single comment,
+    // so no marker text is available for ordered/bullet classification.
+    const html =
+      "<p class=MsoListParagraph style='mso-list:l0 level1 lfo1'>" +
+      "<!--[if !supportLists]><span style='mso-list:Ignore'>1.</span><![endif]-->Item</p>"
+    expect(htmlToMarkdown(html)).toBe('- Item')
+  })
+
+  it('does not treat a marker-less MsoListParagraph continuation as a list item', () => {
+    // Word puts the MsoListParagraph class (without mso-list metadata) on
+    // wrapped continuation paragraphs under a bullet — those are prose.
+    const html =
+      wordItem(1, '·', 'One') +
+      '<p class=MsoListParagraph>continued text</p>' +
+      wordItem(1, '·', 'Two')
+    expect(htmlToMarkdown(html)).toBe('- One\n\ncontinued text\n\n- Two')
+  })
+
+  it('drops Word <o:p> placeholders and <xml> islands', () => {
+    const html =
+      '<xml><w:Data>junk</w:Data></xml>' +
+      '<p class=MsoNormal>Hi<o:p></o:p></p><p class=MsoNormal><o:p>&nbsp;</o:p></p>'
+    expect(htmlToMarkdown(html)).toBe('Hi')
+  })
+
+  // -------------------------------------------------------------------------
   // Unwrapping, entities, whitespace, escaping
   // -------------------------------------------------------------------------
 
@@ -250,5 +373,28 @@ describe('htmlToMarkdown', () => {
 
   it('caps consecutive blank lines at one between blocks', () => {
     expect(htmlToMarkdown('<p>a</p>\n\n\n<p>b</p>')).toBe('a\n\nb')
+  })
+})
+
+describe('isOfficeHtml', () => {
+  it('detects the Word clipboard fingerprints', () => {
+    expect(isOfficeHtml(WORD_MAC_BULLETS)).toBe(true)
+    expect(isOfficeHtml('<meta name=ProgId content=Word.Document><p>x</p>')).toBe(true)
+    expect(isOfficeHtml('<p class=MsoNormal>x</p>')).toBe(true)
+    expect(isOfficeHtml('<p class="MsoNormal">x</p>')).toBe(true)
+    expect(isOfficeHtml('<span style="mso-bidi-font-weight:bold">x</span>')).toBe(true)
+    expect(isOfficeHtml('<html xmlns:o="urn:schemas-microsoft-com:office:office">x</html>')).toBe(
+      true,
+    )
+  })
+
+  it('does not flag non-Office html', () => {
+    expect(isOfficeHtml('')).toBe(false)
+    expect(isOfficeHtml('<p>plain</p>')).toBe(false)
+    expect(isOfficeHtml('<img src="https://x.com/a.png">')).toBe(false)
+    // Google-Docs-shaped clipboard html must keep its current image-vs-text behavior.
+    expect(isOfficeHtml('<b style="font-weight:normal" id="docs-internal-guid-abc">x</b>')).toBe(
+      false,
+    )
   })
 })

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-markdown-paste.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-markdown-paste.test.tsx
@@ -25,11 +25,17 @@ type ClipboardPayload = {
   segments?: string
 }
 
+type ClipboardItemMock = { type: string; getAsFile: () => File | null }
+
 /** Builds the plain-object clipboardData mock the paste handler reads. */
-function makeClipboard(payload: ClipboardPayload, files: File[] = []) {
+function makeClipboard(
+  payload: ClipboardPayload,
+  files: File[] = [],
+  items: ClipboardItemMock[] = [],
+) {
   return {
     files,
-    items: [],
+    items,
     getData: (type: string): string => {
       if (type === 'text/markdown') return payload.markdown ?? ''
       if (type === 'text/html') return payload.html ?? ''
@@ -76,10 +82,15 @@ const lastOnChange = (spy: ReturnType<typeof vi.fn>) =>
 
 const lastSegments = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls.at(-1)?.[0] as Segment[]
 
-function paste(editor: HTMLDivElement, payload: ClipboardPayload, files: File[] = []) {
+function paste(
+  editor: HTMLDivElement,
+  payload: ClipboardPayload,
+  files: File[] = [],
+  items: ClipboardItemMock[] = [],
+) {
   act(() => {
     placeCursorAtEnd(editor)
-    fireEvent.paste(editor, { clipboardData: makeClipboard(payload, files) })
+    fireEvent.paste(editor, { clipboardData: makeClipboard(payload, files, items) })
   })
 }
 
@@ -224,5 +235,92 @@ describe('PromptArea rich HTML paste (markdown mode)', () => {
     paste(editor, { html: '<b>bold</b>', plain: 'plain fallback' })
     // A converter throw must not drop the paste — the plain-text flavor is used.
     expect(lastOnChange(onChangeSpy)).toBe('plain fallback')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Word clipboard pastes (JUMA-762)
+// ---------------------------------------------------------------------------
+
+/**
+ * Abridged Word clipboard HTML: no <ul>/<ol> — each item is an mso-list
+ * paragraph with the marker glyph in an `mso-list:Ignore` span behind
+ * conditional comments. Word (macOS especially) additionally puts a bitmap
+ * RENDERING of the copied selection on the clipboard, which used to win over
+ * the text flavors and silently drop the paste.
+ */
+function wordListHtml(items: Array<{ level: number; marker: string; text: string }>): string {
+  const paragraphs = items
+    .map(
+      ({ level, marker, text }) =>
+        `<p class=MsoListParagraphCxSpMiddle style='text-indent:-.25in;mso-list:l0 level${level} lfo1'>` +
+        `<![if !supportLists]><span style='mso-list:Ignore'>${marker}<span ` +
+        `style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp; </span></span><![endif]>` +
+        `${text}<o:p></o:p></p>`,
+    )
+    .join('\n')
+  return `<html xmlns:o="urn:schemas-microsoft-com:office:office"><head><meta name=ProgId content=Word.Document></head><body><!--StartFragment-->${paragraphs}<!--EndFragment--></body></html>`
+}
+
+const WORD_BULLETS = wordListHtml([
+  { level: 1, marker: '·', text: 'Alpha' },
+  { level: 2, marker: 'o', text: 'Beta' },
+  { level: 1, marker: '·', text: 'Gamma' },
+])
+
+describe('PromptArea Word clipboard pastes', () => {
+  it('pastes the Word text instead of the bitmap flavor Word also puts on the clipboard', () => {
+    const onImagePaste = vi.fn()
+    const { editor, onChangeSpy } = renderEditor({ markdown: true, onImagePaste })
+    const bitmap = new File(['pixels'], 'rendering.png', { type: 'image/png' })
+    paste(editor, { html: WORD_BULLETS, plain: 'Alpha\nBeta\nGamma' }, [bitmap])
+    expect(onImagePaste).not.toHaveBeenCalled()
+    expect(lastOnChange(onChangeSpy)).toBe('• Alpha\n  • Beta\n• Gamma')
+  })
+
+  it('pastes the Word text when the bitmap arrives via clipboard items', () => {
+    const onImagePaste = vi.fn()
+    const { editor, onChangeSpy } = renderEditor({ markdown: true, onImagePaste })
+    const bitmap = new File(['pixels'], 'rendering.png', { type: 'image/png' })
+    paste(
+      editor,
+      { html: WORD_BULLETS, plain: 'Alpha\nBeta\nGamma' },
+      [],
+      [{ type: 'image/png', getAsFile: () => bitmap }],
+    )
+    expect(onImagePaste).not.toHaveBeenCalled()
+    expect(lastOnChange(onChangeSpy)).toBe('• Alpha\n  • Beta\n• Gamma')
+  })
+
+  it('renumbers a pasted Word ordered list sequentially', () => {
+    const { editor, onChangeSpy } = renderEditor({ markdown: true })
+    const html = wordListHtml([
+      { level: 1, marker: '3.', text: 'First' },
+      { level: 1, marker: '4.', text: 'Second' },
+    ])
+    paste(editor, { html })
+    expect(lastOnChange(onChangeSpy)).toBe('1. First\n2. Second')
+  })
+
+  it('falls back to text/plain for a Word paste when markdown is off', () => {
+    const onImagePaste = vi.fn()
+    const { editor, onChangeSpy } = renderEditor({ markdown: false, onImagePaste })
+    const bitmap = new File(['pixels'], 'rendering.png', { type: 'image/png' })
+    paste(editor, { html: WORD_BULLETS, plain: 'Alpha\nBeta\nGamma' }, [bitmap])
+    // The Office sniff is independent of markdown mode: the text still wins.
+    expect(onImagePaste).not.toHaveBeenCalled()
+    expect(lastOnChange(onChangeSpy)).toBe('Alpha\nBeta\nGamma')
+  })
+
+  it('delivers the image when an Office clipboard yields no text', () => {
+    // An image/drawing object copied inside Word: Office-flagged html whose
+    // content converts to nothing, no text/plain — the bypassed image flavor
+    // must still reach onImagePaste (deferred, not suppressed).
+    const onImagePaste = vi.fn()
+    const { editor, onChangeSpy } = renderEditor({ markdown: true, onImagePaste })
+    const bitmap = new File(['pixels'], 'drawing.png', { type: 'image/png' })
+    paste(editor, { html: '<p class=MsoNormal><o:p></o:p></p>' }, [bitmap])
+    expect(onImagePaste).toHaveBeenCalledWith(bitmap)
+    expect(onChangeSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/prompt-area/src/prompt-area/html-to-markdown.ts
+++ b/packages/prompt-area/src/prompt-area/html-to-markdown.ts
@@ -3,7 +3,7 @@
  *
  * Used by the paste handler: when the editor is in markdown mode and the
  * clipboard carries rich `text/html` (web pages, Notion, Google Docs, GitHub,
- * Slack, etc.), we convert it to markdown SOURCE text so the paste keeps its
+ * Slack, Word, etc.), we convert it to markdown SOURCE text so the paste keeps its
  * formatting. The resulting string flows through the same insertion path as a
  * plain-text paste, and the editor's inline decorators render `*`/`**`/`***`
  * and bare URLs automatically.
@@ -70,6 +70,98 @@ function collapseWhitespace(text: string): string {
 /** Escapes literal `*` from HTML text so prose isn't re-read as emphasis. */
 function escapeText(text: string): string {
   return text.replace(/\*/g, '\\*')
+}
+
+// ---------------------------------------------------------------------------
+// Microsoft Office clipboard HTML (Word / Outlook / Excel)
+// ---------------------------------------------------------------------------
+
+/**
+ * Office fingerprints: `urn:schemas-microsoft-com:office` xmlns declarations,
+ * `<meta name=ProgId content=Word.Document>`, `Mso*` class names (quoted or
+ * Word's unquoted `class=MsoNormal`), and `mso-*` style declarations.
+ */
+const OFFICE_HTML_MARKER =
+  /urn:schemas-microsoft-com:office|name=["']?ProgId|class=["']?Mso|\bmso-[\w-]+\s*:/i
+
+/**
+ * Whether clipboard HTML came from a Microsoft Office app. Office apps put a
+ * bitmap RENDERING of the copied selection on the clipboard alongside the
+ * HTML (macOS Word especially), so the paste handler uses this to keep a
+ * text copy from being mistaken for an image paste.
+ */
+export function isOfficeHtml(html: string): boolean {
+  return OFFICE_HTML_MARKER.test(html)
+}
+
+/** Word's inline list metadata: `mso-list:l0 level2 lfo1` → nesting level 2. */
+const MSO_LIST_LEVEL = /mso-list:\s*l\d+\s+level(\d+)/i
+/** `1.` / `12)` — numeric ordered marker; captures the digits. */
+const NUMERIC_MARKER = /^(\d+)[.)]/
+/** `a.` / `B)` / `iv.` — alphabetic/roman ordered marker. */
+const ALPHA_MARKER = /^[a-z]{1,5}[.)]/i
+
+type WordListItem = { p: HTMLElement; level: number }
+
+/**
+ * Classifies a `<p>` as a Word list paragraph. Word clipboard HTML has no
+ * `<ul>/<ol>`: each item is a paragraph whose inline style carries
+ * `mso-list:l<id> level<n> lfo<id>`, with the visible marker glyph in a
+ * `<span style='mso-list:Ignore'>` behind conditional comments. The class
+ * (`MsoListParagraph*`) is deliberately NOT a signal — Word puts it on
+ * marker-less continuation paragraphs too.
+ */
+function wordListLevel(p: HTMLElement): number | null {
+  const match = MSO_LIST_LEVEL.exec(p.getAttribute('style') ?? '')
+  return match ? Number(match[1]) : null
+}
+
+/**
+ * Detaches the `mso-list:Ignore` marker span and returns its text (`·`, `o`,
+ * `§`, `1.`, `a.` …) for classification, keeping the glyph out of the item's
+ * serialized content. Returns '' when no marker span is revealed (the
+ * downlevel-hidden conditional-comment variant).
+ */
+function takeWordListMarker(p: HTMLElement): string {
+  for (const span of Array.from(p.querySelectorAll('span'))) {
+    if (getStyleValue(span.getAttribute('style') ?? '', 'mso-list') === 'ignore') {
+      span.remove()
+      return (span.textContent ?? '').trim()
+    }
+  }
+  return ''
+}
+
+/**
+ * Serializes a run of consecutive Word list paragraphs as markdown list lines —
+ * single-newline separated, 2-space indent per level, the exact shape
+ * `serializeList` emits for real `<ul>/<ol>`. Numeric markers seed the
+ * per-level counter from their own digits (so a list continued after an
+ * interrupting paragraph keeps Word's numbering); alpha/roman markers count
+ * from 1; anything else (`·`, `o`, `§`, Wingdings, or a hidden marker) is a
+ * bullet.
+ */
+function serializeWordListRun(items: WordListItem[], depth: number): string {
+  const counters = new Map<number, number>()
+  const lines: string[] = []
+  for (const { p, level } of items) {
+    // Returning to a shallower level ends its deeper sublists.
+    for (const key of Array.from(counters.keys())) {
+      if (key > level) counters.delete(key)
+    }
+    const markerText = takeWordListMarker(p)
+    const numeric = NUMERIC_MARKER.exec(markerText)
+    let marker = '- '
+    if (numeric || ALPHA_MARKER.test(markerText)) {
+      const n = (counters.get(level) ?? (numeric ? Number(numeric[1]) - 1 : 0)) + 1
+      counters.set(level, n)
+      marker = `${n}. `
+    } else {
+      counters.delete(level)
+    }
+    lines.push(`${'  '.repeat(depth + level - 1)}${marker}${serializeChildren(p, depth).trim()}`)
+  }
+  return lines.join('\n')
 }
 
 // ---------------------------------------------------------------------------
@@ -186,9 +278,34 @@ function serializeTable(table: HTMLElement, depth: number): string {
 
 function serializeChildren(node: Node, depth: number): string {
   let out = ''
-  node.childNodes.forEach((child) => {
+  const children = Array.from(node.childNodes)
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i]
+    if (isHTMLElement(child) && child.tagName === 'P') {
+      const level = wordListLevel(child)
+      if (level !== null) {
+        // Consume the whole run of consecutive Word list items, skipping the
+        // whitespace text nodes and comments Word puts between them, and
+        // serialize it as one list block (same `\n\n…\n\n` contract as UL/OL).
+        const run: WordListItem[] = [{ p: child, level }]
+        let j = i + 1
+        for (; j < children.length; j++) {
+          const next = children[j]
+          if (isHTMLElement(next)) {
+            const nextLevel = next.tagName === 'P' ? wordListLevel(next) : null
+            if (nextLevel === null) break
+            run.push({ p: next, level: nextLevel })
+          } else if (isTextNode(next) && (next.textContent ?? '').trim() !== '') {
+            break
+          }
+        }
+        out += `\n\n${serializeWordListRun(run, depth)}\n\n`
+        i = j - 1
+        continue
+      }
+    }
     out += serializeNode(child, depth)
-  })
+  }
   return out
 }
 
@@ -203,6 +320,8 @@ function serializeNode(node: Node, depth: number): string {
     case 'NOSCRIPT':
     case 'HEAD':
     case 'TITLE':
+    case 'XML': // Word <xml> data island — the parser reparents it out of <head>
+    case 'O:P': // Word paragraph-mark placeholder (often wraps a lone &nbsp;)
       return ''
     case 'BR':
       return '\n'

--- a/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
@@ -11,7 +11,7 @@ import {
   parseSegmentsFromClipboard,
   insertSegmentsAtCursor,
 } from './clipboard-helpers'
-import { htmlToMarkdown } from './html-to-markdown'
+import { htmlToMarkdown, isOfficeHtml } from './html-to-markdown'
 import {
   normalizeListPrefixText,
   renumberOrderedListLines,
@@ -140,14 +140,19 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
       if (!editor) return
 
       // Check for image files in clipboard before processing text
-      // Some browsers/OSes provide pasted images via `items` instead of `files` (e.g. screenshots)
+      // Some browsers/OSes provide pasted images via `items` instead of `files` (e.g. screenshots).
+      // Exception: Office apps (Word especially, on macOS) put a bitmap RENDERING
+      // of the copied selection on the clipboard alongside text/html; treating
+      // that as an image paste silently dropped the text, so for Office
+      // clipboards the text path wins and the image is only a last resort below.
+      const html = e.clipboardData.getData('text/html')
       const imageFile =
         Array.from(e.clipboardData.files).find((f) => f.type.startsWith('image/')) ??
         (() => {
           const item = Array.from(e.clipboardData.items).find((i) => i.type.startsWith('image/'))
           return item?.getAsFile() ?? null
         })()
-      if (imageFile) {
+      if (imageFile && !isOfficeHtml(html)) {
         onImagePaste?.(imageFile)
         return
       }
@@ -189,7 +194,7 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
       // When markdown mode is on, prefer the richest clipboard flavor:
       //   1. text/markdown — some apps (e.g. Slack) hand out markdown directly,
       //      preserving nested lists that their text/plain flattens.
-      //   2. text/html     — convert web/Notion/Docs/GitHub HTML to markdown.
+      //   2. text/html     — convert web/Notion/Docs/GitHub/Word HTML to markdown.
       // Otherwise (markdown off, or neither present) fall back to plain text.
       let text = ''
       if (markdownEnabled) {
@@ -199,22 +204,26 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
           // parentheses so the source reads cleanly. They carry no markdown
           // meaning, unlike `\*` / `\.` / `\-` which are left intact.
           text = text.replace(/\\([()])/g, '$1')
-        } else {
-          const html = e.clipboardData.getData('text/html')
+        } else if (html) {
           // A converter failure (e.g. stack overflow on pathologically deep
           // nesting) must not drop the paste — leave text empty so the
           // text/plain fallback below still runs.
-          if (html) {
-            try {
-              text = htmlToMarkdown(html)
-            } catch {
-              text = ''
-            }
+          try {
+            text = htmlToMarkdown(html)
+          } catch {
+            text = ''
           }
         }
       }
       if (!text) text = e.clipboardData.getData('text/plain')
-      if (!text) return
+      if (!text) {
+        // An Office clipboard whose html/plain flavors produced no text — e.g.
+        // an image or drawing object copied inside Word (its HTML is a file:///
+        // <img> that converts to nothing). Fall back to the image flavor
+        // bypassed above so image-only Office copies still reach onImagePaste.
+        if (imageFile) onImagePaste?.(imageFile)
+        return
+      }
 
       // Normalize pasted list markers ("- " → "•") so pasted bullets match
       // typed input. Applies to both the HTML→markdown and plain-text paths.


### PR DESCRIPTION
Copying from Microsoft Word (JUMA-762) pasted nothing: Word — macOS
especially — puts a bitmap rendering of the copied selection on the
clipboard next to its text/html, and the paste handler's image branch
consumed it and returned before reading any text flavor. With no
onImagePaste consumer wired, the paste silently vanished.

The handler now sniffs the clipboard's text/html for Office fingerprints
(office xmlns, ProgId meta, Mso classes, mso-* styles) and lets the text
path win on a match. The image is deferred, not suppressed: when an
Office clipboard yields no text at all — an image or drawing object
copied inside Word converts to nothing — the bypassed bitmap still
reaches onImagePaste. Non-Office pastes keep the existing precedence:
a copied image beats incidental <img> html.

Word's HTML also converts properly now. It carries no <ul>/<ol>; each
item is an mso-list paragraph whose marker glyph (·/o/§, 1., a.) hides
in an mso-list:Ignore span behind conditional comments. Runs of those
paragraphs become nested markdown lists — 2-space indent per level,
per-level numbering seeded from Word's own digits, bullets normalizing
to • downstream — instead of literal · lines separated by blank lines.
Detection is gated on the inline mso-list level style, never the
MsoListParagraph class, which Word also puts on marker-less
continuation paragraphs. <o:p> placeholders and <xml> data islands
(reparented out of <head> by the HTML parser) no longer leak junk text.

Covered by converter fixtures for both comment forms (Mac bogus
comments, Windows regular comments) and component tests pasting Word
html with the bitmap in files and in items.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012wXuyajYNsCot8QYGVJKDw