### PR TITLE
fix(prompt-area): keep commas inside detected URLs

### DIFF
--- a/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/dom-helpers.test.ts
@@ -829,6 +829,35 @@ describe('decorateURLsInEditor edge cases', () => {
     expect(anchors[0]?.textContent).toBe('https://a.com')
     expect(anchors[1]?.textContent).toBe('https://b.com')
   })
+
+  it('decorates a URL with a comma in its path', () => {
+    const editor = document.createElement('div')
+    editor.appendChild(
+      document.createTextNode(
+        'read https://en.wikipedia.org/wiki/Dominic_Johnson,_Baron_Johnson_of_Lainston now',
+      ),
+    )
+
+    decorateURLsInEditor(editor)
+
+    const anchor = editor.querySelector('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor?.textContent).toBe(
+      'https://en.wikipedia.org/wiki/Dominic_Johnson,_Baron_Johnson_of_Lainston',
+    )
+  })
+
+  it('strips a trailing comma after a URL', () => {
+    const editor = document.createElement('div')
+    editor.appendChild(document.createTextNode('see https://example.com/page, then continue'))
+
+    decorateURLsInEditor(editor)
+
+    const anchor = editor.querySelector('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor?.textContent).toBe('https://example.com/page')
+    expect(editor.textContent).toBe('see https://example.com/page, then continue')
+  })
 })
 
 // ===========================================================================

--- a/packages/prompt-area/src/prompt-area/__tests__/prompt-area-engine.test.ts
+++ b/packages/prompt-area/src/prompt-area/__tests__/prompt-area-engine.test.ts
@@ -477,6 +477,30 @@ describe('parseInlineMarkdown', () => {
     ])
   })
 
+  it('keeps commas inside a URL path', () => {
+    const result = parseInlineMarkdown(
+      'read https://en.wikipedia.org/wiki/Dominic_Johnson,_Baron_Johnson_of_Lainston now',
+    )
+    expect(result).toEqual([
+      { type: 'plain', text: 'read ' },
+      {
+        type: 'url',
+        text: 'https://en.wikipedia.org/wiki/Dominic_Johnson,_Baron_Johnson_of_Lainston',
+      },
+      { type: 'plain', text: ' now' },
+    ])
+  })
+
+  it('strips trailing punctuation after a URL', () => {
+    const result = parseInlineMarkdown('see https://example.com/page, then continue')
+    expect(result).toEqual([
+      { type: 'plain', text: 'see ' },
+      { type: 'url', text: 'https://example.com/page' },
+      { type: 'plain', text: ',' },
+      { type: 'plain', text: ' then continue' },
+    ])
+  })
+
   it('returns plain text when no markdown', () => {
     const result = parseInlineMarkdown('hello world')
     expect(result).toEqual([{ type: 'plain', text: 'hello world' }])

--- a/packages/prompt-area/src/prompt-area/dom-helpers.ts
+++ b/packages/prompt-area/src/prompt-area/dom-helpers.ts
@@ -314,8 +314,9 @@ export function normalizeEditorDOM(editor: HTMLElement): boolean {
 // URL decoration
 // ---------------------------------------------------------------------------
 
-/** URL pattern for detecting URLs in text content */
-const URL_PATTERN = /https?:\/\/[^\s),]+/g
+/** URL pattern for detecting URLs in text content. Commas are allowed
+ * mid-URL (e.g. Wikipedia paths); trailing punctuation is trimmed below. */
+const URL_PATTERN = /https?:\/\/[^\s)]+/g
 
 /**
  * Walks direct-child text nodes in the editor and wraps URL text in
@@ -349,7 +350,7 @@ export function decorateURLsInEditor(editor: HTMLElement): boolean {
     while ((match = URL_PATTERN.exec(text)) !== null) {
       // Trim trailing punctuation that's likely not part of the URL
       let url = match[0]
-      while (url.length > 0 && /[.;:!?]$/.test(url)) {
+      while (url.length > 0 && /[.,;:!?]$/.test(url)) {
         url = url.slice(0, -1)
       }
       if (url.length > 0) {

--- a/packages/prompt-area/src/prompt-area/prompt-area-engine.ts
+++ b/packages/prompt-area/src/prompt-area/prompt-area-engine.ts
@@ -609,7 +609,7 @@ export function parseInlineMarkdown(text: string): MarkdownToken[] {
   // 2. **text** or __text__   -> bold
   // 3. *text* or _text_       -> italic
   // 4. https://... or http://... -> URL
-  const pattern = /(\*{3}(.+?)\*{3})|(\*{2}(.+?)\*{2})|(\*(.+?)\*)|(https?:\/\/[^\s),]+)/g
+  const pattern = /(\*{3}(.+?)\*{3})|(\*{2}(.+?)\*{2})|(\*(.+?)\*)|(https?:\/\/[^\s)]+)/g
 
   let lastIndex = 0
   let match: RegExpExecArray | null
@@ -630,8 +630,18 @@ export function parseInlineMarkdown(text: string): MarkdownToken[] {
       // *italic*
       tokens.push({ type: 'italic', text: match[6] })
     } else if (match[7]) {
-      // URL
-      tokens.push({ type: 'url', text: match[7] })
+      // URL — trim trailing punctuation that's likely not part of the URL
+      let url = match[7]
+      while (url.length > 0 && /[.,;:!?]$/.test(url)) {
+        url = url.slice(0, -1)
+      }
+      if (url.length > 0) {
+        tokens.push({ type: 'url', text: url })
+      }
+      const trimmed = match[7].slice(url.length)
+      if (trimmed) {
+        tokens.push({ type: 'plain', text: trimmed })
+      }
     }
 
     lastIndex = match.index + match[0].length


### PR DESCRIPTION
## Problem

The prompt area truncates URLs at the first comma. Pasting
`https://en.wikipedia.org/wiki/Dominic_Johnson,_Baron_Johnson_of_Lainston`
only linkifies up to `.../Dominic_Johnson`.

Root cause: the URL detection regex `/https?:\/\/[^\s),]+/g` excludes commas entirely, in both `decorateURLsInEditor` (dom-helpers.ts) and `parseInlineMarkdown` (prompt-area-engine.ts).

## Fix

- Allow commas inside URLs: regex is now `/https?:\/\/[^\s)]+/g` (still stops at whitespace and `)` for markdown-style contexts).
- Trim a *trailing* comma along with the other trailing punctuation, so `see https://example.com/page, then...` keeps the comma out of the link.
- `parseInlineMarkdown` had no trailing-punctuation trim at all; added the same trim there, re-emitting the trimmed tail as a plain token.

<img width="1836" height="768" alt="image" src="https://github.com/user-attachments/assets/df6164ca-9478-4747-aa35-59ecb53a3ddf" />



## Tests

Added four cases: the Wikipedia comma-in-path URL decorates as one full link, and a trailing comma after a URL stays plain text (both in `decorateURLsInEditor` and `parseInlineMarkdown`). Full suite passes: 958 tests, 33 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)