### PR TITLE
refactor: replace clsx + tailwind-merge with the cn package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import { PromptArea } from 'prompt-area'
 import 'prompt-area/styles.css'
 ```
 
-The package ships a prebuilt, self-contained `styles.css` (no Tailwind required) plus an optional `prompt-area/tailwind.css` preset for token-level theming. `clsx` and `tailwind-merge` are peer dependencies (zero bundled runtime deps) — npm/pnpm/bun install them automatically; on yarn run `yarn add prompt-area clsx tailwind-merge`. See [`packages/prompt-area/README.md`](packages/prompt-area/README.md) for the full guide.
+The package ships a prebuilt, self-contained `styles.css` (no Tailwind required) plus an optional `prompt-area/tailwind.css` preset for token-level theming. The [`cn`](https://www.npmjs.com/package/cn) class-merging package is a peer dependency (zero bundled runtime deps) — npm/pnpm/bun install it automatically; on yarn run `yarn add prompt-area cn`. See [`packages/prompt-area/README.md`](packages/prompt-area/README.md) for the full guide.
 
 ### shadcn registry
 

--- a/app/docs/installation/page.tsx
+++ b/app/docs/installation/page.tsx
@@ -89,13 +89,15 @@ import 'prompt-area/styles.css'`}
         instead for token-level theming.
       </DocsP>
       <DocsP>
-        The package bundles zero runtime dependencies:{' '}
-        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">clsx</code> and{' '}
-        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">tailwind-merge</code> are
-        peer dependencies so they dedupe with the copies most projects already have. npm, pnpm and
-        bun install them automatically; with yarn (or if your setup skips peers), add them yourself:{' '}
+        The package bundles zero runtime dependencies: the class-merging helper{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">cn</code> (shadcn&apos;s
+        drop-in replacement for{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">clsx</code> +{' '}
+        <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">tailwind-merge</code>) is a
+        peer dependency so it dedupes with the copy most projects already have. npm, pnpm and bun
+        install it automatically; with yarn (or if your setup skips peers), add it yourself:{' '}
         <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">
-          yarn add prompt-area clsx tailwind-merge
+          yarn add prompt-area cn
         </code>
         .
       </DocsP>

--- a/app/docs/try-it-live/page.tsx
+++ b/app/docs/try-it-live/page.tsx
@@ -60,8 +60,10 @@ export default function TryItLivePage() {
         Edit <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">src/App.tsx</code> and
         the preview updates live. The first run installs dependencies, so give it a few seconds.
       </DocsP>
-      {/* clsx + tailwind-merge are peerDependencies since 0.5.0 — Sandpack does
-          not auto-install peers, so they must be listed explicitly. */}
+      {/* Sandpack does not auto-install peers, so the published package's peer
+          dependencies must be listed explicitly. PROMPT_AREA_VERSION still peers
+          on clsx + tailwind-merge; swap these for `cn` when bumping to the
+          first release that peers on the `cn` package instead. */}
       <LiveExample
         files={exampleFiles}
         dependencies={{

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from 'cn'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@vercel/edge-config": "^1.5.1",
     "@vercel/functions": "^3.9.5",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.5",
     "geist": "^1.7.2",
     "lucide-react": "^1.33.0",
     "next": "^16.3.3",
@@ -40,7 +40,6 @@
     "react-dom": "^19.2.8",
     "shadcn": "^4.18.0",
     "shiki": "^4.4.3",
-    "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "ws": "^8.21.3"
   },

--- a/packages/prompt-area/.size-limit.json
+++ b/packages/prompt-area/.size-limit.json
@@ -3,21 +3,21 @@
     "name": "index (all exports)",
     "path": "dist/index.js",
     "import": "*",
-    "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
+    "ignore": ["react", "react-dom", "react/jsx-runtime", "cn"],
     "limit": "20 KB"
   },
   {
     "name": "prompt-area (component)",
     "path": "dist/prompt-area/index.js",
     "import": "*",
-    "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
+    "ignore": ["react", "react-dom", "react/jsx-runtime", "cn"],
     "limit": "18.5 KB"
   },
   {
     "name": "helpers (RSC-safe)",
     "path": "dist/helpers/index.js",
     "import": "*",
-    "ignore": ["react", "react-dom", "react/jsx-runtime", "clsx", "tailwind-merge"],
+    "ignore": ["react", "react-dom", "react/jsx-runtime", "cn"],
     "limit": "2.5 KB"
   }
 ]

--- a/packages/prompt-area/CHANGELOG.md
+++ b/packages/prompt-area/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `prompt-area` package are documented here. This
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.7.0
+
+### Changed
+
+- **BREAKING: the `cn` package replaces `clsx` + `tailwind-merge` as the
+  peer dependency.** The class-merging helper is now re-exported from
+  [`cn`](https://www.npmjs.com/package/cn), shadcn's compiled, zero-dependency
+  engine with the same API and full parity with `clsx` + `tailwind-merge`.
+  prompt-area still bundles zero runtime dependencies; `cn` is a peer so it
+  dedupes with the copy your project already ships. npm, pnpm and bun install
+  it automatically; on yarn, or in setups that skip peers, run `pnpm add cn`.
+  `clsx` and `tailwind-merge` are no longer required by prompt-area — keep
+  them only if something else in your project still imports them
+  (`npx shadcn@latest migrate cn` switches a shadcn project over).
+- **BREAKING: Node 20+ is now required**, matching the `cn` package's engine
+  range. Node 18 reached end of life in April 2025.
+
 ## 0.6.8
 
 ### Fixed

--- a/packages/prompt-area/README.md
+++ b/packages/prompt-area/README.md
@@ -21,11 +21,12 @@ pnpm add prompt-area
 ```
 
 Peer dependencies: `react` and `react-dom` (most React apps already have them),
-plus `clsx` and `tailwind-merge` — the two `cn` helpers, already present in any
-shadcn/Tailwind project. If you don't have them yet:
+plus [`cn`](https://www.npmjs.com/package/cn) — shadcn's compiled class-merging
+engine, the drop-in replacement for `clsx` + `tailwind-merge`. If you don't
+have it yet:
 
 ```bash
-pnpm add clsx tailwind-merge
+pnpm add cn
 ```
 
 ## Quick start
@@ -118,12 +119,14 @@ The components are client components and carry a `'use client'` boundary, so you
 
 ## Dependencies
 
-- **Peer:** `react`, `react-dom` (>= 18), plus `clsx` and `tailwind-merge` —
-  the two `cn` helpers. These are peer (not bundled) dependencies so they
-  dedupe with the copies any shadcn/Tailwind project already ships, keeping
-  prompt-area's own footprint to **zero bundled runtime dependencies**. Both
-  are tiny and already present in shadcn projects; install them explicitly if
-  you don't have them (`pnpm add clsx tailwind-merge`).
+- **Peer:** `react`, `react-dom` (>= 18), plus [`cn`](https://www.npmjs.com/package/cn)
+  (>= 0.2) — the class-merging helper. It is a peer (not bundled) dependency so
+  it dedupes with the copy any shadcn/Tailwind project already ships, keeping
+  prompt-area's own footprint to **zero bundled runtime dependencies**. It has
+  zero dependencies of its own; install it explicitly if you don't have it
+  (`pnpm add cn`). Projects still on `clsx` + `tailwind-merge` can keep
+  them — `cn` is a drop-in replacement, and `npx shadcn@latest migrate cn`
+  switches a shadcn project over in one step.
 - **Tailwind is not a peer dependency.** The prebuilt `prompt-area/styles.css`
   is self-contained and works with **any** stack — Tailwind v4, v3, or no
   Tailwind at all. The optional `prompt-area/tailwind.css` preset uses Tailwind
@@ -134,7 +137,7 @@ No animation library and no icon library: animations use CSS (`tw-animate-css`
 utilities) and icons are inline SVGs. No editor framework (ProseMirror, Slate,
 Lexical) either.
 
-ESM-only. Requires Node 18+ / a modern bundler (Next.js, Vite, etc.).
+ESM-only. Requires Node 20+ / a modern bundler (Next.js, Vite, etc.).
 
 ## License
 

--- a/packages/prompt-area/package.json
+++ b/packages/prompt-area/package.json
@@ -76,13 +76,12 @@
     "prepublishOnly": "pnpm run build"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "peerDependencies": {
-    "clsx": ">=2",
+    "cn": ">=0.2",
     "react": ">=18",
-    "react-dom": ">=18",
-    "tailwind-merge": ">=2"
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
@@ -90,12 +89,11 @@
     "@tailwindcss/cli": "^4.3.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "^19.2.4",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.5",
     "publint": "^0.3.24",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "size-limit": "^13.0.3",
-    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tsup": "^8.5.0",
     "tw-animate-css": "^1.4.0",

--- a/packages/prompt-area/src/lib/cn.ts
+++ b/packages/prompt-area/src/lib/cn.ts
@@ -1,16 +1,12 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
-
 /**
  * Merge class names with Tailwind-aware conflict resolution.
  *
  * The `cn` helper is bundled into the npm package so consumers don't need a
  * `@/lib/utils` helper of their own; the package build aliases `@/lib/utils`
  * to this module, while the shadcn registry relies on the consumer's own
- * utils. `clsx` and `tailwind-merge` are peer dependencies, kept out of the
- * bundle so they dedupe with the copies any shadcn/Tailwind project already
- * ships rather than shipping a second copy.
+ * utils. The implementation comes from the `cn` package (shadcn's compiled
+ * drop-in replacement for `clsx` + `tailwind-merge`), declared as a peer
+ * dependency and kept out of the bundle so it dedupes with the copy any
+ * shadcn/Tailwind project already ships rather than shipping a second one.
  */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from 'cn'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.5
+        version: 0.2.5
       geist:
         specifier: ^1.7.2
         version: 1.7.2(next@16.3.3(@babel/core@7.29.7)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -79,9 +79,6 @@ importers:
       shiki:
         specifier: ^4.4.3
         version: 4.4.3
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -182,9 +179,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.5(@types/react@19.2.18)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.5
+        version: 0.2.5
       publint:
         specifier: ^0.3.24
         version: 0.3.24
@@ -197,9 +194,6 @@ importers:
       size-limit:
         specifier: ^13.0.3
         version: 13.0.3
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -2372,6 +2366,11 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cn@0.2.5:
+    resolution: {integrity: sha512-OCjZtMeQfXbI4Es1+EIjkd77gvWzaE689gD8KhfexlqjClC06qR1MQBR+Z35ZMSPNEBWyHiItW1Soy0UvwNv9w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -7269,6 +7268,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cn@0.2.5: {}
+
   code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
@@ -7680,8 +7681,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.3(eslint@9.39.5(jiti@2.7.0))
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -7703,7 +7704,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7714,22 +7715,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7740,7 +7741,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Both `cn` helpers (the site's `lib/utils.ts` and the package's
`src/lib/cn.ts`) now re-export `cn` from shadcn's `cn` package, the
compiled drop-in replacement for clsx + tailwind-merge, instead of
composing the two by hand.

For the npm package this swaps the peer dependency: `cn` (>= 0.2)
replaces `clsx` and `tailwind-merge`. It stays a peer so the package
still bundles zero runtime dependencies and dedupes with the consumer's
copy. `cn` requires Node 20, so the package engine range moves from
>= 18 to >= 20; both changes are logged as breaking under 0.7.0.

Docs (root and package READMEs, installation page) are updated to
match. The try-it-live Sandpack demo and examples/basic still list
clsx + tailwind-merge on purpose: they consume the published 0.6.8,
whose peers have not changed yet.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J8dHMp1JMaksPjproDoA4V