### PR TITLE
Optimize typing performance with single-pass DOM scanning

### DIFF
--- a/app/bench/page.tsx
+++ b/app/bench/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+/**
+ * Dev-only typing benchmark page for the PromptArea component.
+ *
+ * Driven by scripts/bench-typing.mjs (Playwright), but also usable by hand:
+ *
+ *   /bench?lines=600&mode=md&autogrow=1
+ *
+ * Seeds `lines` lines of content exercising every decoration pass (bullets,
+ * indents, ordered lists, headings, bold/italic, URLs) and exposes:
+ *   window.__benchReady            – content is mounted and decorated
+ *   window.__placeCaretAtLine(n)   – put the caret at the end of line n
+ */
+
+import { notFound } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { PromptArea } from 'prompt-area'
+import type { Segment } from 'prompt-area'
+
+declare global {
+  interface Window {
+    __benchReady?: boolean
+    __placeCaretAtLine?: (line: number) => boolean
+  }
+}
+
+function buildBenchText(lineCount: number, mode: 'md' | 'plain'): string {
+  const lines: string[] = []
+  for (let i = 0; i < lineCount; i++) {
+    if (mode === 'plain') {
+      lines.push(`Line ${i}: The quick brown fox jumps over the lazy dog near the river bank.`)
+      continue
+    }
+    switch (i % 10) {
+      case 3:
+        lines.push(`  • bullet ${i} with **bold** emphasis`)
+        break
+      case 4:
+        lines.push(`## Heading ${i} with *italic* flair`)
+        break
+      case 5:
+        lines.push(`1. first step of block ${i}`)
+        break
+      case 6:
+        lines.push(`2. second step of block ${i}`)
+        break
+      case 7:
+        lines.push(`see https://example.com/path/${i} for details`)
+        break
+      default:
+        lines.push(`Line ${i}: The quick brown fox jumps over the lazy dog near the river bank.`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function placeCaretAtLine(line: number): boolean {
+  const editor = document.querySelector<HTMLElement>('[data-test-id="bench-editor"]')
+  if (!editor) return false
+  editor.focus()
+
+  let brCount = 0
+  for (let i = 0; i < editor.childNodes.length; i++) {
+    if (editor.childNodes[i].nodeName === 'BR') {
+      brCount++
+      if (brCount === line) {
+        // The boundary just before the line's terminating <br> = end of line.
+        const range = document.createRange()
+        range.setStart(editor, i)
+        range.collapse(true)
+        const sel = window.getSelection()
+        if (!sel) return false
+        sel.removeAllRanges()
+        sel.addRange(range)
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export default function BenchPage() {
+  const [value, setValue] = useState<Segment[]>([])
+  const [config, setConfig] = useState<{ autoGrow: boolean } | null>(null)
+  const seeded = useRef(false)
+
+  useEffect(() => {
+    if (seeded.current) return
+    seeded.current = true
+
+    const params = new URLSearchParams(window.location.search)
+    const lines = Math.max(1, Number(params.get('lines') ?? 400))
+    const mode = params.get('mode') === 'plain' ? 'plain' : 'md'
+    const autoGrow = params.get('autogrow') !== '0'
+
+    setConfig({ autoGrow })
+    setValue([{ type: 'text', text: buildBenchText(lines, mode) }])
+    window.__placeCaretAtLine = placeCaretAtLine
+
+    // Two frames: one for React to commit the value, one for the decorated
+    // paint to settle before the harness starts measuring.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.__benchReady = true
+      })
+    })
+  }, [])
+
+  // Dev tool only — a production build serves 404 here.
+  if (process.env.NODE_ENV === 'production') notFound()
+
+  if (!config) {
+    return <main className="p-8 font-mono text-sm">bench: seeding…</main>
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-4 font-mono text-sm text-neutral-500">
+        prompt-area typing benchmark — {value.length ? 'ready' : 'seeding'}
+      </h1>
+      <PromptArea
+        value={value}
+        onChange={setValue}
+        markdown
+        markdownHeadings
+        autoGrow={config.autoGrow}
+        maxHeight={480}
+        minHeight={200}
+        data-test-id="bench-editor"
+        className="rounded-lg border border-neutral-300"
+      />
+    </main>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest-axe": "^11.0.0",
     "jsdom": "^30.0.0",
     "lefthook": "^2.1.10",
+    "playwright-core": "^1.62.1",
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "pretty-quick": "^4.2.2",

--- a/packages/prompt-area/.size-limit.json
+++ b/packages/prompt-area/.size-limit.json
@@ -4,14 +4,14 @@
     "path": "dist/index.js",
     "import": "*",
     "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
-    "limit": "18.5 KB"
+    "limit": "20 KB"
   },
   {
     "name": "prompt-area (component)",
     "path": "dist/prompt-area/index.js",
     "import": "*",
     "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
-    "limit": "17 KB"
+    "limit": "18.5 KB"
   },
   {
     "name": "helpers (RSC-safe)",

--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.6.6
+
+### Fixed
+
+- **Typing stays fast when the editor holds pages of text.** Every keystroke
+  used to do work proportional to the whole document: the caret offset was
+  measured by deep-cloning everything before it (`Range.cloneContents`, two to
+  three times per keystroke), the DOM was read and serialized to plain text up
+  to four separate times, all decorations (bold/italic, URLs, bullets,
+  indents, headings) were stripped and rebuilt across every line, autoGrow
+  forced two full layout reflows, and a fresh empty suggestions array forced a
+  React re-render even when nothing changed. On a multi-page document a single
+  keystroke blocked the frame for 40–80 ms. Offsets are now computed by
+  walking the live tree without cloning, one scan produces the segments and
+  plain text for the whole keystroke, the decoration cycle runs only on the
+  caret's `<br>`-delimited line (decorations are line-local; anything
+  ambiguous — foreign elements, literal newlines in text nodes, no collapsed
+  caret — still takes the full pass), height syncs coalesce into one
+  pre-paint `requestAnimationFrame`, and idle keystrokes no longer re-render.
+  Measured at 600 seeded lines with markdown and autoGrow: median keystroke
+  handler time dropped from 39.8 ms to 7.5 ms and input-to-frame latency from
+  45 ms to 8 ms, with p95 under one 60 Hz frame.
+- **Newlines insert without rebuilding the document.** Shift+Enter (and Enter
+  with `submitOnEnter` off) re-rendered and re-decorated the entire editor to
+  insert one `\n`, a ~37 ms stutter at 600 lines. When the caret is collapsed
+  in a clean flat DOM and ordered-list renumbering is provably a no-op, the
+  newline is now inserted surgically — split the caret's text node, insert one
+  `<br>`, re-decorate just that line — halving the cost; every other case
+  keeps the full re-render.
+
 ## 0.6.5
 
 ### Fixed

--- a/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers-offsets-parity.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers-offsets-parity.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  getCursorOffset,
+  getSelectionOffsets,
+  getTextLengthInRange,
+  getTextOffsetAtPoint,
+  setCursorAtOffset,
+} from '../cursor-helpers'
+
+// ---------------------------------------------------------------------------
+// The allocation-free getTextOffsetAtPoint must agree with the legacy
+// cloneContents-based measurement (kept as getTextLengthInRange) at every DOM
+// boundary point. The sweep below generates seeded random flat editors in the
+// shapes the component actually produces — text nodes, <br>s, a sentinel <br>,
+// chips, and nested decoration elements — and checks every enumerable
+// boundary point against the legacy oracle.
+// ---------------------------------------------------------------------------
+
+/** The pre-P1 implementation, verbatim, as the parity oracle. */
+function oracleOffsetAtPoint(editor: HTMLElement, container: Node, offset: number): number {
+  const preRange = document.createRange()
+  preRange.selectNodeContents(editor)
+  preRange.setEnd(container, offset)
+  return getTextLengthInRange(preRange)
+}
+
+/** Deterministic LCG so failures reproduce. */
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+function makeChip(trigger: string, display: string): HTMLSpanElement {
+  const chip = document.createElement('span')
+  chip.dataset.chipTrigger = trigger
+  chip.dataset.chipDisplay = display
+  chip.contentEditable = 'false'
+  chip.textContent = trigger + display
+  return chip
+}
+
+function makeDecorationSpan(text: string): HTMLSpanElement {
+  const span = document.createElement('span')
+  span.dataset.md = 'true'
+  span.textContent = text
+  return span
+}
+
+/** Heading-style wrapper: a data-md span containing marker + body spans. */
+function makeHeadingSpan(level: number, text: string): HTMLSpanElement {
+  const wrapper = document.createElement('span')
+  wrapper.dataset.md = 'true'
+  wrapper.dataset.mdHeading = String(level)
+  const marker = document.createElement('span')
+  marker.className = 'prompt-area-md-marker'
+  marker.textContent = `${'#'.repeat(level)} `
+  const body = document.createElement('span')
+  body.className = 'prompt-area-md-heading-text'
+  body.textContent = text
+  wrapper.appendChild(marker)
+  wrapper.appendChild(body)
+  return wrapper
+}
+
+function makeUrlAnchor(url: string): HTMLAnchorElement {
+  const anchor = document.createElement('a')
+  anchor.dataset.url = 'true'
+  anchor.href = url
+  anchor.textContent = url
+  return anchor
+}
+
+const SAMPLE_TEXTS = ['', 'a', 'hello', '  • x', '**b**', 'see #4', 'long enough text']
+
+function buildRandomEditor(rand: () => number): HTMLDivElement {
+  const editor = document.createElement('div')
+  editor.setAttribute('contenteditable', 'true')
+  document.body.appendChild(editor)
+
+  const childCount = 1 + Math.floor(rand() * 7)
+  for (let i = 0; i < childCount; i++) {
+    const roll = rand()
+    if (roll < 0.35) {
+      editor.appendChild(
+        document.createTextNode(SAMPLE_TEXTS[Math.floor(rand() * SAMPLE_TEXTS.length)]),
+      )
+    } else if (roll < 0.55) {
+      editor.appendChild(document.createElement('br'))
+    } else if (roll < 0.7) {
+      editor.appendChild(makeChip('@', `user${Math.floor(rand() * 10)}`))
+    } else if (roll < 0.82) {
+      editor.appendChild(makeDecorationSpan(SAMPLE_TEXTS[1 + Math.floor(rand() * 5)]))
+    } else if (roll < 0.92) {
+      editor.appendChild(makeUrlAnchor('https://example.com/x'))
+    } else {
+      editor.appendChild(makeHeadingSpan(1 + Math.floor(rand() * 3), 'Heading text'))
+    }
+  }
+  // Trailing sentinel <br> half the time, mirroring renderSegmentsToDOM.
+  if (rand() < 0.5) {
+    const sentinel = document.createElement('br')
+    sentinel.dataset.sentinel = 'true'
+    editor.appendChild(sentinel)
+  }
+  return editor
+}
+
+type BoundaryPoint = { container: Node; offset: number }
+
+/** Every valid (container, offset) boundary point in the subtree. */
+function enumerateBoundaryPoints(root: Node): BoundaryPoint[] {
+  const points: BoundaryPoint[] = []
+  const visit = (node: Node): void => {
+    if (node instanceof Text) {
+      const len = (node.textContent ?? '').length
+      for (let o = 0; o <= len; o++) points.push({ container: node, offset: o })
+      return
+    }
+    for (let o = 0; o <= node.childNodes.length; o++) points.push({ container: node, offset: o })
+    node.childNodes.forEach(visit)
+  }
+  visit(root)
+  return points
+}
+
+function placeCursor(node: Node, offset: number): void {
+  const sel = window.getSelection()
+  if (!sel) throw new Error('no selection')
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getTextOffsetAtPoint parity with the cloneContents oracle', () => {
+  it('matches at every boundary point across seeded random editors', () => {
+    const rand = makeRandom(0xc0ffee)
+    for (let e = 0; e < 200; e++) {
+      const editor = buildRandomEditor(rand)
+      for (const { container, offset } of enumerateBoundaryPoints(editor)) {
+        const actual = getTextOffsetAtPoint(editor, container, offset)
+        const expected = oracleOffsetAtPoint(editor, container, offset)
+        if (actual !== expected) {
+          throw new Error(
+            `editor #${e} mismatch at <${container.nodeName}>, offset ${offset}: ` +
+              `got ${actual}, oracle ${expected}, html: ${editor.innerHTML}`,
+          )
+        }
+      }
+      editor.remove()
+    }
+  })
+
+  it('returns null for a container outside the editor', () => {
+    const editor = document.createElement('div')
+    document.body.appendChild(editor)
+    const outside = document.createTextNode('elsewhere')
+    document.body.appendChild(outside)
+    expect(getTextOffsetAtPoint(editor, outside, 0)).toBeNull()
+  })
+
+  it('counts a boundary inside a chip subtree as the whole chip', () => {
+    const editor = document.createElement('div')
+    document.body.appendChild(editor)
+    editor.appendChild(document.createTextNode('hi '))
+    const chip = makeChip('@', 'alice')
+    editor.appendChild(chip)
+    const chipText = chip.firstChild as Text
+    // '@alice' is 6 chars; a boundary 2 chars into the chip's text still
+    // counts the full chip, exactly as the partial-clone walk does.
+    expect(getTextOffsetAtPoint(editor, chipText, 2)).toBe(3 + 6)
+    expect(getTextOffsetAtPoint(editor, chipText, 2)).toBe(oracleOffsetAtPoint(editor, chipText, 2))
+  })
+
+  it('skips the sentinel <br> and counts real <br> containers as one character', () => {
+    const editor = document.createElement('div')
+    document.body.appendChild(editor)
+    editor.appendChild(document.createTextNode('ab'))
+    const br = document.createElement('br')
+    editor.appendChild(br)
+    const sentinel = document.createElement('br')
+    sentinel.dataset.sentinel = 'true'
+    editor.appendChild(sentinel)
+
+    expect(getTextOffsetAtPoint(editor, br, 0)).toBe(oracleOffsetAtPoint(editor, br, 0))
+    expect(getTextOffsetAtPoint(editor, sentinel, 0)).toBe(oracleOffsetAtPoint(editor, sentinel, 0))
+    expect(getTextOffsetAtPoint(editor, editor, 3)).toBe(3) // ab + br
+    expect(getTextOffsetAtPoint(editor, editor, 3)).toBe(oracleOffsetAtPoint(editor, editor, 3))
+  })
+})
+
+describe('getCursorOffset / getSelectionOffsets parity via live selections', () => {
+  it('getCursorOffset agrees with the oracle at sampled points', () => {
+    const rand = makeRandom(0xbadf00d)
+    for (let e = 0; e < 40; e++) {
+      const editor = buildRandomEditor(rand)
+      const points = enumerateBoundaryPoints(editor)
+      for (let s = 0; s < 12; s++) {
+        const { container, offset } = points[Math.floor(rand() * points.length)]
+        placeCursor(container, offset)
+        expect(getCursorOffset(editor)).toBe(oracleOffsetAtPoint(editor, container, offset))
+      }
+      editor.remove()
+    }
+  })
+
+  it('getSelectionOffsets agrees with the oracle for non-collapsed selections', () => {
+    const rand = makeRandom(0xfeed)
+    for (let e = 0; e < 40; e++) {
+      const editor = buildRandomEditor(rand)
+      const points = enumerateBoundaryPoints(editor)
+      for (let s = 0; s < 8; s++) {
+        const a = points[Math.floor(rand() * points.length)]
+        const b = points[Math.floor(rand() * points.length)]
+        const range = document.createRange()
+        range.setStart(a.container, a.offset)
+        // setEnd before the start collapses the range to the end point; read
+        // the normalized boundaries back as ground truth either way.
+        range.setEnd(b.container, b.offset)
+        const sel = window.getSelection()
+        if (!sel) throw new Error('no selection')
+        sel.removeAllRanges()
+        sel.addRange(range)
+
+        const offsets = getSelectionOffsets(editor)
+        expect(offsets).not.toBeNull()
+        expect(offsets?.start).toBe(
+          oracleOffsetAtPoint(editor, range.startContainer, range.startOffset),
+        )
+        expect(offsets?.end).toBe(oracleOffsetAtPoint(editor, range.endContainer, range.endOffset))
+      }
+      editor.remove()
+    }
+  })
+
+  it('setCursorAtOffset placements read back consistently with the oracle', () => {
+    const editor = document.createElement('div')
+    document.body.appendChild(editor)
+    editor.appendChild(document.createTextNode('one '))
+    editor.appendChild(makeDecorationSpan('**two**'))
+    editor.appendChild(document.createElement('br'))
+    editor.appendChild(document.createTextNode('three'))
+
+    const total = getTextOffsetAtPoint(editor, editor, editor.childNodes.length) ?? 0
+    expect(total).toBe('one '.length + '**two**'.length + 1 + 'three'.length)
+
+    for (let k = 0; k <= total; k++) {
+      setCursorAtOffset(editor, k, { scroll: false })
+      const sel = window.getSelection()
+      expect(sel?.rangeCount).toBe(1)
+      const range = sel!.getRangeAt(0)
+      expect(getCursorOffset(editor)).toBe(
+        oracleOffsetAtPoint(editor, range.startContainer, range.startOffset),
+      )
+    }
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers-offsets-parity.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/cursor-helpers-offsets-parity.test.ts
@@ -159,6 +159,28 @@ describe('getTextOffsetAtPoint parity with the cloneContents oracle', () => {
     }
   })
 
+  it('ignores text inside non-HTML subtrees, matching the clone walk', () => {
+    const editor = document.createElement('div')
+    document.body.appendChild(editor)
+    editor.appendChild(document.createTextNode('hi '))
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    const svgText = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    svgText.appendChild(document.createTextNode('svgtext'))
+    svg.appendChild(svgText)
+    editor.appendChild(svg)
+    editor.appendChild(document.createTextNode(' bye'))
+
+    // The legacy walk recursed only through HTMLElements, so the svg subtree
+    // contributed nothing — a boundary inside it maps to the subtree's start.
+    const inner = svgText.firstChild as Text
+    expect(getTextOffsetAtPoint(editor, inner, 3)).toBe(oracleOffsetAtPoint(editor, inner, 3))
+    expect(getTextOffsetAtPoint(editor, inner, 3)).toBe('hi '.length)
+    expect(getTextOffsetAtPoint(editor, svg, 1)).toBe(oracleOffsetAtPoint(editor, svg, 1))
+    // Sibling positions after the svg are unaffected.
+    const bye = editor.lastChild as Text
+    expect(getTextOffsetAtPoint(editor, bye, 2)).toBe(oracleOffsetAtPoint(editor, bye, 2))
+  })
+
   it('returns null for a container outside the editor', () => {
     const editor = document.createElement('div')
     document.body.appendChild(editor)

--- a/packages/prompt-area/src/prompt-area/__tests__/dom-helpers-scoped-decorate.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/dom-helpers-scoped-decorate.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  decorateEditor,
+  decorateBulletsInEditor,
+  decorateURLsInEditor,
+  stripDecorationsInRange,
+  type DecorateBounds,
+} from '../dom-helpers'
+
+// ---------------------------------------------------------------------------
+// Bounded decoration must equal the full pass restricted to the line, and
+// must not touch a single node outside the bounds. stripDecorationsInRange
+// must mirror normalizeEditorDOM's strip + editor.normalize() within bounds.
+// ---------------------------------------------------------------------------
+
+function makeEditor(): HTMLDivElement {
+  const editor = document.createElement('div')
+  editor.setAttribute('contenteditable', 'true')
+  document.body.appendChild(editor)
+  return editor
+}
+
+function chip(trigger: string, value: string, display: string): HTMLSpanElement {
+  const el = document.createElement('span')
+  el.contentEditable = 'false'
+  el.dataset.chipTrigger = trigger
+  el.dataset.chipValue = value
+  el.dataset.chipDisplay = display
+  el.textContent = `${trigger}${display}`
+  return el
+}
+
+function mdSpan(text: string): HTMLSpanElement {
+  const el = document.createElement('span')
+  el.dataset.md = 'true'
+  el.textContent = text
+  return el
+}
+
+function urlAnchor(url: string): HTMLAnchorElement {
+  const el = document.createElement('a')
+  el.dataset.url = 'true'
+  el.href = url
+  el.textContent = url
+  return el
+}
+
+/** Serializes the nodes strictly inside bounds for comparisons. */
+function rangeHTML(editor: HTMLElement, bounds: DecorateBounds): string {
+  const container = document.createElement('div')
+  let node = bounds.after ? bounds.after.nextSibling : editor.firstChild
+  while (node && node !== bounds.before) {
+    container.appendChild(node.cloneNode(true))
+    node = node.nextSibling
+  }
+  return container.innerHTML
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('bounded decoration passes', () => {
+  it('decorates only the line inside the bounds, leaving other lines untouched by identity', () => {
+    const editor = makeEditor()
+    const line1 = document.createTextNode('**first** https://one.example')
+    const br1 = document.createElement('br')
+    const line2 = document.createTextNode('  • **mid** and https://two.example ok')
+    const br2 = document.createElement('br')
+    const line3 = document.createTextNode('# head **third**')
+    editor.append(line1, br1, line2, br2, line3)
+
+    const bounds: DecorateBounds = { after: br1, before: br2 }
+    decorateEditor(editor, true, true, bounds)
+
+    // Out-of-range lines: same node objects, still raw text.
+    expect(editor.childNodes[0]).toBe(line1)
+    expect(editor.lastChild).toBe(line3)
+    expect(line1.textContent).toBe('**first** https://one.example')
+    expect(line3.textContent).toBe('# head **third**')
+
+    // In-range line matches what a full pass produces for the same line.
+    const reference = makeEditor()
+    const refBr1 = document.createElement('br')
+    const refBr2 = document.createElement('br')
+    reference.append(
+      document.createTextNode('**first** https://one.example'),
+      refBr1,
+      document.createTextNode('  • **mid** and https://two.example ok'),
+      refBr2,
+      document.createTextNode('# head **third**'),
+    )
+    decorateEditor(reference, true, true)
+    expect(rangeHTML(editor, bounds)).toBe(rangeHTML(reference, { after: refBr1, before: refBr2 }))
+  })
+
+  it('handles null bounds edges for the first and last lines', () => {
+    const editor = makeEditor()
+    const line1 = document.createTextNode('• first https://a.example')
+    const br1 = document.createElement('br')
+    const line2 = document.createTextNode('untouched **mid**')
+    const br2 = document.createElement('br')
+    const line3 = document.createTextNode('• last')
+    editor.append(line1, br1, line2, br2, line3)
+
+    decorateEditor(editor, true, false, { after: null, before: br1 })
+    decorateEditor(editor, true, false, { after: br2, before: null })
+
+    expect(editor.querySelectorAll('.prompt-area-list-bullet').length).toBe(2)
+    // Middle line untouched by identity and content (line 1's decoration
+    // split it into several children, so locate line 2 relative to its <br>).
+    expect(br1.nextSibling).toBe(line2)
+    expect(line2.textContent).toBe('untouched **mid**')
+  })
+
+  it('bounded single passes decorate within range only', () => {
+    const editor = makeEditor()
+    const line1 = document.createTextNode('• one')
+    const br1 = document.createElement('br')
+    const line2 = document.createTextNode('• two https://x.example')
+    editor.append(line1, br1, line2)
+
+    decorateBulletsInEditor(editor, { after: br1, before: null })
+    decorateURLsInEditor(editor, { after: br1, before: null })
+
+    expect(editor.childNodes[0]).toBe(line1)
+    expect(line1.textContent).toBe('• one')
+    expect(editor.querySelectorAll('.prompt-area-list-bullet').length).toBe(1)
+    expect(editor.querySelectorAll('a[data-url]').length).toBe(1)
+  })
+
+  it('applies inline emphasis inside headings created by a bounded pass', () => {
+    const editor = makeEditor()
+    const br1 = document.createElement('br')
+    editor.append(document.createTextNode('plain'), br1, document.createTextNode('## Risky *bit*'))
+
+    decorateEditor(editor, true, true, { after: br1, before: null })
+
+    const heading = editor.querySelector('.prompt-area-md-heading-text')
+    expect(heading).not.toBeNull()
+    expect(heading?.querySelector('span.italic')).not.toBeNull()
+  })
+})
+
+describe('stripDecorationsInRange', () => {
+  it('unwraps decorations and merges adjacent text within bounds only', () => {
+    const editor = makeEditor()
+    const line1Span = mdSpan('**keep**')
+    const br1 = document.createElement('br')
+    const a = document.createTextNode('a')
+    const bold = mdSpan('**b**')
+    const url = urlAnchor('https://x.example')
+    const empty = mdSpan('')
+    const c = document.createTextNode('c')
+    const br2 = document.createElement('br')
+    const line3Anchor = urlAnchor('https://keep.example')
+    editor.append(line1Span, br1, a, bold, url, empty, c, br2, line3Anchor)
+
+    stripDecorationsInRange(editor, { after: br1, before: br2 })
+
+    // Out-of-range decorations untouched, by identity.
+    expect(editor.firstChild).toBe(line1Span)
+    expect(editor.lastChild).toBe(line3Anchor)
+
+    // In-range: one merged text node, no elements left.
+    const inRange: Node[] = []
+    let node = br1.nextSibling
+    while (node && node !== br2) {
+      inRange.push(node)
+      node = node.nextSibling
+    }
+    expect(inRange).toHaveLength(1)
+    expect(inRange[0].nodeType).toBe(Node.TEXT_NODE)
+    expect(inRange[0].textContent).toBe('a**b**https://x.examplec')
+  })
+
+  it('keeps chips intact and merges around them separately', () => {
+    const editor = makeEditor()
+    const theChip = chip('@', 'u', 'ada')
+    editor.append(document.createTextNode('x'), mdSpan('*i*'), theChip, mdSpan('*j*'))
+
+    stripDecorationsInRange(editor, { after: null, before: null })
+
+    expect(editor.childNodes).toHaveLength(3)
+    expect(editor.childNodes[0].textContent).toBe('x*i*')
+    expect(editor.childNodes[1]).toBe(theChip)
+    expect(editor.childNodes[2].textContent).toBe('*j*')
+  })
+
+  it('drops empty text nodes within bounds', () => {
+    const editor = makeEditor()
+    editor.append(document.createTextNode(''), document.createTextNode('a'), mdSpan(''))
+    stripDecorationsInRange(editor, { after: null, before: null })
+    expect(editor.childNodes).toHaveLength(1)
+    expect(editor.firstChild?.textContent).toBe('a')
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-autogrow-raf.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-autogrow-raf.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { PromptArea } from '../prompt-area'
 import type { Segment } from '../types'
 
@@ -82,6 +83,26 @@ describe('autoGrow rAF coalescing', () => {
       vi.advanceTimersToNextFrame()
     })
     expect(reads.count()).toBe(beforeUnmount)
+  })
+
+  it('keeps measuring under StrictMode double-mount (guard is not latched by cleanup)', () => {
+    render(
+      <StrictMode>
+        <PromptArea {...defaultProps} autoGrow />
+      </StrictMode>,
+    )
+    const editor = screen.getByRole('textbox')
+    const reads = instrumentScrollHeight(editor)
+
+    fireEvent.focus(editor)
+    fireEvent.input(editor)
+    const before = reads.count()
+    act(() => {
+      vi.advanceTimersToNextFrame()
+    })
+    // The pending-rAF cleanup of the StrictMode remount must not leave the
+    // scheduler thinking a frame is still pending.
+    expect(reads.count()).toBeGreaterThan(before)
   })
 
   it('does not measure at all while blurred', () => {

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-autogrow-raf.test.tsx
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-autogrow-raf.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { PromptArea } from '../prompt-area'
+import type { Segment } from '../types'
+
+// ---------------------------------------------------------------------------
+// autoGrow height syncs are coalesced into one requestAnimationFrame callback
+// per frame. Each sync is a forced reflow (height:auto → read scrollHeight →
+// height:px), so several inputs inside one frame must produce exactly one
+// measurement, and unmounting must cancel a pending one.
+// ---------------------------------------------------------------------------
+
+describe('autoGrow rAF coalescing', () => {
+  const defaultProps = {
+    value: [] as Segment[],
+    onChange: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ['requestAnimationFrame', 'cancelAnimationFrame', 'setTimeout', 'clearTimeout'],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function instrumentScrollHeight(editor: HTMLElement): { count: () => number } {
+    let reads = 0
+    Object.defineProperty(editor, 'scrollHeight', {
+      configurable: true,
+      get() {
+        reads++
+        return 180
+      },
+    })
+    return { count: () => reads }
+  }
+
+  it('measures once per frame no matter how many inputs arrive', () => {
+    render(<PromptArea {...defaultProps} autoGrow />)
+    const editor = screen.getByRole('textbox')
+    const reads = instrumentScrollHeight(editor)
+
+    // Focus performs its one synchronous expand measurement and the
+    // focus-driven effect schedules a rAF sync.
+    fireEvent.focus(editor)
+    const afterFocus = reads.count()
+    expect(afterFocus).toBe(1)
+
+    // Three inputs in the same frame: no synchronous measurements…
+    fireEvent.input(editor)
+    fireEvent.input(editor)
+    fireEvent.input(editor)
+    expect(reads.count()).toBe(afterFocus)
+
+    // …and flushing the frame runs exactly one coalesced measurement.
+    act(() => {
+      vi.advanceTimersToNextFrame()
+    })
+    expect(reads.count()).toBe(afterFocus + 1)
+
+    // A quiet next frame measures nothing.
+    act(() => {
+      vi.advanceTimersToNextFrame()
+    })
+    expect(reads.count()).toBe(afterFocus + 1)
+  })
+
+  it('cancels a pending measurement on unmount', () => {
+    const { unmount } = render(<PromptArea {...defaultProps} autoGrow />)
+    const editor = screen.getByRole('textbox')
+    const reads = instrumentScrollHeight(editor)
+
+    fireEvent.focus(editor)
+    fireEvent.input(editor)
+    const beforeUnmount = reads.count()
+
+    unmount()
+    act(() => {
+      vi.advanceTimersToNextFrame()
+    })
+    expect(reads.count()).toBe(beforeUnmount)
+  })
+
+  it('does not measure at all while blurred', () => {
+    render(<PromptArea {...defaultProps} autoGrow />)
+    const editor = screen.getByRole('textbox')
+    const reads = instrumentScrollHeight(editor)
+
+    fireEvent.input(editor)
+    act(() => {
+      vi.advanceTimersToNextFrame()
+    })
+    expect(reads.count()).toBe(0)
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePromptArea } from '../use-prompt-area'
+import { decorateEditor } from '../dom-helpers'
+import { getCursorOffset } from '../cursor-helpers'
+import { segmentsToPlainText } from '../prompt-area-engine'
+import type { Segment } from '../types'
+
+// ---------------------------------------------------------------------------
+// jsdom polyfill: Range.getBoundingClientRect is not implemented
+// ---------------------------------------------------------------------------
+
+if (!Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shift+Enter on large documents takes the surgical path: split the caret's
+// text node, insert one <br>, re-decorate only that line — instead of a full
+// renderSegmentsToDOM teardown. These tests pin the fast path's DOM shape,
+// model output, caret, and every fallback to the legacy full render.
+// ---------------------------------------------------------------------------
+
+function setup() {
+  const onChange = vi.fn()
+  const { result } = renderHook(() =>
+    usePromptArea({
+      value: [] as Segment[],
+      onChange,
+      markdownHeadings: true,
+    }),
+  )
+  const editor = document.createElement('div')
+  editor.contentEditable = 'true'
+  document.body.appendChild(editor)
+  ;(result.current.editorRef as React.MutableRefObject<HTMLDivElement>).current = editor
+  return { result, editor, onChange }
+}
+
+function placeCursor(node: Node, offset: number) {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  const sel = window.getSelection()!
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
+function shiftEnter(): React.KeyboardEvent<HTMLDivElement> {
+  return {
+    key: 'Enter',
+    shiftKey: true,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    nativeEvent: { isComposing: false },
+    preventDefault: vi.fn(),
+  } as unknown as React.KeyboardEvent<HTMLDivElement>
+}
+
+function lastChangeText(onChange: ReturnType<typeof vi.fn>): string {
+  const segments = onChange.mock.calls.at(-1)?.[0] as Segment[]
+  return segmentsToPlainText(segments)
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('Shift+Enter surgical newline', () => {
+  it('splits the caret line with one <br> and keeps other lines by node identity', () => {
+    const { result, editor, onChange } = setup()
+    editor.append(
+      document.createTextNode('first **bold** line'),
+      document.createElement('br'),
+      document.createTextNode('split here please'),
+      document.createElement('br'),
+      document.createTextNode('third https://example.com line'),
+    )
+    decorateEditor(editor, true, true)
+    const line1Span = editor.querySelector('span[data-md]')!
+    const line3Anchor = editor.querySelector('a[data-url]')!
+
+    // Caret after "split" (offset inside line 2's text node).
+    const brs = editor.querySelectorAll('br')
+    const line2 = brs[0].nextSibling as Text
+    placeCursor(line2, 'split'.length)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    // Model: newline at the caret's plain-text offset.
+    expect(lastChangeText(onChange)).toBe(
+      'first **bold** line\nsplit\n here please\nthird https://example.com line',
+    )
+    // DOM: the line was split by a real <br>; siblings kept their nodes.
+    expect(editor.querySelectorAll('br')).toHaveLength(3)
+    expect(editor.contains(line1Span)).toBe(true)
+    expect(editor.contains(line3Anchor)).toBe(true)
+    // Caret: right after the inserted newline.
+    expect(getCursorOffset(editor)).toBe('first **bold** line\nsplit'.length + 1)
+  })
+
+  it('re-decorates both halves of the split line', () => {
+    const { result, editor } = setup()
+    editor.append(document.createTextNode('**left** and https://right.example'))
+    decorateEditor(editor, true, true)
+
+    // Caret between "**left** and" and " https://…".
+    // After the split, the emphasis stays on line 1 and the URL is line 2.
+    const offset = '**left** and'.length
+    // The decorated line's first text node is inside/around spans; place via
+    // the hook's own mapping by using the editor boundary walk instead:
+    const sel = window.getSelection()!
+    const range = document.createRange()
+    // Find the text node containing " and " to anchor precisely.
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT)
+    let target: Text | null = null
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      if ((node.textContent ?? '').includes(' and')) {
+        target = node as Text
+        break
+      }
+    }
+    expect(target).not.toBeNull()
+    const local = (target!.textContent ?? '').indexOf(' and') + ' and'.length
+    range.setStart(target!, local)
+    range.collapse(true)
+    sel.removeAllRanges()
+    sel.addRange(range)
+    expect(getCursorOffset(editor)).toBe(offset)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    const spans = editor.querySelectorAll('span[data-md]')
+    const anchors = editor.querySelectorAll('a[data-url]')
+    expect(spans.length).toBeGreaterThan(0)
+    expect(anchors).toHaveLength(1)
+    expect(spans[0].textContent).toBe('**left**')
+    expect(anchors[0].textContent).toBe('https://right.example')
+  })
+
+  it('appends the sentinel <br> when splitting at the document end', () => {
+    const { result, editor, onChange } = setup()
+    const text = document.createTextNode('tail line')
+    editor.append(text)
+    placeCursor(text, 'tail line'.length)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('tail line\n')
+    const brs = editor.querySelectorAll('br')
+    expect(brs).toHaveLength(2)
+    expect((brs[1] as HTMLElement).dataset.sentinel).toBe('true')
+    expect((brs[0] as HTMLElement).dataset.sentinel).toBeUndefined()
+  })
+
+  it('keeps ordered-list numbering intact when splitting a prose line below a list', () => {
+    const { result, editor, onChange } = setup()
+    editor.append(
+      document.createTextNode('1. alpha'),
+      document.createElement('br'),
+      document.createTextNode('2. beta'),
+      document.createElement('br'),
+      document.createTextNode('prose line to split'),
+    )
+    const prose = editor.childNodes[4] as Text
+    placeCursor(prose, 'prose'.length)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('1. alpha\n2. beta\nprose\n line to split')
+  })
+
+  it('falls back to the full path for a non-collapsed selection', () => {
+    const { result, editor, onChange } = setup()
+    const text = document.createTextNode('delete THIS part')
+    editor.append(text)
+    const start = 'delete '.length
+    const end = 'delete THIS'.length
+    const range = document.createRange()
+    range.setStart(text, start)
+    range.setEnd(text, end)
+    const sel = window.getSelection()!
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('delete \n part')
+  })
+
+  it('falls back to the full path when the editor holds a foreign element', () => {
+    const { result, editor, onChange } = setup()
+    const bold = document.createElement('b')
+    bold.textContent = 'junk'
+    const text = document.createTextNode('clean text')
+    editor.append(bold, document.createElement('br'), text)
+    placeCursor(text, 5)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    // Legacy path read the DOM (b unwrapped by the full render afterwards)
+    // and produced the model edit at the caret.
+    expect(lastChangeText(onChange)).toBe('junk\nclean\n text')
+    expect(editor.querySelector('b')).toBeNull()
+  })
+
+  it('handles an empty editor through the full path', () => {
+    const { result, editor, onChange } = setup()
+    placeCursor(editor, 0)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('\n')
+    const brs = editor.querySelectorAll('br')
+    expect(brs).toHaveLength(2)
+    expect((brs[1] as HTMLElement).dataset.sentinel).toBe('true')
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-enter-fast-path.test.ts
@@ -231,6 +231,95 @@ describe('Shift+Enter surgical newline', () => {
     expect(editor.querySelector('b')).toBeNull()
   })
 
+  it('inserts before a document-leading chip, keeping DOM and model in agreement', () => {
+    const { result, editor, onChange } = setup()
+    const chip = document.createElement('span')
+    chip.contentEditable = 'false'
+    chip.dataset.chipTrigger = '@'
+    chip.dataset.chipValue = 'u1'
+    chip.dataset.chipDisplay = 'alice'
+    chip.textContent = '@alice'
+    editor.append(chip, document.createTextNode(' tail'))
+    placeCursor(editor, 0)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    // findDOMPosition maps offset 0 to AFTER a leading chip (caret bias); the
+    // surgical path must detect that and fall back so the <br> lands where
+    // the model put the newline — before the chip.
+    expect(lastChangeText(onChange)).toBe('\n@alice tail')
+    expect(editor.firstChild?.nodeName).toBe('BR')
+    const domText = Array.from(editor.childNodes)
+      .map((n) =>
+        n.nodeName === 'BR'
+          ? (n as HTMLElement).dataset.sentinel
+            ? ''
+            : '\n'
+          : (n.textContent ?? ''),
+      )
+      .join('')
+    expect(domText).toBe('\n@alice tail')
+    expect(getCursorOffset(editor)).toBe(1)
+  })
+
+  it('falls back and renumbers when the document holds a single misnumbered list line', () => {
+    const { result, editor, onChange } = setup()
+    editor.append(
+      document.createTextNode('5. solo item'),
+      document.createElement('br'),
+      document.createTextNode('prose line'),
+    )
+    const prose = editor.childNodes[2] as Text
+    placeCursor(prose, 'prose'.length)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    // applyEditResult renumbers unconditionally; the fast path must not skip
+    // that just because the single line is not a "run".
+    expect(lastChangeText(onChange)).toBe('1. solo item\nprose\n line')
+  })
+
+  it('repairs a missing sentinel when the document ends with a bare <br>', () => {
+    const { result, editor, onChange } = setup()
+    // A user can delete the sentinel with Backspace, leaving a bare trailing
+    // <br> that reads as a final "\n" with nothing keeping it visible.
+    editor.append(document.createTextNode('ab'), document.createElement('br'))
+    placeCursor(editor.firstChild!, 1)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('a\nb\n')
+    const brs = editor.querySelectorAll('br')
+    expect(brs).toHaveLength(3)
+    expect((brs[2] as HTMLElement).dataset.sentinel).toBe('true')
+  })
+
+  it('inserts on an empty line correctly via the round-trip fallback', () => {
+    const { result, editor, onChange } = setup()
+    editor.append(
+      document.createTextNode('a'),
+      document.createElement('br'),
+      document.createElement('br'),
+      document.createTextNode('b'),
+    )
+    // Caret on the empty line: between the two <br>s.
+    placeCursor(editor, 2)
+    expect(getCursorOffset(editor)).toBe(2)
+
+    act(() => {
+      result.current.handleKeyDown(shiftEnter())
+    })
+
+    expect(lastChangeText(onChange)).toBe('a\n\n\nb')
+    expect(getCursorOffset(editor)).toBe(3)
+  })
+
   it('handles an empty editor through the full path', () => {
     const { result, editor, onChange } = setup()
     placeCursor(editor, 0)

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-hot-path.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-hot-path.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePromptArea } from '../use-prompt-area'
+import { decorateEditor } from '../dom-helpers'
+import type { Segment, TriggerConfig } from '../types'
+
+// ---------------------------------------------------------------------------
+// jsdom polyfill: Range.getBoundingClientRect is not implemented
+// ---------------------------------------------------------------------------
+
+if (!Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The typing hot path's two structural guarantees:
+// 1. No Range.cloneContents anywhere in a plain keystroke (offset math walks
+//    the live tree).
+// 2. The decoration cycle touches only the caret's <br>-delimited line —
+//    other lines keep their exact DOM nodes — with full-pass fallbacks when
+//    the DOM state makes scoping unsafe.
+// ---------------------------------------------------------------------------
+
+const mentionTrigger: TriggerConfig = {
+  char: '@',
+  position: 'any',
+  mode: 'dropdown',
+  onSearch: vi.fn(() => []),
+}
+
+function setup(options: { markdownHeadings?: boolean } = {}) {
+  const onChange = vi.fn()
+  const { result } = renderHook(() =>
+    usePromptArea({
+      value: [] as Segment[],
+      onChange,
+      triggers: [mentionTrigger],
+      markdownHeadings: options.markdownHeadings ?? true,
+    }),
+  )
+  const editor = document.createElement('div')
+  editor.contentEditable = 'true'
+  document.body.appendChild(editor)
+  ;(result.current.editorRef as React.MutableRefObject<HTMLDivElement>).current = editor
+  return { result, editor, onChange }
+}
+
+function placeCursor(node: Node, offset: number) {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  const sel = window.getSelection()!
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
+function makeKeyEvent(key: string): React.KeyboardEvent<HTMLDivElement> {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    nativeEvent: { isComposing: false },
+    preventDefault: vi.fn(),
+  } as unknown as React.KeyboardEvent<HTMLDivElement>
+}
+
+/**
+ * Seeds three decorated lines and returns the pieces. Line 2 is the line the
+ * tests edit; lines 1 and 3 carry decorations whose node identity is asserted.
+ */
+function seedThreeLines(editor: HTMLDivElement) {
+  editor.append(
+    document.createTextNode('first **bold** line'),
+    document.createElement('br'),
+    document.createTextNode('edit me'),
+    document.createElement('br'),
+    document.createTextNode('third https://example.com/x line'),
+  )
+  // Establish the steady state a real render produces: everything decorated.
+  decorateEditor(editor, true, true)
+
+  const line1Span = editor.querySelector('span[data-md]')
+  const line3Anchor = editor.querySelector('a[data-url]')
+  const brs = editor.querySelectorAll('br')
+  expect(line1Span).not.toBeNull()
+  expect(line3Anchor).not.toBeNull()
+  expect(brs).toHaveLength(2)
+
+  // The middle line stayed a bare text node ("edit me" has nothing to
+  // decorate); find it between the two <br>s.
+  const line2Text = brs[0].nextSibling as Text
+  expect(line2Text.textContent).toBe('edit me')
+  return { line1Span: line1Span!, line3Anchor: line3Anchor!, line2Text, brs }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('typing hot path', () => {
+  it('performs zero Range.cloneContents on a plain keystroke', () => {
+    const { result, editor } = setup()
+    const { line2Text } = seedThreeLines(editor)
+
+    // Simulate the browser having inserted a character at the caret.
+    line2Text.textContent = 'edit mex'
+    placeCursor(line2Text, 'edit mex'.length)
+
+    const cloneSpy = vi.spyOn(Range.prototype, 'cloneContents')
+    act(() => {
+      result.current.handleKeyDown(makeKeyEvent('x'))
+      result.current.handleInput()
+    })
+    expect(cloneSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-decorates only the caret line; other lines keep their exact nodes', () => {
+    const { result, editor, onChange } = setup()
+    const { line1Span, line3Anchor, line2Text } = seedThreeLines(editor)
+
+    line2Text.textContent = 'edit me **now**'
+    placeCursor(line2Text, 'edit me **now**'.length)
+    act(() => {
+      result.current.handleInput()
+    })
+
+    // Model updated with the typed text.
+    const lastChange = onChange.mock.calls.at(-1)?.[0] as Segment[]
+    expect(lastChange.map((s) => (s.type === 'text' ? s.text : '')).join('')).toBe(
+      'first **bold** line\nedit me **now**\nthird https://example.com/x line',
+    )
+
+    // The caret line got its fresh decoration…
+    const brs = editor.querySelectorAll('br')
+    let decoratedInLine2 = false
+    for (let n = brs[0].nextSibling; n && n !== brs[1]; n = n.nextSibling) {
+      if (n instanceof HTMLElement && n.dataset.md !== undefined) decoratedInLine2 = true
+    }
+    expect(decoratedInLine2).toBe(true)
+
+    // …while the other lines' decoration elements are the same objects.
+    expect(editor.contains(line1Span)).toBe(true)
+    expect(editor.contains(line3Anchor)).toBe(true)
+  })
+
+  it('re-decorates a line edited inside an existing decoration span', () => {
+    const { result, editor } = setup()
+    seedThreeLines(editor)
+
+    // Type inside line 1's bold span content: "**bold**" -> "**bolder**".
+    const styled = editor.querySelector('span[data-md] span.font-bold') as HTMLElement
+    const inner = styled.firstChild as Text
+    inner.textContent = 'bolder'
+    placeCursor(inner, 'bolder'.length)
+    act(() => {
+      result.current.handleInput()
+    })
+
+    // The line was stripped and re-decorated into a consistent fresh state.
+    const span = editor.querySelector('span[data-md]')
+    expect(span?.textContent).toBe('**bolder**')
+    expect(span?.querySelector('span.font-bold')?.textContent).toBe('bolder')
+  })
+
+  it('falls back to a full normalize when a foreign element exists anywhere', () => {
+    const { result, editor } = setup()
+    const { line2Text, line3Anchor } = seedThreeLines(editor)
+
+    // Browser-style junk on line 3, far from the caret.
+    const bold = document.createElement('b')
+    bold.textContent = 'junk'
+    editor.insertBefore(bold, line3Anchor)
+
+    line2Text.textContent = 'edit mex'
+    placeCursor(line2Text, 3)
+    act(() => {
+      result.current.handleInput()
+    })
+
+    // The full path unwrapped the <b> everywhere, not just on the caret line.
+    expect(editor.querySelector('b')).toBeNull()
+    expect(editor.textContent).toContain('junk')
+  })
+
+  it('falls back to a full decorate when a text node contains a literal newline', () => {
+    const { result, editor } = setup()
+
+    // Artificial state: line 1 raw and undecorated, and a text node carrying
+    // a literal newline — scoping must not run, so the full pass reaches and
+    // decorates line 1 too.
+    const line1 = document.createTextNode('raw **bold** here')
+    const multi = document.createTextNode('two\nlines')
+    editor.append(line1, document.createElement('br'), multi)
+    placeCursor(multi, 2)
+
+    act(() => {
+      result.current.handleInput()
+    })
+
+    expect(editor.querySelector('span[data-md]')).not.toBeNull()
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-hot-path.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-hot-path.test.ts
@@ -198,6 +198,51 @@ describe('typing hot path', () => {
     expect(editor.textContent).toContain('junk')
   })
 
+  it('repairs an IME-composed line with a full decorate on the next input, wherever the caret is', () => {
+    const { result, editor } = setup()
+    const { line2Text, brs } = seedThreeLines(editor)
+
+    // Compose "**ime**" into line 2 (decoration cycle is skipped mid-composition).
+    act(() => {
+      result.current.eventHandlers.onCompositionStart()
+    })
+    line2Text.textContent = 'edit me **ime**'
+    placeCursor(line2Text, 'edit me **ime**'.length)
+    act(() => {
+      result.current.handleInput()
+    })
+    act(() => {
+      result.current.eventHandlers.onCompositionEnd()
+    })
+    expect(editor.querySelector('span[data-md]')?.textContent).not.toBe('**ime**')
+
+    // Next regular keystroke lands on line 3 — the composed line 2 must still
+    // get its decoration (full pass), exactly like the pre-scoping behavior.
+    const line3 = brs[1].nextSibling as Text
+    line3.textContent = (line3.textContent ?? '') + 'x'
+    placeCursor(line3, (line3.textContent ?? '').length)
+    act(() => {
+      result.current.handleInput()
+    })
+
+    const decorated = Array.from(editor.querySelectorAll('span[data-md]')).some(
+      (s) => s.textContent === '**ime**',
+    )
+    expect(decorated).toBe(true)
+
+    // And scoping resumes afterwards: an edit on line 3 leaves line 1's
+    // decoration node untouched by identity. (Re-locate line 3's text node —
+    // the repair pass split the original around its URL anchor.)
+    const line1Span = editor.querySelector('span[data-md]')!
+    const line3Fresh = brs[1].nextSibling as Text
+    line3Fresh.textContent = (line3Fresh.textContent ?? '') + 'y'
+    placeCursor(line3Fresh, (line3Fresh.textContent ?? '').length)
+    act(() => {
+      result.current.handleInput()
+    })
+    expect(editor.contains(line1Span)).toBe(true)
+  })
+
   it('falls back to a full decorate when a text node contains a literal newline', () => {
     const { result, editor } = setup()
 

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-identity.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-identity.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePromptArea } from '../use-prompt-area'
+import type { Segment, TriggerConfig } from '../types'
+
+// ---------------------------------------------------------------------------
+// jsdom polyfill: Range.getBoundingClientRect is not implemented
+// ---------------------------------------------------------------------------
+
+if (!Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Referential stability of the hook's outputs. The typing hot path re-renders
+// the whole PromptArea when any of these lose identity: `events` (feeds
+// handleInput, the imperative handle, eventHandlers) and `suggestions` (reset
+// on every trigger-less keystroke). These tests pin the invariants the
+// per-keystroke React work relies on.
+// ---------------------------------------------------------------------------
+
+const mentionTrigger: TriggerConfig = {
+  char: '@',
+  position: 'any',
+  mode: 'dropdown',
+  onSearch: vi.fn(() => [{ value: 'alice', label: 'Alice' }]),
+}
+
+function attachEditor(hookResult: ReturnType<typeof usePromptArea>): HTMLDivElement {
+  const editor = document.createElement('div')
+  editor.contentEditable = 'true'
+  document.body.appendChild(editor)
+  ;(hookResult.editorRef as React.MutableRefObject<HTMLDivElement>).current = editor
+  return editor
+}
+
+function placeCursor(node: Node, offset: number) {
+  const range = document.createRange()
+  range.setStart(node, offset)
+  range.collapse(true)
+  const sel = window.getSelection()!
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
+describe('usePromptArea referential stability', () => {
+  it('keeps handle, eventHandlers, and handleInput identity across rerenders with stable props', () => {
+    const props = {
+      value: [] as Segment[],
+      onChange: vi.fn(),
+      triggers: [mentionTrigger],
+    }
+    const { result, rerender } = renderHook(() => usePromptArea(props))
+
+    const firstHandle = result.current.handle
+    const firstEventHandlers = result.current.eventHandlers
+    const firstHandleInput = result.current.handleInput
+    const firstHandleKeyDown = result.current.handleKeyDown
+
+    rerender()
+
+    expect(result.current.handle).toBe(firstHandle)
+    expect(result.current.eventHandlers).toBe(firstEventHandlers)
+    expect(result.current.handleInput).toBe(firstHandleInput)
+    expect(result.current.handleKeyDown).toBe(firstHandleKeyDown)
+  })
+
+  it('does not re-render on a trigger-less keystroke (suggestions reset bails out)', () => {
+    let renders = 0
+    const props = {
+      value: [] as Segment[],
+      onChange: vi.fn(),
+      triggers: [mentionTrigger],
+    }
+    const { result } = renderHook(() => {
+      renders++
+      return usePromptArea(props)
+    })
+
+    const editor = attachEditor(result.current)
+    editor.appendChild(document.createTextNode('hello world'))
+    placeCursor(editor.firstChild!, 5)
+
+    const rendersBefore = renders
+    const suggestionsBefore = result.current.suggestions
+
+    act(() => {
+      result.current.handleInput()
+    })
+    act(() => {
+      result.current.handleInput()
+    })
+
+    expect(renders).toBe(rendersBefore)
+    expect(result.current.suggestions).toBe(suggestionsBefore)
+    expect(props.onChange).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-scan.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/use-prompt-area-scan.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { scanEditorDOM } from '../use-prompt-area'
+import {
+  normalizeEditorDOM,
+  isChipElement,
+  isBRElement,
+  isHTMLElement,
+  chipNodeToSegment,
+} from '../dom-helpers'
+import { segmentsToPlainText } from '../prompt-area-engine'
+import type { Segment } from '../types'
+
+// ---------------------------------------------------------------------------
+// scanEditorDOM must produce exactly what the legacy typing path produced:
+// normalizeEditorDOM(editor) followed by readSegmentsFromDOM(). The oracle
+// below is a verbatim copy of readSegmentsFromDOM's logic (the real one is a
+// hook-internal closure), run against a normalized clone so the scan's
+// non-mutating read can be compared on the same input DOM.
+// ---------------------------------------------------------------------------
+
+function oracleReadSegments(editor: HTMLElement): Segment[] {
+  const segments: Segment[] = []
+  let hasRealContent = false
+  let hasSentinel = false
+
+  for (let i = 0; i < editor.childNodes.length; i++) {
+    const node = editor.childNodes[i]
+
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? ''
+      if (text) {
+        segments.push({ type: 'text', text })
+        hasRealContent = true
+      }
+    } else if (isChipElement(node)) {
+      const chip = chipNodeToSegment(node)
+      if (chip) {
+        segments.push(chip)
+        hasRealContent = true
+      }
+    } else if (isBRElement(node)) {
+      if (node.dataset.sentinel) {
+        hasSentinel = true
+        continue
+      }
+      segments.push({ type: 'text', text: '\n' })
+    } else if (isHTMLElement(node)) {
+      const text = node.textContent ?? ''
+      if (text) {
+        segments.push({ type: 'text', text })
+        hasRealContent = true
+      }
+    }
+  }
+
+  if (!hasRealContent && !hasSentinel) return []
+  return segments
+}
+
+function oracle(editor: HTMLElement): Segment[] {
+  const clone = editor.cloneNode(true) as HTMLElement
+  document.body.appendChild(clone)
+  normalizeEditorDOM(clone)
+  const segments = oracleReadSegments(clone)
+  clone.remove()
+  return segments
+}
+
+function makeEditor(): HTMLDivElement {
+  const editor = document.createElement('div')
+  editor.setAttribute('contenteditable', 'true')
+  document.body.appendChild(editor)
+  return editor
+}
+
+function chip(trigger: string, value: string, display: string): HTMLSpanElement {
+  const el = document.createElement('span')
+  el.contentEditable = 'false'
+  el.dataset.chipTrigger = trigger
+  el.dataset.chipValue = value
+  el.dataset.chipDisplay = display
+  el.textContent = `${trigger}${display}`
+  return el
+}
+
+function mdSpan(text: string): HTMLSpanElement {
+  const el = document.createElement('span')
+  el.dataset.md = 'true'
+  el.textContent = text
+  return el
+}
+
+function urlAnchor(url: string): HTMLAnchorElement {
+  const el = document.createElement('a')
+  el.dataset.url = 'true'
+  el.href = url
+  el.textContent = url
+  return el
+}
+
+function headingSpan(level: number, text: string): HTMLSpanElement {
+  const wrapper = document.createElement('span')
+  wrapper.dataset.md = 'true'
+  wrapper.dataset.mdHeading = String(level)
+  const marker = document.createElement('span')
+  marker.textContent = `${'#'.repeat(level)} `
+  const body = document.createElement('span')
+  body.textContent = text
+  wrapper.appendChild(marker)
+  wrapper.appendChild(body)
+  return wrapper
+}
+
+function br(sentinel = false): HTMLBRElement {
+  const el = document.createElement('br')
+  if (sentinel) el.dataset.sentinel = 'true'
+  return el
+}
+
+function expectScanMatchesOracle(editor: HTMLElement): void {
+  const scan = scanEditorDOM(editor)
+  const expected = oracle(editor)
+  expect(scan.segments).toEqual(expected)
+  expect(scan.plainText).toBe(segmentsToPlainText(expected))
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('scanEditorDOM equivalence with normalizeEditorDOM + readSegmentsFromDOM', () => {
+  it('reads plain multi-line content', () => {
+    const editor = makeEditor()
+    editor.append('first line', br(), 'second line', br(), br(), 'fourth')
+    expectScanMatchesOracle(editor)
+  })
+
+  it('merges decoration elements into the surrounding text run', () => {
+    const editor = makeEditor()
+    editor.append('see ', urlAnchor('https://example.com/a'), ' and ', mdSpan('**bold**'), ' end')
+    expectScanMatchesOracle(editor)
+    expect(scanEditorDOM(editor).segments).toEqual([
+      { type: 'text', text: 'see https://example.com/a and **bold** end' },
+    ])
+  })
+
+  it('reads bullet, indent, and heading decorations back as one line run', () => {
+    const editor = makeEditor()
+    editor.append(mdSpan('  '), mdSpan('•'), ' item', br(), headingSpan(2, 'Title'), br(), 'tail')
+    expectScanMatchesOracle(editor)
+  })
+
+  it('keeps chips as separate segments and breaks text runs around them', () => {
+    const editor = makeEditor()
+    editor.append('hi ', chip('@', 'u1', 'alice'), chip('@', 'u2', 'bob'), ' bye', br())
+    editor.append(chip('#', 't', 'tag'))
+    expectScanMatchesOracle(editor)
+  })
+
+  it('skips malformed chips but still breaks the text run at them', () => {
+    const editor = makeEditor()
+    const broken = document.createElement('span')
+    broken.dataset.chipTrigger = '@'
+    // no chipValue/chipDisplay — chipNodeToSegment returns null
+    broken.textContent = '@broken'
+    editor.append('before', broken, 'after')
+    expectScanMatchesOracle(editor)
+    expect(scanEditorDOM(editor).segments).toEqual([
+      { type: 'text', text: 'before' },
+      { type: 'text', text: 'after' },
+    ])
+  })
+
+  it('merges text through an empty decoration element', () => {
+    const editor = makeEditor()
+    editor.append('ab', mdSpan(''), 'cd')
+    expectScanMatchesOracle(editor)
+    expect(scanEditorDOM(editor).segments).toEqual([{ type: 'text', text: 'abcd' }])
+  })
+
+  it('handles the sentinel <br> and trailing newlines', () => {
+    const editor = makeEditor()
+    editor.append('line', br(), br(true))
+    expectScanMatchesOracle(editor)
+  })
+
+  it('reads a filler-<br>-only editor as empty', () => {
+    const editor = makeEditor()
+    editor.append(br())
+    expectScanMatchesOracle(editor)
+    expect(scanEditorDOM(editor).segments).toEqual([])
+    expect(scanEditorDOM(editor).plainText).toBe('')
+  })
+
+  it('reads an empty editor as empty', () => {
+    const editor = makeEditor()
+    expectScanMatchesOracle(editor)
+  })
+})
+
+describe('scanEditorDOM fallback flags', () => {
+  it.each(['div', 'p', 'b', 'i', 'font', 'strong', 'em', 'u'])(
+    'flags a <%s> child as foreign',
+    (tag) => {
+      const editor = makeEditor()
+      const el = document.createElement(tag)
+      el.textContent = 'x'
+      editor.append('a', el, 'b')
+      expect(scanEditorDOM(editor).sawForeignElement).toBe(true)
+    },
+  )
+
+  it('flags a plain <span> without data-md as foreign', () => {
+    const editor = makeEditor()
+    const span = document.createElement('span')
+    span.textContent = 'styled'
+    editor.append(span)
+    expect(scanEditorDOM(editor).sawForeignElement).toBe(true)
+  })
+
+  it('flags an <a> without data-url as foreign', () => {
+    const editor = makeEditor()
+    const a = document.createElement('a')
+    a.href = 'https://example.com'
+    a.textContent = 'link'
+    editor.append(a)
+    expect(scanEditorDOM(editor).sawForeignElement).toBe(true)
+  })
+
+  it('does not flag chips, brs, decorations, or text', () => {
+    const editor = makeEditor()
+    editor.append(
+      'a',
+      mdSpan('*i*'),
+      urlAnchor('https://x.co'),
+      chip('@', 'v', 'd'),
+      br(),
+      br(true),
+    )
+    const scan = scanEditorDOM(editor)
+    expect(scan.sawForeignElement).toBe(false)
+    expect(scan.sawNewlineInText).toBe(false)
+  })
+
+  it('flags literal newlines inside text nodes and still reads them like the oracle', () => {
+    const editor = makeEditor()
+    editor.append('one\ntwo', br(), 'three')
+    const scan = scanEditorDOM(editor)
+    expect(scan.sawNewlineInText).toBe(true)
+    expectScanMatchesOracle(editor)
+  })
+
+  it('flags literal newlines inside decoration elements', () => {
+    const editor = makeEditor()
+    editor.append(mdSpan('a\nb'))
+    expect(scanEditorDOM(editor).sawNewlineInText).toBe(true)
+  })
+})

--- a/packages/prompt-area/src/prompt-area/cursor-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/cursor-helpers.ts
@@ -142,6 +142,12 @@ export function getTextOffsetAtPoint(
     if (isChipElement(pathChild)) {
       return length + chipNodeTextLength(pathChild)
     }
+    // Non-HTML subtrees (svg, MathML) contribute nothing in the clone walk —
+    // it only recurses through HTMLElements — so a boundary inside one maps
+    // to the subtree's start rather than counting its internal text.
+    if (!isHTMLElement(pathChild) && !isTextNode(pathChild)) {
+      return length
+    }
     parent = pathChild
   }
 

--- a/packages/prompt-area/src/prompt-area/cursor-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/cursor-helpers.ts
@@ -77,11 +77,89 @@ export function getCursorOffset(editor: HTMLElement): number | null {
   if (!range) return null
   if (!editor.contains(range.startContainer)) return null
 
-  const preRange = document.createRange()
-  preRange.selectNodeContents(editor)
-  preRange.setEnd(range.startContainer, range.startOffset)
+  return getTextOffsetAtPoint(editor, range.startContainer, range.startOffset)
+}
 
-  return getTextLengthInRange(preRange)
+/**
+ * Plain-text length a whole node contributes to cursor offsets. Counting rules
+ * are shared with {@link getTextLengthInRange}'s fragment walk: text nodes by
+ * length, chips atomically via {@link chipNodeTextLength}, `<br>` as one
+ * character (sentinel `<br>` as zero), other elements by their children.
+ */
+function nodeTextContribution(node: Node): number {
+  if (isTextNode(node)) return (node.textContent ?? '').length
+  if (isChipElement(node)) return chipNodeTextLength(node)
+  if (isHTMLElement(node)) {
+    if (node.tagName === 'BR') return node.dataset.sentinel ? 0 : 1
+    let length = 0
+    const children = node.childNodes
+    for (let i = 0; i < children.length; i++) {
+      length += nodeTextContribution(children[i])
+    }
+    return length
+  }
+  return 0
+}
+
+/**
+ * Plain-text offset of the DOM boundary point `(container, offset)` inside the
+ * editor — the length of everything before the point, under the same counting
+ * rules as {@link getTextLengthInRange}, without the `Range.cloneContents()`
+ * that function needs. Cloning allocates a deep copy of the whole document
+ * prefix, which made every caret-offset query on the typing hot path cost
+ * O(document) in allocations; this walk only reads.
+ *
+ * Returns null when `container` is not inside the editor.
+ */
+export function getTextOffsetAtPoint(
+  editor: HTMLElement,
+  container: Node,
+  offset: number,
+): number | null {
+  // Ancestor path container → … → direct child of editor (empty when the
+  // container is the editor itself).
+  const path: Node[] = []
+  let ancestor: Node | null = container
+  while (ancestor && ancestor !== editor) {
+    path.push(ancestor)
+    ancestor = ancestor.parentNode
+  }
+  if (!ancestor) return null
+
+  let length = 0
+  let parent: Node = editor
+  for (let depth = path.length - 1; depth >= 0; depth--) {
+    const pathChild = path[depth]
+    const siblings = parent.childNodes
+    for (let i = 0; i < siblings.length; i++) {
+      const sibling = siblings[i]
+      if (sibling === pathChild) break
+      length += nodeTextContribution(sibling)
+    }
+    // Chips are atomic: a boundary inside a chip subtree counts the whole chip,
+    // matching the clone walk (a partial clone keeps the chip shell and its
+    // data attributes, so chipNodeTextLength reads the full length).
+    if (isChipElement(pathChild)) {
+      return length + chipNodeTextLength(pathChild)
+    }
+    parent = pathChild
+  }
+
+  if (isTextNode(container)) {
+    return length + Math.min(offset, (container.textContent ?? '').length)
+  }
+  if (isHTMLElement(container) && container.tagName === 'BR') {
+    // setEnd(<br>, 0) partially includes the <br>, whose cloned shell the
+    // clone walk counts as one character (zero for the sentinel).
+    return length + (container.dataset.sentinel ? 0 : 1)
+  }
+  // Element container: children before the offset index are fully included.
+  const children = container.childNodes
+  const limit = Math.min(offset, children.length)
+  for (let i = 0; i < limit; i++) {
+    length += nodeTextContribution(children[i])
+  }
+  return length
 }
 
 /**
@@ -146,17 +224,15 @@ export function getSelectionOffsets(editor: HTMLElement): { start: number; end: 
   if (!range) return null
   if (!editor.contains(range.startContainer)) return null
 
-  const startRange = document.createRange()
-  startRange.selectNodeContents(editor)
-  startRange.setEnd(range.startContainer, range.startOffset)
-  const start = getTextLengthInRange(startRange)
+  const start = getTextOffsetAtPoint(editor, range.startContainer, range.startOffset)
+  if (start === null) return null
 
   if (range.collapsed) return { start, end: start }
 
-  const endRange = document.createRange()
-  endRange.selectNodeContents(editor)
-  endRange.setEnd(range.endContainer, range.endOffset)
-  const end = getTextLengthInRange(endRange)
+  // A selection dragged past the editor's edge has its end outside; treat it
+  // as collapsed rather than mapping a foreign node to an arbitrary offset.
+  const end = getTextOffsetAtPoint(editor, range.endContainer, range.endOffset)
+  if (end === null) return { start, end: start }
 
   return { start, end }
 }

--- a/packages/prompt-area/src/prompt-area/dom-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/dom-helpers.ts
@@ -311,6 +311,86 @@ export function normalizeEditorDOM(editor: HTMLElement): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Decoration bounds (line scoping)
+// ---------------------------------------------------------------------------
+
+/**
+ * Exclusive boundaries limiting decoration work to one `<br>`-delimited line.
+ * `after`/`before` are the `<br>` nodes on either side (null = document edge).
+ * `<br>` is the one node kind no decoration pass ever replaces, so the
+ * boundary nodes stay valid across every pass of a decorate cycle.
+ */
+export type DecorateBounds = {
+  after: Node | null
+  before: Node | null
+}
+
+/** Iterates the direct children strictly inside `bounds` (all children when undefined). */
+function forEachChildInBounds(
+  root: HTMLElement,
+  bounds: DecorateBounds | undefined,
+  callback: (node: Node) => void,
+): void {
+  let node = bounds?.after ? bounds.after.nextSibling : root.firstChild
+  const stop = bounds?.before ?? null
+  while (node && node !== stop) {
+    callback(node)
+    node = node.nextSibling
+  }
+}
+
+/**
+ * Scoped stand-in for {@link normalizeEditorDOM}'s decoration strip and
+ * `editor.normalize()`: unwraps decoration elements (markdown `<span data-md>`,
+ * URL `<a data-url>`) strictly inside the bounds back to plain text, drops the
+ * empty ones, and merges the resulting adjacent text nodes — leaving every
+ * node outside the bounds untouched. Only safe when the surrounding DOM holds
+ * no foreign elements (the caller establishes that via scanEditorDOM).
+ */
+export function stripDecorationsInRange(editor: HTMLElement, bounds: DecorateBounds): void {
+  const stop = bounds.before
+
+  let node: Node | null = bounds.after ? bounds.after.nextSibling : editor.firstChild
+  while (node && node !== stop) {
+    const next: Node | null = node.nextSibling
+    // Chips carry data-chip-trigger and are never decorations — leave them.
+    if (isHTMLElement(node) && node.dataset.chipTrigger === undefined) {
+      if ((node.tagName === 'SPAN' && node.dataset.md !== undefined) || isLinkElement(node)) {
+        const text = node.textContent ?? ''
+        if (text) {
+          editor.replaceChild(document.createTextNode(text), node)
+        } else {
+          editor.removeChild(node)
+        }
+      }
+    }
+    node = next
+  }
+
+  // Bounded equivalent of editor.normalize(): drop empty text nodes, merge
+  // adjacent ones.
+  node = bounds.after ? bounds.after.nextSibling : editor.firstChild
+  while (node && node !== stop) {
+    if (isTextNode(node)) {
+      if ((node.textContent ?? '') === '') {
+        const next: Node | null = node.nextSibling
+        editor.removeChild(node)
+        node = next
+        continue
+      }
+      let sibling: Node | null = node.nextSibling
+      while (sibling && sibling !== stop && isTextNode(sibling)) {
+        node.textContent = (node.textContent ?? '') + (sibling.textContent ?? '')
+        const nextSibling: Node | null = sibling.nextSibling
+        editor.removeChild(sibling)
+        sibling = nextSibling
+      }
+    }
+    node = node.nextSibling
+  }
+}
+
+// ---------------------------------------------------------------------------
 // URL decoration
 // ---------------------------------------------------------------------------
 
@@ -328,17 +408,18 @@ const URL_PATTERN = /https?:\/\/[^\s),]+/g
  * @param editor - The contentEditable root element
  * @returns Whether any decorations were applied
  */
-export function decorateURLsInEditor(editor: HTMLElement): boolean {
+export function decorateURLsInEditor(editor: HTMLElement, bounds?: DecorateBounds): boolean {
   let decorated = false
 
-  // Collect text nodes first (avoid modifying while iterating)
+  // Collect text nodes first (avoid modifying while iterating). The includes
+  // check is a cheap pre-gate: URL_PATTERN can only match text containing
+  // "http", so everything else skips the regex entirely.
   const textNodes: Text[] = []
-  for (let i = 0; i < editor.childNodes.length; i++) {
-    const node = editor.childNodes[i]
-    if (isTextNode(node) && node.textContent) {
+  forEachChildInBounds(editor, bounds, (node) => {
+    if (isTextNode(node) && node.textContent && node.textContent.includes('http')) {
       textNodes.push(node)
     }
-  }
+  })
 
   for (const textNode of textNodes) {
     const text = textNode.textContent ?? ''
@@ -431,17 +512,17 @@ const MARKDOWN_INLINE_PATTERN = /(\*{3})(.+?)\*{3}|(\*{2})(.+?)\*{2}|(\*)(.+?)\*
  * @param editor - The contentEditable root element
  * @returns Whether any decorations were applied
  */
-export function decorateMarkdownInEditor(editor: HTMLElement): boolean {
+export function decorateMarkdownInEditor(editor: HTMLElement, bounds?: DecorateBounds): boolean {
   let decorated = false
 
-  // Collect text nodes first (avoid modifying while iterating)
+  // Collect text nodes first (avoid modifying while iterating). Emphasis
+  // needs at least one asterisk, so plain text skips the regex.
   const textNodes: Text[] = []
-  for (let i = 0; i < editor.childNodes.length; i++) {
-    const node = editor.childNodes[i]
-    if (isTextNode(node) && node.textContent) {
+  forEachChildInBounds(editor, bounds, (node) => {
+    if (isTextNode(node) && node.textContent && node.textContent.includes('*')) {
       textNodes.push(node)
     }
-  }
+  })
 
   for (const textNode of textNodes) {
     const text = textNode.textContent ?? ''
@@ -554,16 +635,15 @@ const LIST_BULLET_PATTERN = /(^|\n)([ \t]*)•/g
  * @param editor - The contentEditable root element
  * @returns Whether any decorations were applied
  */
-export function decorateBulletsInEditor(editor: HTMLElement): boolean {
+export function decorateBulletsInEditor(editor: HTMLElement, bounds?: DecorateBounds): boolean {
   let decorated = false
 
   const textNodes: Text[] = []
-  for (let i = 0; i < editor.childNodes.length; i++) {
-    const node = editor.childNodes[i]
+  forEachChildInBounds(editor, bounds, (node) => {
     if (isTextNode(node) && node.textContent?.includes('•')) {
       textNodes.push(node)
     }
-  }
+  })
 
   for (const textNode of textNodes) {
     const text = textNode.textContent ?? ''
@@ -631,16 +711,15 @@ const HEADING_PATTERN = /^(#{1,6}) (.*)$/
  * @param editor - The contentEditable root element
  * @returns Whether any decorations were applied
  */
-export function decorateHeadingsInEditor(editor: HTMLElement): boolean {
+export function decorateHeadingsInEditor(editor: HTMLElement, bounds?: DecorateBounds): boolean {
   let decorated = false
 
   const textNodes: Text[] = []
-  for (let i = 0; i < editor.childNodes.length; i++) {
-    const node = editor.childNodes[i]
+  forEachChildInBounds(editor, bounds, (node) => {
     if (isTextNode(node) && node.textContent?.includes('#')) {
       textNodes.push(node)
     }
-  }
+  })
 
   for (const textNode of textNodes) {
     const text = textNode.textContent ?? ''
@@ -720,14 +799,20 @@ const LIST_INDENT_PATTERN = /(^|\n)([ \t]+)(?=(?:[•\-*] |\d+\. ))/g
  *
  * @returns Whether any decorations were applied
  */
-export function decorateListIndentInEditor(editor: HTMLElement): boolean {
+export function decorateListIndentInEditor(editor: HTMLElement, bounds?: DecorateBounds): boolean {
   let decorated = false
 
+  // Pre-gate: the indent pattern only matches leading whitespace at the node
+  // start or after an embedded newline, so unindented single-line nodes (the
+  // overwhelming majority) skip the regex.
   const textNodes: Text[] = []
-  for (let i = 0; i < editor.childNodes.length; i++) {
-    const node = editor.childNodes[i]
-    if (isTextNode(node)) textNodes.push(node)
-  }
+  forEachChildInBounds(editor, bounds, (node) => {
+    if (!isTextNode(node)) return
+    const text = node.textContent
+    if (text && (text[0] === ' ' || text[0] === '\t' || text.includes('\n'))) {
+      textNodes.push(node)
+    }
+  })
 
   for (const textNode of textNodes) {
     const text = textNode.textContent ?? ''
@@ -794,27 +879,39 @@ export function decorateEditor(
   editor: HTMLElement,
   markdownEnabled: boolean,
   headingsEnabled = false,
+  bounds?: DecorateBounds,
 ): void {
   // Whole-line passes run FIRST, while each direct-child text node is still a
   // full line. The URL and markdown passes split text nodes mid-line, so a tail
   // fragment beginning with "•" would let the bullet regex's `^` anchor
   // false-match a mid-line separator (e.g. `**bold** • middle`).
   if (markdownEnabled) {
-    if (headingsEnabled) decorateHeadingsInEditor(editor)
-    decorateListIndentInEditor(editor)
-    decorateBulletsInEditor(editor)
+    if (headingsEnabled) decorateHeadingsInEditor(editor, bounds)
+    decorateListIndentInEditor(editor, bounds)
+    decorateBulletsInEditor(editor, bounds)
   }
-  decorateURLsInEditor(editor)
-  if (markdownEnabled) decorateMarkdownInEditor(editor)
+  decorateURLsInEditor(editor, bounds)
+  if (markdownEnabled) decorateMarkdownInEditor(editor, bounds)
 
   // Inline emphasis *inside* a heading. The heading pass consumed the line's
   // text node into its own span, so the editor-level pass above can't reach it
   // — without this, `## Risks and *caveats*` would show its asterisks raw.
   if (markdownEnabled && headingsEnabled) {
-    const headingTexts = editor.querySelectorAll('.prompt-area-md-heading-text')
-    for (let i = 0; i < headingTexts.length; i++) {
-      const body = headingTexts[i]
-      if (isHTMLElement(body)) decorateMarkdownInEditor(body)
+    if (bounds) {
+      // Scoped cycle: the only heading wrappers needing the inline pass are
+      // the ones the bounded heading pass just created inside this line.
+      forEachChildInBounds(editor, bounds, (node) => {
+        if (isHTMLElement(node) && node.dataset.mdHeading !== undefined) {
+          const body = node.querySelector('.prompt-area-md-heading-text')
+          if (body && isHTMLElement(body)) decorateMarkdownInEditor(body)
+        }
+      })
+    } else {
+      const headingTexts = editor.querySelectorAll('.prompt-area-md-heading-text')
+      for (let i = 0; i < headingTexts.length; i++) {
+        const body = headingTexts[i]
+        if (isHTMLElement(body)) decorateMarkdownInEditor(body)
+      }
     }
   }
 }

--- a/packages/prompt-area/src/prompt-area/prompt-area-list-ops.ts
+++ b/packages/prompt-area/src/prompt-area/prompt-area-list-ops.ts
@@ -105,8 +105,10 @@ export function getListContext(text: string, cursorPos: number): ListContext | n
 export function autoFormatListPrefix(
   segments: Segment[],
   cursorPos: number,
+  // Callers on the typing hot path pass the plain text they already built so
+  // this doesn't re-serialize the whole document per keystroke.
+  plainText: string = segmentsToPlainText(segments),
 ): { segments: Segment[]; cursorOffset: number } | null {
-  const plainText = segmentsToPlainText(segments)
   const lineStart = plainText.lastIndexOf('\n', cursorPos - 1) + 1
   const lineText = plainText.slice(lineStart, cursorPos)
 
@@ -483,11 +485,15 @@ export function remapOffset(old: number, edits: NumberEdit[]): number {
  * returns the changed spans for {@link remapOffset}. Digit runs are pure text at
  * line starts, so chips are never touched.
  */
-export function renumberOrderedListSegments(segments: Segment[]): {
+export function renumberOrderedListSegments(
+  segments: Segment[],
+  // Optional precomputed serialization, same rationale as autoFormatListPrefix.
+  plainText: string = segmentsToPlainText(segments),
+): {
   segments: Segment[]
   edits: NumberEdit[]
 } {
-  const { edits } = renumberOrderedListLines(segmentsToPlainText(segments))
+  const { edits } = renumberOrderedListLines(plainText)
   if (edits.length === 0) return { segments, edits }
 
   let result = segments

--- a/packages/prompt-area/src/prompt-area/prompt-area.tsx
+++ b/packages/prompt-area/src/prompt-area/prompt-area.tsx
@@ -161,7 +161,13 @@ export function PromptArea({
 
   useEffect(() => {
     return () => {
-      if (heightRaf.current !== null) cancelAnimationFrame(heightRaf.current)
+      if (heightRaf.current !== null) {
+        cancelAnimationFrame(heightRaf.current)
+        // Clear the guard too: StrictMode's dev double-mount runs this
+        // cleanup and re-runs the effect on the same component instance, and
+        // a stale id would latch scheduleSyncHeight closed forever.
+        heightRaf.current = null
+      }
     }
   }, [])
 

--- a/packages/prompt-area/src/prompt-area/prompt-area.tsx
+++ b/packages/prompt-area/src/prompt-area/prompt-area.tsx
@@ -144,6 +144,27 @@ export function PromptArea({
     setEditorHeight(contentHeight)
   }, [editorRef])
 
+  // One height measurement per frame: the input handler and the value-change
+  // effect both request a sync on every keystroke, and each measurement is a
+  // forced reflow of the whole editor (the height:auto dance invalidates
+  // layout, then scrollHeight reads it). Coalescing them into a single
+  // pre-paint rAF callback halves the per-keystroke reflows without a
+  // visible frame at a stale height.
+  const heightRaf = useRef<number | null>(null)
+  const scheduleSyncHeight = useCallback(() => {
+    if (heightRaf.current !== null) return
+    heightRaf.current = requestAnimationFrame(() => {
+      heightRaf.current = null
+      syncHeight()
+    })
+  }, [syncHeight])
+
+  useEffect(() => {
+    return () => {
+      if (heightRaf.current !== null) cancelAnimationFrame(heightRaf.current)
+    }
+  }, [])
+
   const handleFocus = useCallback(() => {
     if (!autoGrow) return
     setIsFocused(true)
@@ -167,16 +188,16 @@ export function PromptArea({
   const handleInputWithGrow = useCallback(() => {
     handleInput()
     if (autoGrow && isFocused) {
-      syncHeight()
+      scheduleSyncHeight()
     }
-  }, [handleInput, autoGrow, isFocused, syncHeight])
+  }, [handleInput, autoGrow, isFocused, scheduleSyncHeight])
 
   // Re-measure on value changes (chip insertion, undo/redo, programmatic updates)
   useEffect(() => {
     if (autoGrow && isFocused) {
-      requestAnimationFrame(() => syncHeight())
+      scheduleSyncHeight()
     }
-  }, [value, autoGrow, isFocused, syncHeight])
+  }, [value, autoGrow, isFocused, scheduleSyncHeight])
 
   // -----------------------------------------------------------------------
   // Overflow indicator: detect when collapsed content is clipped

--- a/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area-events.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import type { Segment, ChipSegment, TriggerConfig } from './types'
 import { resolveTriggersInSegments } from './prompt-area-engine'
 import { normalizeEditorDOM, safeJsonStringify, getSelectionRange } from './dom-helpers'
@@ -464,18 +464,38 @@ export function usePromptAreaEvents(deps: EventHandlerDeps): PromptAreaEventHand
     [readSegmentsFromDOM, onChange, renderSegmentsToDOM, onUndo, onRedo],
   )
 
-  return {
-    handlePaste,
-    handleCopy,
-    handleCut,
-    handleDrop,
-    handleDragOver,
-    handleCompositionStart,
-    handleCompositionEnd,
-    handleBlur,
-    handleKeyDownForUndoRedo,
-    pushUndo,
-    resetUndoHistory,
-    isComposing,
-  }
+  // A stable object: every member is a stable useCallback (or a ref), and
+  // downstream hooks — handleInput, the imperative handle, the eventHandlers
+  // memo — list `events` in their deps. A fresh literal here would rebuild all
+  // of them (and re-run useImperativeHandle) on every keystroke's render.
+  return useMemo(
+    () => ({
+      handlePaste,
+      handleCopy,
+      handleCut,
+      handleDrop,
+      handleDragOver,
+      handleCompositionStart,
+      handleCompositionEnd,
+      handleBlur,
+      handleKeyDownForUndoRedo,
+      pushUndo,
+      resetUndoHistory,
+      isComposing,
+    }),
+    [
+      handlePaste,
+      handleCopy,
+      handleCut,
+      handleDrop,
+      handleDragOver,
+      handleCompositionStart,
+      handleCompositionEnd,
+      handleBlur,
+      handleKeyDownForUndoRedo,
+      pushUndo,
+      resetUndoHistory,
+      isComposing,
+    ],
+  )
 }

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -63,6 +63,7 @@ import {
   setSelectionAtOffsets,
   caretLineRect,
   findDOMPosition,
+  getTextOffsetAtPoint,
 } from './cursor-helpers'
 import { usePromptAreaEvents } from './use-prompt-area-events'
 import { useTriggerSearch } from './use-trigger-search'
@@ -350,6 +351,13 @@ export function usePromptArea({
   const isSyncing = useRef(false)
   const lastRenderedValue = useRef<Segment[]>([])
 
+  // IME-composed input skips the decoration cycle entirely (mutating the DOM
+  // mid-composition breaks the composition), so the composed line is stale
+  // until a decorate reaches it. The baseline repaired it because the next
+  // keystroke re-decorated the whole document; with line scoping, this flag
+  // forces that next decorate to be a full pass wherever the caret is.
+  const imeDirty = useRef(false)
+
   // Debounced undo: groups consecutive keystrokes into a single undo snapshot
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const undoBaseState = useRef<Segment[] | null>(null)
@@ -482,6 +490,7 @@ export function usePromptArea({
 
       // Decorate URLs, markdown formatting, and list bullets in text nodes
       decorateEditor(editor, markdownEnabled, headingsEnabled)
+      imeDirty.current = false
 
       // The child-clear above collapsed scrollHeight, which clamped scrollTop
       // to 0. Put the viewport back before the caret restore so an in-view
@@ -677,6 +686,7 @@ export function usePromptArea({
 
     // During IME composition, sync model but skip trigger detection
     if (events.isComposing.current) {
+      imeDirty.current = true
       const segments = readSegmentsFromDOM()
       lastRenderedValue.current = segments
       onChange(segments)
@@ -718,15 +728,19 @@ export function usePromptArea({
 
     // Enforce maxLength: if the edit pushed the editor past the cap, truncate
     // back to maxLength characters and keep the caret where the user was
-    // editing (clamped to the cap) rather than forcing it to the end. The
-    // selection hasn't moved since savedCursorOffset was captured, so re-
-    // reading it here would return the same offset.
+    // editing (clamped to the cap) rather than forcing it to the end. On the
+    // clean-scan path the selection hasn't moved since savedCursorOffset was
+    // captured, so re-reading it would return the same offset; after the
+    // foreign-element normalize, the DOM (and possibly the text, via block
+    // unwrapping) changed, so measure the caret fresh — as the pre-scan
+    // implementation did.
     if (maxLength != null && editor && plainText.length > maxLength) {
+      const caret = domNormalized ? getCursorOffset(editor) : savedCursorOffset
       const truncated = truncateSegmentsToLength(segments, maxLength)
       lastRenderedValue.current = truncated
       onChange(truncated)
       renderSegmentsToDOM(truncated)
-      const clamped = savedCursorOffset != null ? Math.min(savedCursorOffset, maxLength) : maxLength
+      const clamped = caret != null ? Math.min(caret, maxLength) : maxLength
       setCursorAtOffset(editor, clamped)
       runTriggerDetection({
         segments: truncated,
@@ -804,7 +818,7 @@ export function usePromptArea({
         finalCursor = renumberedCursor
       } else {
         let scoped = false
-        if (scopedEligible) {
+        if (scopedEligible && !imeDirty.current) {
           const selRange = getSelectionRange()
           if (selRange && selRange.collapsed && editor.contains(selRange.startContainer)) {
             const bounds = findLineBounds(editor, selRange.startContainer, selRange.startOffset)
@@ -820,6 +834,7 @@ export function usePromptArea({
             normalizeEditorDOM(editor)
           }
           decorateEditor(editor, markdownEnabled, headingsEnabled)
+          imeDirty.current = false
         }
         if (savedCursorOffset !== null) {
           // scroll: false — this placement only re-establishes the caret that
@@ -1522,11 +1537,20 @@ export function usePromptArea({
         // provably a no-op, the same end state is reachable by splitting the
         // caret's text node, inserting one <br>, and re-decorating only that
         // line's range.
-        if (cleanScan && offsets.start === offsets.end && scan.segments.length > 0) {
+        if (
+          cleanScan &&
+          offsets.start === offsets.end &&
+          scan.segments.length > 0 &&
+          !imeDirty.current
+        ) {
           const plainAfter =
             scan.plainText.slice(0, offsets.start) + '\n' + scan.plainText.slice(offsets.start)
+          // Exact parity with applyEditResult, which renumbers unconditionally:
+          // the fast path is only taken when that renumber provably does
+          // nothing (renumberOrderedListLines has its own cheap no-list
+          // pre-gate, so this is string work only).
           let renumberNoop = true
-          if (markdownEnabled && hasOrderedListRun(plainAfter)) {
+          if (markdownEnabled) {
             renumberNoop = renumberOrderedListSegments(newSegments, plainAfter).edits.length === 0
           }
           if (renumberNoop && insertNewlineSurgically(editor, offsets.start)) {
@@ -1558,6 +1582,13 @@ export function usePromptArea({
 
         const pos = findDOMPosition(editor, offset)
         if (!pos) return false
+        // findDOMPosition resolves boundary offsets with a caret bias: an
+        // offset at the start of a chip (or of a <br> on an empty line) maps
+        // to the position AFTER that element. Fine for placing a caret, wrong
+        // for structural insertion — the model puts the newline BEFORE the
+        // element. Only proceed when the mapping round-trips to the exact
+        // offset; otherwise the full re-render handles it.
+        if (getTextOffsetAtPoint(editor, pos.node, pos.offset) !== offset) return false
 
         const br = document.createElement('br')
         if (pos.node === editor) {
@@ -1578,7 +1609,12 @@ export function usePromptArea({
           return false
         }
 
-        if (editor.lastChild === br) {
+        // renderSegmentsToDOM's rule: a trailing real <br> needs the sentinel
+        // so the final newline stays visible. Checking the actual last child
+        // (not just the inserted one) also repairs a bare trailing <br> the
+        // user exposed by deleting a previous sentinel.
+        const last = editor.lastChild
+        if (last && isBRElement(last) && !last.dataset.sentinel) {
           const sentinel = document.createElement('br')
           sentinel.dataset.sentinel = 'true'
           editor.appendChild(sentinel)
@@ -1680,6 +1716,7 @@ export function usePromptArea({
       onChange,
       renderSegmentsToDOM,
       markdownEnabled,
+      headingsEnabled,
       dismissTrigger,
       handleChipBackspace,
       handleChipForwardDelete,

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -62,6 +62,7 @@ import {
   getSelectionOffsets,
   setSelectionAtOffsets,
   caretLineRect,
+  findDOMPosition,
 } from './cursor-helpers'
 import { usePromptAreaEvents } from './use-prompt-area-events'
 import { useTriggerSearch } from './use-trigger-search'
@@ -1508,10 +1509,83 @@ export function usePromptArea({
       const insertPlainNewline = (editor: HTMLDivElement): void => {
         const offsets = getSelectionOffsets(editor)
         if (!offsets) return
-        const currentSegments = readSegmentsFromDOM()
+        const scan = scanEditorDOM(editor)
+        const cleanScan = !scan.sawForeignElement && !scan.sawNewlineInText
+        const currentSegments = cleanScan ? scan.segments : readSegmentsFromDOM()
         events.pushUndo(currentSegments)
         const newSegments = replaceTextRange(currentSegments, offsets.start, offsets.end, '\n')
+
+        // Surgical fast path: a full renderSegmentsToDOM tears down and
+        // rebuilds (and re-decorates) the entire document, which makes every
+        // newline stutter on large content. When the edit is a collapsed
+        // caret in a clean flat DOM with real content, and renumbering is
+        // provably a no-op, the same end state is reachable by splitting the
+        // caret's text node, inserting one <br>, and re-decorating only that
+        // line's range.
+        if (cleanScan && offsets.start === offsets.end && scan.segments.length > 0) {
+          const plainAfter =
+            scan.plainText.slice(0, offsets.start) + '\n' + scan.plainText.slice(offsets.start)
+          let renumberNoop = true
+          if (markdownEnabled && hasOrderedListRun(plainAfter)) {
+            renumberNoop = renumberOrderedListSegments(newSegments, plainAfter).edits.length === 0
+          }
+          if (renumberNoop && insertNewlineSurgically(editor, offsets.start)) {
+            lastRenderedValue.current = newSegments
+            onChange(newSegments)
+            setCursorAtOffset(editor, offsets.start + 1)
+            return
+          }
+        }
+
         applyEditResult(editor, { segments: newSegments, cursorOffset: offsets.start + 1 })
+      }
+
+      // The DOM half of the fast path above. Strips the caret line's
+      // decorations (so the plain-text offset maps into a direct-child text
+      // node), inserts the <br>, mirrors renderSegmentsToDOM's sentinel rule
+      // for a trailing newline, and re-decorates the original line's range —
+      // which now spans both halves of the split. Returns false to make the
+      // caller fall back to the full re-render.
+      const insertNewlineSurgically = (editor: HTMLDivElement, offset: number): boolean => {
+        const selRange = getSelectionRange()
+        if (!selRange || !selRange.collapsed || !editor.contains(selRange.startContainer)) {
+          return false
+        }
+        const bounds = findLineBounds(editor, selRange.startContainer, selRange.startOffset)
+        if (!bounds) return false
+
+        stripDecorationsInRange(editor, bounds)
+
+        const pos = findDOMPosition(editor, offset)
+        if (!pos) return false
+
+        const br = document.createElement('br')
+        if (pos.node === editor) {
+          editor.insertBefore(br, editor.childNodes[pos.offset] ?? null)
+        } else if (isTextNode(pos.node) && pos.node.parentNode === editor) {
+          const text = pos.node.textContent ?? ''
+          if (pos.offset <= 0) {
+            editor.insertBefore(br, pos.node)
+          } else if (pos.offset >= text.length) {
+            editor.insertBefore(br, pos.node.nextSibling)
+          } else {
+            const tail = pos.node.splitText(pos.offset)
+            editor.insertBefore(br, tail)
+          }
+        } else {
+          // A position inside a nested element — shouldn't happen after the
+          // strip, so let the full re-render canonicalize instead.
+          return false
+        }
+
+        if (editor.lastChild === br) {
+          const sentinel = document.createElement('br')
+          sentinel.dataset.sentinel = 'true'
+          editor.appendChild(sentinel)
+        }
+
+        decorateEditor(editor, markdownEnabled, headingsEnabled, bounds)
+        return true
       }
 
       // 2.8 Shift+Enter always inserts a newline (after a list-continuation check).

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -48,9 +48,11 @@ import {
   domChildIndexToSegmentIndex,
   normalizeEditorDOM,
   decorateEditor,
+  stripDecorationsInRange,
   safeJsonStringify,
   getSelectionRange,
 } from './dom-helpers'
+import type { DecorateBounds } from './dom-helpers'
 import {
   saveCursorPosition,
   restoreCursorPosition,
@@ -223,6 +225,52 @@ export function scanEditorDOM(editor: HTMLElement): EditorScan {
   }
 
   return { segments, plainText, sawForeignElement, sawNewlineInText }
+}
+
+/**
+ * The `<br>`-delimited line around a caret boundary point, as exclusive
+ * {@link DecorateBounds} over the editor's flat child list. This is the range
+ * a native single-caret edit can have touched: typing lands in one line, and
+ * a deletion that merged lines leaves all mutated content on the caret's
+ * single merged line. Returns null when the container isn't anchored in the
+ * editor's direct-child structure.
+ */
+export function findLineBounds(
+  editor: HTMLElement,
+  container: Node,
+  offset: number,
+): DecorateBounds | null {
+  let leftFrom: Node | null
+  let rightFrom: Node | null
+
+  if (container === editor) {
+    const index = Math.min(offset, editor.childNodes.length)
+    leftFrom = index > 0 ? editor.childNodes[index - 1] : null
+    rightFrom = index < editor.childNodes.length ? editor.childNodes[index] : null
+  } else {
+    const direct = getDirectChildContaining(editor, container)
+    if (!direct) return null
+    leftFrom = direct.previousSibling
+    rightFrom = direct
+  }
+
+  let after: Node | null = null
+  for (let node = leftFrom; node; node = node.previousSibling) {
+    if (isBRElement(node)) {
+      after = node
+      break
+    }
+  }
+
+  let before: Node | null = null
+  for (let node = rightFrom; node; node = node.nextSibling) {
+    if (isBRElement(node)) {
+      before = node
+      break
+    }
+  }
+
+  return { after, before }
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +697,10 @@ export function usePromptArea({
     let segments: Segment[] = []
     let plainText = ''
     let domNormalized = false
+    // Line scoping is only trustworthy when the DOM holds nothing but our own
+    // flat shapes and every newline is a real <br> (a literal "\n" inside a
+    // text node would put line content out of the caret line's node range).
+    let scopedEligible = false
     if (editor) {
       const scan = scanEditorDOM(editor)
       if (scan.sawForeignElement) {
@@ -659,6 +711,7 @@ export function usePromptArea({
       } else {
         segments = scan.segments
         plainText = scan.plainText
+        scopedEligible = !scan.sawNewlineInText
       }
     }
 
@@ -733,9 +786,15 @@ export function usePromptArea({
       undoTimer.current = null
     }, UNDO_DEBOUNCE_MS)
 
-    // Apply the recomputed model to the DOM. A renumber rewrites text nodes, so
-    // it needs a full re-render (which also re-decorates); otherwise strip the
-    // stale decorations and re-decorate the existing DOM in place.
+    // Apply the recomputed model to the DOM. A renumber rewrites text nodes,
+    // so it needs a full re-render (which also re-decorates). Otherwise the
+    // decoration cycle — strip stale decorations, re-apply fresh ones — runs
+    // scoped to the caret's <br>-delimited line: a native single-caret edit
+    // can only have touched that line, and every decoration is line-local, so
+    // the other lines' decorations are still exactly what a full pass would
+    // produce. Anything that makes the scope uncertain (foreign elements,
+    // literal newlines in text, no collapsed in-editor selection) falls back
+    // to the full normalize + decorate.
     let finalCursor = savedCursorOffset
     if (editor) {
       if (renumberedCursor !== null) {
@@ -743,10 +802,24 @@ export function usePromptArea({
         setCursorAtOffset(editor, renumberedCursor)
         finalCursor = renumberedCursor
       } else {
-        if (!domNormalized) {
-          normalizeEditorDOM(editor)
+        let scoped = false
+        if (scopedEligible) {
+          const selRange = getSelectionRange()
+          if (selRange && selRange.collapsed && editor.contains(selRange.startContainer)) {
+            const bounds = findLineBounds(editor, selRange.startContainer, selRange.startOffset)
+            if (bounds) {
+              stripDecorationsInRange(editor, bounds)
+              decorateEditor(editor, markdownEnabled, headingsEnabled, bounds)
+              scoped = true
+            }
+          }
         }
-        decorateEditor(editor, markdownEnabled, headingsEnabled)
+        if (!scoped) {
+          if (!domNormalized) {
+            normalizeEditorDOM(editor)
+          }
+          decorateEditor(editor, markdownEnabled, headingsEnabled)
+        }
         if (savedCursorOffset !== null) {
           // scroll: false — this placement only re-establishes the caret that
           // native editing just revealed, and the correction's layout read

--- a/packages/prompt-area/src/prompt-area/use-prompt-area.ts
+++ b/packages/prompt-area/src/prompt-area/use-prompt-area.ts
@@ -40,6 +40,7 @@ import {
   isChipElement,
   isLinkElement,
   isBRElement,
+  isTextNode,
   chipNodeToSegment,
   getChipAutoResolved,
   getDirectChildContaining,
@@ -119,6 +120,110 @@ type UsePromptAreaReturn = {
 
 /** Debounce interval for grouping typed characters into a single undo snapshot */
 const UNDO_DEBOUNCE_MS = 300
+
+// ---------------------------------------------------------------------------
+// Single-pass editor scan (typing hot path)
+// ---------------------------------------------------------------------------
+
+export type EditorScan = {
+  segments: Segment[]
+  plainText: string
+  /**
+   * A direct child the scan cannot model: a block wrapper (div/p) or an
+   * unknown inline element. Those change the plain text when unwrapped, so
+   * the caller must fall back to `normalizeEditorDOM` + `readSegmentsFromDOM`.
+   */
+  sawForeignElement: boolean
+  /**
+   * Some text run contains a literal newline. Our own render paths only ever
+   * represent newlines as `<br>`, so this flags DOM states where `<br>`-based
+   * line scoping cannot be trusted.
+   */
+  sawNewlineInText: boolean
+}
+
+/**
+ * Reads the editor's direct children into the segment model in one pass,
+ * producing exactly what `normalizeEditorDOM(editor)` followed by
+ * `readSegmentsFromDOM()` produces — without mutating the DOM and without
+ * a second serialization for the plain text.
+ *
+ * Decoration elements (the markdown/bullet/indent/heading `<span data-md>`s
+ * and URL `<a data-url>`s) contribute their textContent to the surrounding
+ * text run, mirroring how `normalizeEditorDOM` inlines them to text nodes and
+ * `editor.normalize()` merges the results. Chips and `<br>`s break runs the
+ * same way real elements break `editor.normalize()`'s merging.
+ */
+export function scanEditorDOM(editor: HTMLElement): EditorScan {
+  const segments: Segment[] = []
+  let plainText = ''
+  let buffer = ''
+  let hasRealContent = false
+  let hasSentinel = false
+  let sawForeignElement = false
+  let sawNewlineInText = false
+
+  const flushBuffer = (): void => {
+    if (!buffer) return
+    segments.push({ type: 'text', text: buffer })
+    plainText += buffer
+    hasRealContent = true
+    buffer = ''
+  }
+
+  const children = editor.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const node = children[i]
+
+    if (isTextNode(node)) {
+      const text = node.textContent ?? ''
+      if (text) {
+        if (text.includes('\n')) sawNewlineInText = true
+        buffer += text
+      }
+    } else if (isChipElement(node)) {
+      // A chip breaks the text run even when malformed (chipNodeToSegment
+      // null): normalize skips chip elements, so the element still separates
+      // its neighboring text nodes.
+      flushBuffer()
+      const chip = chipNodeToSegment(node)
+      if (chip) {
+        segments.push(chip)
+        plainText += `${chip.trigger}${chip.displayText}`
+        hasRealContent = true
+      }
+    } else if (isBRElement(node)) {
+      flushBuffer()
+      if (node.dataset.sentinel) {
+        hasSentinel = true
+      } else {
+        segments.push({ type: 'text', text: '\n' })
+        plainText += '\n'
+      }
+    } else if (
+      isHTMLElement(node) &&
+      ((node.tagName === 'SPAN' && node.dataset.md !== undefined) || isLinkElement(node))
+    ) {
+      const text = node.textContent ?? ''
+      if (text) {
+        if (text.includes('\n')) sawNewlineInText = true
+        buffer += text
+      }
+    } else {
+      sawForeignElement = true
+    }
+  }
+  flushBuffer()
+
+  // Same emptiness rule as readSegmentsFromDOM: without real content or our
+  // sentinel, any <br>s present are the browser's filler for an emptied
+  // editor and must not read back as newline content.
+  if (!hasRealContent && !hasSentinel) {
+    return { segments: [], plainText: '', sawForeignElement, sawNewlineInText }
+  }
+
+  return { segments, plainText, sawForeignElement, sawNewlineInText }
+}
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -375,61 +480,67 @@ export function usePromptArea({
     [onChange, renderSegmentsToDOM, onChipAdd],
   )
 
-  const runTriggerDetection = useCallback(() => {
-    const editor = editorRef.current
-    if (!editor) return
+  const runTriggerDetection = useCallback(
+    // The typing hot path passes the segments/plainText/cursor it already
+    // computed; zero-arg callers (paste, chip ops, composition end) let the
+    // detection read the DOM itself.
+    (ctx?: { segments: Segment[]; plainText: string; cursorPos: number | null }) => {
+      const editor = editorRef.current
+      if (!editor) return
 
-    const segments = readSegmentsFromDOM()
-    const plainText = segmentsToPlainText(segments)
-    const cursorPos = getCursorOffset(editor)
+      const segments = ctx ? ctx.segments : readSegmentsFromDOM()
+      const plainText = ctx ? ctx.plainText : segmentsToPlainText(segments)
+      const cursorPos = ctx ? ctx.cursorPos : getCursorOffset(editor)
 
-    if (cursorPos === null) return
+      if (cursorPos === null) return
 
-    const detected = detectActiveTrigger(plainText, cursorPos, triggers)
+      const detected = detectActiveTrigger(plainText, cursorPos, triggers)
 
-    // Typing supersedes a chip-click dropdown: whichever branch we take next,
-    // the popover no longer edits the clicked chip.
-    editingChip.current = null
-    openChipNode.current = null
+      // Typing supersedes a chip-click dropdown: whichever branch we take next,
+      // the popover no longer edits the clicked chip.
+      editingChip.current = null
+      openChipNode.current = null
 
-    if (detected) {
-      setActiveTrigger(detected)
-      setSelectedSuggestionIndex(0)
+      if (detected) {
+        setActiveTrigger(detected)
+        setSelectedSuggestionIndex(0)
 
-      // Position the popover at the trigger character, not the cursor.
-      // Build a range at detected.startOffset so the dropdown anchors to
-      // the trigger char even when the cursor has moved past it.
-      const triggerRange = createRangeAtOffset(editor, detected.startOffset)
-      if (triggerRange) {
-        // caretLineRect measures element-boundary positions too (a trigger
-        // typed right after a chip or <br>), so the popover anchors at the
-        // real trigger position instead of skipping the update. It returns
-        // null only when no geometry exists at all (jsdom) — keep the last
-        // valid rect rather than anchoring at the origin.
-        const rect = caretLineRect(triggerRange)
-        if (rect) {
-          setTriggerRect(rect)
+        // Position the popover at the trigger character, not the cursor.
+        // Build a range at detected.startOffset so the dropdown anchors to
+        // the trigger char even when the cursor has moved past it.
+        const triggerRange = createRangeAtOffset(editor, detected.startOffset)
+        if (triggerRange) {
+          // caretLineRect measures element-boundary positions too (a trigger
+          // typed right after a chip or <br>), so the popover anchors at the
+          // real trigger position instead of skipping the update. It returns
+          // null only when no geometry exists at all (jsdom) — keep the last
+          // valid rect rather than anchoring at the origin.
+          const rect = caretLineRect(triggerRange)
+          if (rect) {
+            setTriggerRect(rect)
+          }
         }
-      }
 
-      // Fetch suggestions for dropdown mode
-      if (detected.config.mode === 'dropdown' && detected.config.onSearch) {
-        runSearch(detected.query, detected.config)
-      }
+        // Fetch suggestions for dropdown mode
+        if (detected.config.mode === 'dropdown' && detected.config.onSearch) {
+          runSearch(detected.query, detected.config)
+        }
 
-      // Fire callback for callback mode
-      if (detected.config.mode === 'callback' && detected.config.onActivate) {
-        detected.config.onActivate({
-          text: plainText,
-          cursorPosition: cursorPos,
-          insertChip: buildInsertChip(segments, detected),
-        })
+        // Fire callback for callback mode
+        if (detected.config.mode === 'callback' && detected.config.onActivate) {
+          detected.config.onActivate({
+            text: plainText,
+            cursorPosition: cursorPos,
+            insertChip: buildInsertChip(segments, detected),
+          })
+        }
+      } else {
+        setActiveTrigger(null)
+        resetSearch()
       }
-    } else {
-      setActiveTrigger(null)
-      resetSearch()
-    }
-  }, [triggers, readSegmentsFromDOM, buildInsertChip, resetSearch, runSearch])
+    },
+    [triggers, readSegmentsFromDOM, buildInsertChip, resetSearch, runSearch],
+  )
 
   // -----------------------------------------------------------------------
   // Dismiss trigger
@@ -525,40 +636,65 @@ export function usePromptArea({
 
     const editor = editorRef.current
 
-    // Capture cursor offset BEFORE normalizeEditorDOM strips <a> elements,
-    // otherwise the anchor node becomes detached and we lose the position.
+    // Capture cursor offset BEFORE any DOM mutation below — stripping the
+    // decoration elements detaches the selection's anchor node and would
+    // lose the position.
     const savedCursorOffset = editor ? getCursorOffset(editor) : null
 
+    // One scan produces the segment model and the plain text every branch
+    // below needs. Only when the browser inserted an element the scan cannot
+    // model (a block wrapper, an unknown inline tag) does the legacy
+    // normalize-then-read path run — it rewrites the DOM to the flat shape
+    // first, because unwrapping those elements changes the plain text.
+    let segments: Segment[] = []
+    let plainText = ''
+    let domNormalized = false
     if (editor) {
-      // Normalize browser-inserted block elements (div, p, font, a, etc.)
-      normalizeEditorDOM(editor)
+      const scan = scanEditorDOM(editor)
+      if (scan.sawForeignElement) {
+        normalizeEditorDOM(editor)
+        domNormalized = true
+        segments = readSegmentsFromDOM()
+        plainText = segmentsToPlainText(segments)
+      } else {
+        segments = scan.segments
+        plainText = scan.plainText
+      }
     }
-
-    const segments = readSegmentsFromDOM()
 
     // Enforce maxLength: if the edit pushed the editor past the cap, truncate
     // back to maxLength characters and keep the caret where the user was
-    // editing (clamped to the cap) rather than forcing it to the end.
-    if (maxLength != null && editor && segmentsToPlainText(segments).length > maxLength) {
-      const caret = getCursorOffset(editor)
+    // editing (clamped to the cap) rather than forcing it to the end. The
+    // selection hasn't moved since savedCursorOffset was captured, so re-
+    // reading it here would return the same offset.
+    if (maxLength != null && editor && plainText.length > maxLength) {
       const truncated = truncateSegmentsToLength(segments, maxLength)
       lastRenderedValue.current = truncated
       onChange(truncated)
       renderSegmentsToDOM(truncated)
-      setCursorAtOffset(editor, caret != null ? Math.min(caret, maxLength) : maxLength)
-      runTriggerDetection()
+      const clamped = savedCursorOffset != null ? Math.min(savedCursorOffset, maxLength) : maxLength
+      setCursorAtOffset(editor, clamped)
+      runTriggerDetection({
+        segments: truncated,
+        plainText: segmentsToPlainText(truncated),
+        cursorPos: clamped,
+      })
       return
     }
 
     // Check for list auto-formatting (e.g., "- " -> "bullet ")
     if (markdownEnabled && normalizeBullets && editor && savedCursorOffset !== null) {
-      const formatted = autoFormatListPrefix(segments, savedCursorOffset)
+      const formatted = autoFormatListPrefix(segments, savedCursorOffset, plainText)
       if (formatted) {
         lastRenderedValue.current = formatted.segments
         onChange(formatted.segments)
         renderSegmentsToDOM(formatted.segments)
         setCursorAtOffset(editor, formatted.cursorOffset)
-        runTriggerDetection()
+        runTriggerDetection({
+          segments: formatted.segments,
+          plainText: segmentsToPlainText(formatted.segments),
+          cursorPos: formatted.cursorOffset,
+        })
         return
       }
     }
@@ -569,15 +705,13 @@ export function usePromptArea({
     // run — this renumbers a real list (1,2,4 → 1,2,3) but leaves incidental
     // numeric prose ("1985. Born / 2020. Died") untouched.
     let nextSegments = segments
+    let nextPlainText = plainText
     let renumberedCursor: number | null = null
-    if (
-      markdownEnabled &&
-      savedCursorOffset !== null &&
-      hasOrderedListRun(segmentsToPlainText(segments))
-    ) {
-      const renumbered = renumberOrderedListSegments(segments)
+    if (markdownEnabled && savedCursorOffset !== null && hasOrderedListRun(plainText)) {
+      const renumbered = renumberOrderedListSegments(segments, plainText)
       if (renumbered.edits.length > 0) {
         nextSegments = renumbered.segments
+        nextPlainText = segmentsToPlainText(renumbered.segments)
         renumberedCursor = remapOffset(savedCursorOffset, renumbered.edits)
       }
     }
@@ -600,13 +734,18 @@ export function usePromptArea({
     }, UNDO_DEBOUNCE_MS)
 
     // Apply the recomputed model to the DOM. A renumber rewrites text nodes, so
-    // it needs a full re-render (which also re-decorates); otherwise just
-    // re-decorate the existing DOM in place.
+    // it needs a full re-render (which also re-decorates); otherwise strip the
+    // stale decorations and re-decorate the existing DOM in place.
+    let finalCursor = savedCursorOffset
     if (editor) {
       if (renumberedCursor !== null) {
         renderSegmentsToDOM(nextSegments)
         setCursorAtOffset(editor, renumberedCursor)
+        finalCursor = renumberedCursor
       } else {
+        if (!domNormalized) {
+          normalizeEditorDOM(editor)
+        }
         decorateEditor(editor, markdownEnabled, headingsEnabled)
         if (savedCursorOffset !== null) {
           // scroll: false — this placement only re-establishes the caret that
@@ -617,7 +756,11 @@ export function usePromptArea({
       }
     }
 
-    runTriggerDetection()
+    runTriggerDetection({
+      segments: nextSegments,
+      plainText: nextPlainText,
+      cursorPos: finalCursor,
+    })
   }, [
     onChange,
     readSegmentsFromDOM,

--- a/packages/prompt-area/src/prompt-area/use-trigger-search.ts
+++ b/packages/prompt-area/src/prompt-area/use-trigger-search.ts
@@ -43,7 +43,10 @@ export function useTriggerSearch(): UseTriggerSearchReturn {
   const reset = useCallback(() => {
     abortController.current?.abort()
     if (debounceTimer.current) clearTimeout(debounceTimer.current)
-    setSuggestions([])
+    // Keep the previous array when already empty: reset runs on every
+    // trigger-less keystroke, and a fresh [] would defeat React's setState
+    // bailout and force a render of the whole PromptArea per keystroke.
+    setSuggestions((prev) => (prev.length === 0 ? prev : []))
     setSuggestionsLoading(false)
     setSuggestionsError(null)
   }, [])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       lefthook:
         specifier: ^2.1.10
         version: 2.1.10
+      playwright-core:
+        specifier: ^1.62.1
+        version: 1.62.1
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -4148,6 +4151,11 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -7629,8 +7637,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.12
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -7652,7 +7660,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7663,22 +7671,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7689,7 +7697,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9143,6 +9151,8 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.62.1: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/bench-typing.mjs
+++ b/scripts/bench-typing.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/**
+ * Real-browser typing benchmark for the PromptArea component.
+ *
+ * Drives the dev-only /bench page with Playwright (playwright-core + a
+ * system Chromium) and measures, per keystroke:
+ *   - sync ms:  time spent in synchronous input handlers (capture-phase
+ *               listener starts the clock before React's root handler,
+ *               bubble-phase document listener stops it after) — this is
+ *               the component's per-keystroke JS + forced-layout cost.
+ *   - frame ms: input event → next requestAnimationFrame — how long the
+ *               keystroke keeps the next frame away (responsiveness).
+ *
+ * Usage:
+ *   node scripts/bench-typing.mjs --url http://localhost:3000 --lines 600 \
+ *     --mode md --autogrow 1 --label after --out bench-after.json
+ *   node scripts/bench-typing.mjs --compare bench-before.json bench-after.json
+ *
+ * The dev server must be running (pnpm dev). Compare runs only against the
+ * same server mode and machine.
+ */
+
+import { chromium } from 'playwright-core'
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const EXECUTABLE = process.env.BENCH_CHROME ?? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
+
+function parseArgs(argv) {
+  const args = {
+    url: 'http://localhost:3000',
+    lines: 600,
+    mode: 'md',
+    autogrow: '1',
+    label: 'run',
+    out: null,
+    compare: null,
+    typeDelay: 30,
+  }
+  for (let i = 2; i < argv.length; i++) {
+    const key = argv[i]
+    if (key === '--compare') {
+      args.compare = [argv[++i], argv[++i]]
+    } else if (key.startsWith('--')) {
+      args[key.slice(2)] = argv[++i]
+    }
+  }
+  args.lines = Number(args.lines)
+  args.typeDelay = Number(args.typeDelay)
+  return args
+}
+
+function stats(values) {
+  if (values.length === 0) return { n: 0, median: 0, p95: 0, max: 0, mean: 0 }
+  const sorted = [...values].sort((a, b) => a - b)
+  const pick = (q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+  const mean = values.reduce((a, b) => a + b, 0) / values.length
+  return {
+    n: values.length,
+    median: pick(0.5),
+    p95: pick(0.95),
+    max: sorted[sorted.length - 1],
+    mean,
+  }
+}
+
+function fmt(s) {
+  return `n=${String(s.n).padStart(3)}  median=${s.median.toFixed(1).padStart(7)}ms  p95=${s.p95
+    .toFixed(1)
+    .padStart(7)}ms  max=${s.max.toFixed(1).padStart(7)}ms`
+}
+
+function printReport(label, report) {
+  console.log(
+    `\n=== ${label} (lines=${report.lines}, mode=${report.mode}, autogrow=${report.autogrow})`,
+  )
+  console.log(`  sync  ${fmt(report.sync)}`)
+  console.log(`  frame ${fmt(report.frame)}`)
+}
+
+function compare(beforePath, afterPath) {
+  const before = JSON.parse(readFileSync(beforePath, 'utf8'))
+  const after = JSON.parse(readFileSync(afterPath, 'utf8'))
+  printReport(`BEFORE ${before.label}`, before)
+  printReport(`AFTER ${after.label}`, after)
+  const speedup = (m) => (after[m].median > 0 ? before[m].median / after[m].median : Infinity)
+  console.log(
+    `\n  median speedup: sync ${speedup('sync').toFixed(1)}x, frame ${speedup('frame').toFixed(1)}x`,
+  )
+  const passSync = after.sync.median < 8
+  const passFrame = after.frame.p95 < 50
+  console.log(
+    `  thresholds: sync median < 8ms → ${passSync ? 'PASS' : 'FAIL'}, frame p95 < 50ms → ${passFrame ? 'PASS' : 'FAIL'}`,
+  )
+  process.exitCode = passSync && passFrame ? 0 : 1
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  if (args.compare) {
+    compare(args.compare[0], args.compare[1])
+    return
+  }
+
+  const browser = await chromium.launch({ executablePath: EXECUTABLE, headless: true })
+  try {
+    const page = await browser.newPage()
+
+    await page.addInitScript(() => {
+      window.__sync = []
+      window.__frame = []
+      window.__t0 = 0
+      // Registered before React hydrates, so on the shared document node this
+      // capture listener runs before React's — it starts the clock.
+      document.addEventListener(
+        'input',
+        () => {
+          window.__t0 = performance.now()
+          requestAnimationFrame(() => {
+            window.__frame.push(performance.now() - window.__t0)
+          })
+        },
+        true,
+      )
+    })
+
+    const url = `${args.url}/bench?lines=${args.lines}&mode=${args.mode}&autogrow=${args.autogrow}`
+    console.log(`navigating ${url}`)
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 180_000 })
+    await page.waitForFunction(() => window.__benchReady === true, undefined, { timeout: 180_000 })
+
+    // The sync-end listener must run AFTER React's handlers. React (App
+    // Router) attaches its delegated listeners on document during hydration,
+    // and same-node same-phase listeners run in registration order — so this
+    // one is registered only now, post-hydration.
+    await page.evaluate(() => {
+      document.addEventListener(
+        'input',
+        () => {
+          window.__sync.push(performance.now() - window.__t0)
+        },
+        false,
+      )
+    })
+
+    const midLine = Math.floor(args.lines / 2)
+    const placed = await page.evaluate((line) => window.__placeCaretAtLine?.(line), midLine)
+    if (!placed) throw new Error(`could not place caret at line ${midLine}`)
+
+    // Warmup (JIT, style/layout caches), then reset metrics.
+    await page.keyboard.type('warmup warmup ', { delay: args.typeDelay })
+    await page.waitForTimeout(300)
+    await page.evaluate(() => {
+      window.__sync = []
+      window.__frame = []
+    })
+
+    // Caret-integrity probe: plain-text offset before vs after typing.
+    const offsetBefore = await page.evaluate(() => {
+      const sel = window.getSelection()
+      if (!sel || sel.rangeCount === 0) return -1
+      const editor = document.querySelector('[data-test-id="bench-editor"]')
+      const pre = document.createRange()
+      pre.selectNodeContents(editor)
+      const r = sel.getRangeAt(0)
+      pre.setEnd(r.startContainer, r.startOffset)
+      return pre.toString().length
+    })
+
+    // Measured scenario: prose + markdown + a URL at mid-document… (the
+    // trailing padding is what the Backspaces below consume, keeping the URL
+    // intact for the decoration sanity check)
+    const typed =
+      'The quick brown fox — **bold** move at https://bench.example/x with padding to erase'
+    await page.keyboard.type(typed, { delay: args.typeDelay })
+    // …then deletions…
+    for (let i = 0; i < 15; i++) {
+      await page.keyboard.press('Backspace', { delay: args.typeDelay })
+    }
+    // …then typing at the document end.
+    await page.keyboard.press('Control+End')
+    await page.keyboard.type(' tail typing zone', { delay: args.typeDelay })
+
+    const metrics = await page.evaluate(() => ({ sync: window.__sync, frame: window.__frame }))
+
+    // --- functional sanity checks ------------------------------------------
+    // 1. Caret integrity: after `typed` minus 15 backspaces at mid-line, the
+    //    plain-text offset advanced by exactly typed.length - 15.
+    await page.evaluate((line) => window.__placeCaretAtLine?.(line), midLine)
+    const offsetAfter = await page.evaluate(() => {
+      const sel = window.getSelection()
+      const editor = document.querySelector('[data-test-id="bench-editor"]')
+      const pre = document.createRange()
+      pre.selectNodeContents(editor)
+      const r = sel.getRangeAt(0)
+      pre.setEnd(r.startContainer, r.startOffset)
+      return pre.toString().length
+    })
+    const expectedDelta = typed.length - 15
+    if (offsetAfter - offsetBefore !== expectedDelta) {
+      throw new Error(
+        `caret integrity failed: offset delta ${offsetAfter - offsetBefore}, expected ${expectedDelta}`,
+      )
+    }
+
+    // 2. The typed markdown and URL got decorated on the edited line.
+    const decorated = await page.evaluate(() => {
+      const editor = document.querySelector('[data-test-id="bench-editor"]')
+      const bold = [...editor.querySelectorAll('span[data-md]')].some(
+        (s) => s.textContent === '**bold**',
+      )
+      const url = [...editor.querySelectorAll('a[data-url]')].some((a) =>
+        (a.textContent ?? '').startsWith('https://bench.example/x'),
+      )
+      return { bold, url }
+    })
+    if (!decorated.bold || !decorated.url) {
+      throw new Error(`decoration sanity failed: ${JSON.stringify(decorated)}`)
+    }
+
+    // 3. Decorations elsewhere in the document survived the typing session.
+    const counts = await page.evaluate(() => {
+      const editor = document.querySelector('[data-test-id="bench-editor"]')
+      return {
+        bullets: editor.querySelectorAll('.prompt-area-list-bullet').length,
+        headings: editor.querySelectorAll('.prompt-area-md-heading').length,
+        urls: editor.querySelectorAll('a[data-url]').length,
+      }
+    })
+    if (args.mode === 'md' && (counts.bullets === 0 || counts.headings === 0 || counts.urls < 2)) {
+      throw new Error(`sibling decoration sanity failed: ${JSON.stringify(counts)}`)
+    }
+
+    const report = {
+      label: args.label,
+      lines: args.lines,
+      mode: args.mode,
+      autogrow: args.autogrow,
+      typeDelay: args.typeDelay,
+      timestamp: new Date().toISOString(),
+      sync: stats(metrics.sync),
+      frame: stats(metrics.frame),
+      sanity: { caretDelta: expectedDelta, ...counts },
+    }
+    printReport(args.label, report)
+    console.log(`  sanity: caret ok, decorations ok (${JSON.stringify(counts)})`)
+
+    if (args.out) {
+      writeFileSync(args.out, JSON.stringify(report, null, 2))
+      console.log(`  wrote ${args.out}`)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

This PR significantly improves typing performance in large documents by eliminating expensive DOM operations from the hot path. The main optimization replaces the legacy approach of cloning and serializing the entire document prefix on every keystroke with a single-pass DOM walk that produces the same segment model and plain text without allocations.

## Key Changes

- **New `scanEditorDOM()` function**: Reads editor DOM directly into the segment model in one pass, producing identical output to the legacy `normalizeEditorDOM()` + `readSegmentsFromDOM()` pipeline without mutating the DOM or allocating deep clones.

- **Allocation-free offset calculation**: Replaced `Range.cloneContents()`-based cursor offset measurement with `getTextOffsetAtPoint()`, which walks the live tree to compute plain-text offsets. This eliminates O(document) allocations on every keystroke.

- **Line-scoped decoration**: Added `findLineBounds()` and `stripDecorationsInRange()` to enable surgical re-decoration of only the `<br>`-delimited line containing the caret, leaving other lines' DOM nodes untouched by identity. Falls back to full-pass decoration when the DOM state makes scoping unsafe (foreign elements, literal newlines in text).

- **Shift+Enter fast path**: Implemented a surgical newline insertion that splits the caret's text node and inserts one `<br>`, then re-decorates only that line—instead of a full `renderSegmentsToDOM()` teardown on large documents.

- **Typing context optimization**: The hot-path `runTriggerDetection()` now accepts pre-computed segments/plainText/cursor to avoid redundant DOM reads, with zero-arg fallbacks for paste/chip operations.

- **Stable event handler object**: Wrapped event handlers in `useMemo()` to maintain referential identity across renders, reducing unnecessary re-renders of the PromptArea component.

- **Benchmark infrastructure**: Added `/bench` page and `scripts/bench-typing.mjs` for real-browser typing performance measurement with Playwright, enabling reproducible performance validation.

## Implementation Details

- Decoration elements (`<span data-md>`, `<a data-url>`) are inlined into surrounding text runs during the scan, mirroring how `normalizeEditorDOM()` handles them.
- Chips and `<br>` elements break text runs the same way they do in the real normalization pipeline.
- The scan detects foreign elements and literal newlines in text, flagging cases where scoped decoration cannot be trusted and a full pass is required.
- All new functionality is covered by comprehensive test suites validating equivalence with the legacy paths and parity across boundary points.

## Performance Impact

- Typing in documents with hundreds of lines now stays responsive (sub-8ms sync time, <50ms frame latency) instead of degrading with document size.
- Eliminated per-keystroke deep clones and serialization passes that scaled with document length.
- Single-pass scanning and line-scoped decoration reduce per-keystroke work from O(document) to O(line).

https://claude.ai/code/session_019mkXQFYzFYhV2zstapRead